### PR TITLE
Rewire sprite stuff to not spam the GPU with buffer allocations

### DIFF
--- a/include/Engine/Graphics.h
+++ b/include/Engine/Graphics.h
@@ -171,8 +171,8 @@ public:
     static void InitScene3D(Uint32 sceneIndex, Uint32 numVertices);
     static void MakeSpritePolygon(VertexAttribute data[4], float x, float y, float z, int flipX, int flipY, float scaleX, float scaleY, Texture* texture, int frameX, int frameY, int frameW, int frameH);
     static void MakeSpritePolygonUVs(VertexAttribute data[4], int flipX, int flipY, Texture* texture, int frameX, int frameY, int frameW, int frameH);
-    static void MakeFrameBufferID(ISprite* sprite, AnimFrame* frame);
-    static void DeleteFrameBufferID(AnimFrame* frame);
+    static void MakeFrameBufferID(ISprite* sprite);
+    static void DeleteFrameBufferID(ISprite* sprite);
     static void SetDepthTesting(bool enabled);
     static bool SpriteRangeCheck(ISprite* sprite, int animation, int frame);
     static void ConvertFromARGBtoNative(Uint32* argb, int count);

--- a/include/Engine/Rendering/GL/GLRenderer.h
+++ b/include/Engine/Rendering/GL/GLRenderer.h
@@ -84,8 +84,8 @@ public:
     static void DrawScene3D(Uint32 sceneIndex, Uint32 drawMode);
     static void* CreateVertexBuffer(Uint32 maxVertices);
     static void DeleteVertexBuffer(void* vtxBuf);
-    static void MakeFrameBufferID(ISprite* sprite, AnimFrame* frame);
-    static void DeleteFrameBufferID(AnimFrame* frame);
+    static void MakeFrameBufferID(ISprite* sprite);
+    static void DeleteFrameBufferID(ISprite* sprite);
     static void SetDepthTesting(bool enable);
 };
 

--- a/include/Engine/Rendering/SDL2/SDL2Renderer.h
+++ b/include/Engine/Rendering/SDL2/SDL2Renderer.h
@@ -59,7 +59,7 @@ public:
     static void DrawTexture(Texture* texture, float sx, float sy, float sw, float sh, float x, float y, float w, float h);
     static void DrawSprite(ISprite* sprite, int animation, int frame, int x, int y, bool flipX, bool flipY, float scaleW, float scaleH, float rotation, unsigned paletteID);
     static void DrawSpritePart(ISprite* sprite, int animation, int frame, int sx, int sy, int sw, int sh, int x, int y, bool flipX, bool flipY, float scaleW, float scaleH, float rotation, unsigned paletteID);
-    static void MakeFrameBufferID(ISprite* sprite, AnimFrame* frame);
+    static void MakeFrameBufferID(ISprite* sprite);
 };
 
 #endif /* ENGINE_RENDERING_SDL2_SDL2RENDERER_H */

--- a/include/Engine/Rendering/Software/SoftwareRenderer.h
+++ b/include/Engine/Rendering/Software/SoftwareRenderer.h
@@ -141,7 +141,7 @@ public:
     static void DrawSceneLayer_VerticalParallax(SceneLayer* layer, View* currentView);
     static void DrawSceneLayer_CustomTileScanLines(SceneLayer* layer, View* currentView);
     static void DrawSceneLayer(SceneLayer* layer, View* currentView, int layerIndex, bool useCustomFunction);
-    static void MakeFrameBufferID(ISprite* sprite, AnimFrame* frame);
+    static void MakeFrameBufferID(ISprite* sprite);
 };
 
 #endif /* ENGINE_RENDERING_SOFTWARE_SOFTWARERENDERER_H */

--- a/include/Engine/ResourceTypes/ISprite.h
+++ b/include/Engine/ResourceTypes/ISprite.h
@@ -13,6 +13,8 @@ public:
     vector<string> SpritesheetFilenames;
     int CollisionBoxCount = 0;
     vector<Animation> Animations;
+    int ID = 0;
+    int FrameCount = 0;
 
     ISprite();
     ISprite(const char* filename);
@@ -24,6 +26,7 @@ public:
     void AddFrame(int duration, int left, int top, int width, int height, int pivotX, int pivotY, int id);
     void AddFrame(int animID, int duration, int left, int top, int width, int height, int pivotX, int pivotY, int id);
     void RemoveFrames(int animID);
+    void RefreshGraphicsID();
     void ConvertToRGBA();
     void ConvertToPalette(unsigned paletteNumber);
     bool LoadAnimation(const char* filename);

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -878,6 +878,7 @@ void Application::RunFrame(void* p) {
                         14);
                 }
             }
+            DEBUG_fontSprite->RefreshGraphicsID();
 
             Graphics::SetTextureInterpolation(original);
         }

--- a/source/Engine/FontFace.cpp
+++ b/source/Engine/FontFace.cpp
@@ -249,6 +249,8 @@ ISprite* FontFace::SpriteFromFont(Stream* stream, int pixelSize, const char* fil
         sprite->SaveAnimation(testFilename);
     }
 
+    sprite->RefreshGraphicsID();
+
     Memory::Free(fontFileMemory);
     Memory::Free(pixelData);
     FT_Done_Face(face);

--- a/source/Engine/Graphics.cpp
+++ b/source/Engine/Graphics.cpp
@@ -1349,13 +1349,13 @@ void     Graphics::MakeSpritePolygonUVs(VertexAttribute data[4], int flipX, int 
     data[0].UV.Y       = FP16_DIVIDE(FP16_TO(top_v), textureHeight);
 }
 
-void     Graphics::MakeFrameBufferID(ISprite* sprite, AnimFrame* frame) {
+void     Graphics::MakeFrameBufferID(ISprite* sprite) {
     if (Graphics::GfxFunctions->MakeFrameBufferID)
-        Graphics::GfxFunctions->MakeFrameBufferID(sprite, frame);
+        Graphics::GfxFunctions->MakeFrameBufferID(sprite);
 }
-void     Graphics::DeleteFrameBufferID(AnimFrame* frame) {
+void     Graphics::DeleteFrameBufferID(ISprite* sprite) {
     if (Graphics::GfxFunctions->DeleteFrameBufferID)
-        Graphics::GfxFunctions->DeleteFrameBufferID(frame);
+        Graphics::GfxFunctions->DeleteFrameBufferID(sprite);
 }
 
 void     Graphics::SetDepthTesting(bool enabled) {

--- a/source/Engine/Rendering/GL/GLRenderer.cpp
+++ b/source/Engine/Rendering/GL/GLRenderer.cpp
@@ -2122,8 +2122,6 @@ void     GLRenderer::MakeFrameBufferID(ISprite* sprite) {
 
             if (frame->SheetNumber >= sprite->Spritesheets.size())
                 continue;
-            if (!sprite->Spritesheets[frame->SheetNumber])
-                continue;
 
             float texWidth = sprite->Spritesheets[frame->SheetNumber]->Width;
             float texHeight = sprite->Spritesheets[frame->SheetNumber]->Height;

--- a/source/Engine/Rendering/GL/GLShader.cpp
+++ b/source/Engine/Rendering/GL/GLShader.cpp
@@ -252,7 +252,7 @@ bool GLShader::CheckGLError(int line) {
             break;
     }
     Log::Print(Log::LOG_ERROR, "OpenGL error on line %d: %s", line, errstr);
-    return false;
+    return true;
 }
 #undef CHECK_GL
 

--- a/source/Engine/Rendering/GL/GLShader.cpp
+++ b/source/Engine/Rendering/GL/GLShader.cpp
@@ -221,8 +221,11 @@ GLShader::~GLShader() {
 }
 
 bool GLShader::CheckGLError(int line) {
-    const char* errstr = NULL;
     GLenum error = glGetError();
+    if (error == GL_NO_ERROR) {
+        return false;
+    }
+    const char* errstr = NULL;
     switch (error) {
         case GL_NO_ERROR: errstr = "no error"; break;
         case GL_INVALID_ENUM: errstr = "invalid enumerant"; break;
@@ -248,10 +251,7 @@ bool GLShader::CheckGLError(int line) {
             errstr = "unknown error";
             break;
     }
-    if (error != GL_NO_ERROR) {
-        Log::Print(Log::LOG_ERROR, "OpenGL error on line %d: %s", line, errstr);
-        return true;
-    }
+    Log::Print(Log::LOG_ERROR, "OpenGL error on line %d: %s", line, errstr);
     return false;
 }
 #undef CHECK_GL

--- a/source/Engine/Rendering/GraphicsFunctions.h
+++ b/source/Engine/Rendering/GraphicsFunctions.h
@@ -72,8 +72,8 @@ struct GraphicsFunctions {
 
     void*    (*CreateVertexBuffer)(Uint32 maxVertices);
     void     (*DeleteVertexBuffer)(void* vtxBuf);
-    void     (*MakeFrameBufferID)(ISprite* sprite, AnimFrame* frame);
-    void     (*DeleteFrameBufferID)(AnimFrame* frame);
+    void     (*MakeFrameBufferID)(ISprite* sprite);
+    void     (*DeleteFrameBufferID)(ISprite* sprite);
 
     void     (*SetStencilEnabled)(bool enabled);
     bool     (*IsStencilEnabled)();

--- a/source/Engine/Rendering/SDL2/SDL2Renderer.cpp
+++ b/source/Engine/Rendering/SDL2/SDL2Renderer.cpp
@@ -420,6 +420,6 @@ void     SDL2Renderer::DrawSpritePart(ISprite* sprite, int animation, int frame,
         y + fY * (sy + animframe.OffsetY), fX * sw, fY * sh);
 }
 
-void     SDL2Renderer::MakeFrameBufferID(ISprite* sprite, AnimFrame* frame) {
-    frame->ID = 0;
+void     SDL2Renderer::MakeFrameBufferID(ISprite* sprite) {
+    sprite->ID = 0;
 }

--- a/source/Engine/Rendering/Software/SoftwareRenderer.cpp
+++ b/source/Engine/Rendering/Software/SoftwareRenderer.cpp
@@ -3735,6 +3735,6 @@ void     SoftwareRenderer::DrawSceneLayer(SceneLayer* layer, View* currentView, 
 	}
 }
 
-void     SoftwareRenderer::MakeFrameBufferID(ISprite* sprite, AnimFrame* frame) {
-    frame->ID = 0;
+void     SoftwareRenderer::MakeFrameBufferID(ISprite* sprite) {
+    sprite->ID = 0;
 }

--- a/source/Engine/ResourceTypes/ISprite.cpp
+++ b/source/Engine/ResourceTypes/ISprite.cpp
@@ -207,9 +207,7 @@ void ISprite::RemoveFrames(int animID) {
     Animations[animID].Frames.clear();
 }
 
-void ISprite::RefreshGraphicsID()
-{
-    //Graphics::DeleteFrameBufferID(this);
+void ISprite::RefreshGraphicsID() {
     Graphics::MakeFrameBufferID(this);
 }
 

--- a/source/Engine/ResourceTypes/ISprite.cpp
+++ b/source/Engine/ResourceTypes/ISprite.cpp
@@ -198,15 +198,19 @@ void ISprite::AddFrame(int animID, int duration, int left, int top, int width, i
     anfrm.SheetNumber = 0;
     anfrm.BoxCount = 0;
 
-    // Possibly buffer the position in the renderer.
-    Graphics::MakeFrameBufferID(this, &anfrm);
+    FrameCount++;
 
     Animations[animID].Frames.push_back(anfrm);
 }
 void ISprite::RemoveFrames(int animID) {
-    for (size_t i = 0; i < Animations[animID].Frames.size(); i++)
-        Graphics::DeleteFrameBufferID(&Animations[animID].Frames[i]);
+    FrameCount -= Animations[animID].Frames.size();
     Animations[animID].Frames.clear();
+}
+
+void ISprite::RefreshGraphicsID()
+{
+    //Graphics::DeleteFrameBufferID(this);
+    Graphics::MakeFrameBufferID(this);
 }
 
 void ISprite::ConvertToRGBA() {
@@ -364,9 +368,6 @@ bool ISprite::LoadAnimation(const char* filename) {
                 }
             }
 
-            // Possibly buffer the position in the renderer.
-            Graphics::MakeFrameBufferID(this, &anfrm);
-
 #ifdef ISPRITE_DEBUG
             Log::Print(Log::LOG_VERBOSE, "       (X: %d, Y: %d, W: %d, H: %d, OffX: %d, OffY: %d)", anfrm.X, anfrm.Y, anfrm.Width, anfrm.Height, anfrm.OffsetX, anfrm.OffsetY);
 #endif
@@ -374,6 +375,10 @@ bool ISprite::LoadAnimation(const char* filename) {
         }
         Animations[previousAnimationCount + a] = an;
     }
+    FrameCount = frameID;
+    // Possibly buffer the position in the renderer.
+    Graphics::MakeFrameBufferID(this);
+
     reader->Close();
 
     return true;
@@ -501,6 +506,8 @@ void ISprite::Dispose() {
 
     SpritesheetFilenames.clear();
     SpritesheetFilenames.shrink_to_fit();
+
+    Graphics::DeleteFrameBufferID(this);
 
     Memory::Free(Filename);
     Filename = nullptr;

--- a/source/Engine/ResourceTypes/SceneFormats/HatchSceneReader.cpp
+++ b/source/Engine/ResourceTypes/SceneFormats/HatchSceneReader.cpp
@@ -362,6 +362,8 @@ bool HatchSceneReader::LoadTileset(const char* parentFolder) {
 
     tileSprite->AddFrame(0, 0, 0, 1, 1, 0, 0);
 
+    tileSprite->RefreshGraphicsID();
+
     Tileset sceneTileset(tileSprite, Scene::TileWidth, Scene::TileHeight, 0, curTileCount, Scene::TileSpriteInfos.size(), tilesetFile);
     Scene::Tilesets.push_back(sceneTileset);
 

--- a/source/Engine/ResourceTypes/SceneFormats/RSDKSceneReader.cpp
+++ b/source/Engine/ResourceTypes/SceneFormats/RSDKSceneReader.cpp
@@ -614,6 +614,8 @@ bool RSDKSceneReader::LoadTileset(const char* parentFolder) {
         Scene::TileSpriteInfos.push_back(info);
     }
 
+    tileSprite->RefreshGraphicsID();
+
     Tileset sceneTileset(tileSprite, Scene::TileWidth, Scene::TileHeight, 0, 0, Scene::TileSpriteInfos.size(), filename16x16Tiles);
     Scene::Tilesets.push_back(sceneTileset);
 

--- a/source/Engine/ResourceTypes/SceneFormats/TiledMapReader.cpp
+++ b/source/Engine/ResourceTypes/SceneFormats/TiledMapReader.cpp
@@ -260,6 +260,8 @@ Tileset* TiledMapReader::ParseTilesetImage(XMLNode* node, int firstgid, const ch
             Scene::TileWidth, Scene::TileHeight, -Scene::TileWidth / 2, -Scene::TileHeight / 2);
     }
 
+    tileSprite->RefreshGraphicsID();
+
     Tileset sceneTileset(tileSprite, Scene::TileWidth, Scene::TileHeight, firstgid, curTileCount + numEmptyTiles, (cols * rows) + 1, imagePath);
     Scene::Tilesets.push_back(sceneTileset);
 

--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -2173,6 +2173,8 @@ bool Scene::AddTileset(char* path) {
             Scene::TileWidth, Scene::TileHeight, -Scene::TileWidth / 2, -Scene::TileHeight / 2);
     }
 
+    tileSprite->RefreshGraphicsID();
+
     Scene::SetTileCount(Scene::TileCount + (cols * rows));
 
     return true;

--- a/source/Engine/Sprites/Animation.h
+++ b/source/Engine/Sprites/Animation.h
@@ -16,7 +16,7 @@ struct AnimFrame {
     int           OffsetY;
     int           SheetNumber;
     int           Duration;
-    int           ID;
+    int           BufferOffset;
     int           Advance;
 
     int           BoxCount;

--- a/source/Engine/Types/Tileset.cpp
+++ b/source/Engine/Types/Tileset.cpp
@@ -60,6 +60,8 @@ void Tileset::AddTileAnimSequence(int tileID, TileSpriteInfo* tileSpriteInfo, ve
             TileWidth, TileHeight, -TileWidth / 2, -TileHeight / 2, 0);
     }
 
+    tileSprite->RefreshGraphicsID();
+
     TileAnimator animator(tileSpriteInfo, tileSprite, animID);
     animator.RestartAnimation();
 


### PR DESCRIPTION
This fixes the GL "out of memory" error that occurred after some time of playing.
This changes `Graphics::MakeFrameBufferID` and `Graphics::DeleteFrameBufferID` to give a buffer to the *`ISprite`* and not an `AnimFrame`, extremely cutting down on the amount of buffer allocations. Not only does this give the driver more time to breathe, but this ends up being significantly faster and more optimized as well.
- `AnimFrame.ID` is now `AnimFrame.BufferOffset`, which is an indexed offset into the total buffer of the `ISprite` itself. 
- `ISprite` now has `ISprite.ID` and `ISprite.FrameCount`, the former of which takes place of `AnimFrame.ID` and is the actual buffer instead of every `AnimFrame` containing its own buffer. The latter just helps set an "upper barrier" for the buffer creation.
- `ISprite::RefreshGraphicsID` can be called to recreate the buffer's **data** from anywhere in the code. This helps primarily with tilesets and fonts.
- Some *very* slight optimizations to `GLShader::CheckGLError` that make it run just a *tiny* bit faster when no error is reported by GL. Should help out in the long run considering how much it's used.

No other renderer was majorly changed as none other than the GL renderer actually properly implement `MakeFrameBufferID` or `DeleteFrameBufferID`, but declarations were modified regardless.