### PR TITLE
Optimization: Start overall structure, add compile-time constant math

### DIFF
--- a/include/Engine/Bytecode/Compiler.h
+++ b/include/Engine/Bytecode/Compiler.h
@@ -20,6 +20,7 @@ public:
     static bool                 ShowWarnings;
     static bool                 WriteDebugInfo;
     static bool                 WriteSourceFilename;
+    static bool                 DoOptimizations;
     Compiler* Enclosing = nullptr;
     ObjFunction* Function = nullptr;
     int Type = 0;
@@ -187,6 +188,9 @@ public:
     bool HasThis();
     void SetReceiverName(const char *name);
     void SetReceiverName(Token name);
+    int CheckInfixOptimize(int preCount, int preConstant, ParseFn fn);
+    int CheckPrefixOptimize(int preCount, int preConstant, ParseFn fn);
+    static int GetTotalOpcodeSize(uint8_t op);
     static int HashInstruction(uint8_t opcode, Chunk* chunk, int offset);
     static int ConstantInstruction(uint8_t opcode, Chunk* chunk, int offset);
     static int SimpleInstruction(uint8_t opcode, int offset);

--- a/source/Engine/Bytecode/Compiler.cpp
+++ b/source/Engine/Bytecode/Compiler.cpp
@@ -24,6 +24,7 @@ bool                 Compiler::DoLogging = false;
 bool                 Compiler::ShowWarnings = false;
 bool                 Compiler::WriteDebugInfo = false;
 bool                 Compiler::WriteSourceFilename = false;
+bool                 Compiler::DoOptimizations = false;
 
 #define Panic(returnMe) if (parser.PanicMode) { SynchronizeToken(); return returnMe; }
 
@@ -2669,14 +2670,22 @@ void          Compiler::ParsePrecedence(Precedence precedence) {
         return;
     }
 
+    int preCount = CurrentChunk()->Count;
+    int preConstant = CurrentChunk()->Constants->size();
+
     bool canAssign = precedence <= PREC_ASSIGNMENT;
     (this->*prefixRule)(canAssign);
+
+    if (DoOptimizations)
+        preConstant = CheckPrefixOptimize(preCount, preConstant, prefixRule);
 
     while (precedence <= GetRule(parser.Current.Type)->Precedence) {
         AdvanceToken();
         ParseFn infixRule = GetRule(parser.Previous.Type)->Infix;
         if (infixRule)
             (this->*infixRule)(canAssign);
+        if (DoOptimizations)
+            preConstant = CheckInfixOptimize(preCount, preConstant, infixRule);
     }
 
     if (canAssign && MatchAssignmentToken()) {
@@ -2870,6 +2879,554 @@ void          Compiler::SetReceiverName(Token name) {
     local->Name = name;
 }
 
+int   Compiler::CheckPrefixOptimize(int preCount, int preConstant, ParseFn fn)
+{
+    ///////////
+    //printf("------PrefixOptimize @ %d %d\n", preCount, preConstant);
+    //for (int i = preCount; i < CurrentChunk()->Count;)
+    //    i = DebugInstruction(CurrentChunk(), i);
+    ///////////
+
+    int checkConstant = -1;
+    VMValue out = NULL_VAL;
+
+    if (fn == &Compiler::GetInteger) {
+        //printf("GetInteger\n");
+
+        checkConstant = *(Uint32*)(CurrentChunk()->Code + (preCount + 1));
+        VMValue constant = (*CurrentChunk()->Constants)[checkConstant];
+        int i = AS_INTEGER(constant);
+        if (i == 0 || i == 1) {
+            CurrentChunk()->Count = preCount;
+            EmitByte(!i ? OP_FALSE : OP_TRUE);
+        }
+        else
+            checkConstant = -1;
+    }
+    else if (fn == &Compiler::GetUnary) {
+        //printf("GetUnary\n");
+
+        Uint8 unOp = CurrentChunk()->Code[CurrentChunk()->Count - 1];
+        if (unOp == OP_TYPEOF)
+            return preConstant;
+        Uint8 op = CurrentChunk()->Code[preCount];
+        VMValue constant;
+        switch (op) {
+        case OP_CONSTANT:
+            checkConstant = *(Uint32*)(CurrentChunk()->Code + (preCount + 1));
+            constant = (*CurrentChunk()->Constants)[checkConstant];
+            break;
+        case OP_TRUE:
+        case OP_FALSE:
+            constant = INTEGER_VAL(op == OP_TRUE ? 1 : 0);
+            break;
+        case OP_NULL:
+            constant = NULL_VAL;
+            break;
+        default:
+            return preConstant;
+        }
+
+        if (IS_NOT_NUMBER(constant) && unOp != OP_LG_NOT)
+            return preConstant;
+
+        switch (unOp) {
+        case OP_LG_NOT:
+            CurrentChunk()->Count = preCount;
+
+            switch (constant.Type) {
+            case VAL_NULL:
+                EmitByte(OP_TRUE); break;
+            case VAL_OBJECT:
+                EmitByte(OP_FALSE); break;
+            case VAL_DECIMAL:
+            case VAL_LINKED_DECIMAL:
+                EmitByte((float)(AS_DECIMAL(constant) == 0.0) ? OP_TRUE : OP_FALSE); break;
+            case VAL_INTEGER:
+            case VAL_LINKED_INTEGER:
+                EmitByte(!AS_INTEGER(constant) ? OP_TRUE : OP_FALSE); break;
+            }
+            break;
+        case OP_NEGATE:
+            CurrentChunk()->Count = preCount;
+
+            if (constant.Type == VAL_DECIMAL)
+                out = DECIMAL_VAL(-AS_DECIMAL(constant));
+            else {
+                out = INTEGER_VAL(-AS_INTEGER(constant));
+            }
+            break;
+        case OP_BW_NOT:
+            CurrentChunk()->Count = preCount;
+
+            if (constant.Type == VAL_DECIMAL)
+                out = DECIMAL_VAL((float)(~(int)AS_DECIMAL(constant)));
+            else {
+                out = INTEGER_VAL(~AS_INTEGER(constant));
+            }
+            break;
+        }
+    }
+
+    if (checkConstant >= preConstant) {
+        CurrentChunk()->Constants->pop_back();
+        //Log::PrintSimple("Constant eaten: %d\n", checkConstant);
+    }
+    if (!IS_NULL(out)) {
+        EmitConstant(out);
+        preConstant = CurrentChunk()->Constants->size();
+        if (out.Type == VAL_INTEGER)
+            preConstant = CheckPrefixOptimize(preCount, preConstant, &Compiler::GetInteger);
+    }
+
+    ///////////
+    //printf("------AFTER : @ %d %d\n", preCount, CurrentChunk()->Constants->size());
+    //for (int i = preCount; i < CurrentChunk()->Count;)
+    //    i = DebugInstruction(CurrentChunk(), i);
+    //printf("----------------- @ %d\n", preCount);
+    ///////////
+
+    return preConstant;
+}
+
+int    Compiler::CheckInfixOptimize(int preCount, int preConstant, ParseFn fn)
+{
+    ///////////
+    //printf("------InfixOptimize @ %d %d\n", preCount, preConstant);
+    //for (int i = preCount; i < CurrentChunk()->Count;)
+    //    i = DebugInstruction(CurrentChunk(), i);
+    ///////////
+
+    if (fn == &Compiler::GetBinary) {
+        // this is gonna be really basic for now (constant constant OP)
+        // some of the stuff that passes through here are much longer than that, but this is a very solid start
+        // that already can shrink a good amount
+
+        int off1 = preCount;
+        Uint8 op1 = CurrentChunk()->Code[off1];
+        int off2 = GetTotalOpcodeSize(op1) + off1;
+        if (off2 >= CurrentChunk()->Count)
+            return preConstant;
+        Uint8 op2 = CurrentChunk()->Code[off2];
+        int offB = GetTotalOpcodeSize(op2) + off2;
+        if (offB != CurrentChunk()->Count - 1) // CHANGE TO >= ONCE CASCADING IS ADDED
+            return preConstant;
+        Uint8 opB = CurrentChunk()->Code[offB];
+
+        VMValue a;
+        int checkConstantA = -1;
+        VMValue b;
+        int checkConstantB = -1;
+
+        switch (op1) {
+            case OP_CONSTANT:
+                checkConstantA = *(Uint32*)(CurrentChunk()->Code + (off1 + 1));
+                a = (*CurrentChunk()->Constants)[checkConstantA];
+                break;
+            case OP_TRUE:
+            case OP_FALSE:
+                a = INTEGER_VAL(op1 == OP_TRUE ? 1 : 0);
+                break;
+            case OP_NULL:
+                a = NULL_VAL;
+                break;
+            default:
+                return preConstant;
+        }
+
+        switch (op2) {
+            case OP_CONSTANT:
+                checkConstantB = *(Uint32*)(CurrentChunk()->Code + (off2 + 1));
+                b = (*CurrentChunk()->Constants)[checkConstantB];
+                break;
+            case OP_TRUE:
+            case OP_FALSE:
+                b = INTEGER_VAL(op2 == OP_TRUE ? 1 : 0);
+                break;
+            case OP_NULL:
+                b = NULL_VAL;
+                break;
+            default:
+                return preConstant;
+        }
+
+        VMValue out;
+
+        switch (opB) {
+                // Numeric Operations
+            case OP_ADD: {
+                if (IS_STRING(a) || IS_STRING(b)) {
+                    VMValue str_b = ScriptManager::CastValueAsString(b);
+                    VMValue str_a = ScriptManager::CastValueAsString(a);
+                    out = ScriptManager::Concatenate(str_a, str_b);
+                    break;
+                }
+                else if (IS_NOT_NUMBER(a) || IS_NOT_NUMBER(b))
+                    return preConstant;
+
+                if (a.Type == VAL_DECIMAL || b.Type == VAL_DECIMAL) {
+                    float a_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(a));
+                    float b_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(b));
+                    out = DECIMAL_VAL(a_d + b_d);
+                }
+                else {
+                    int a_d = AS_INTEGER(a);
+                    int b_d = AS_INTEGER(b);
+                    out = INTEGER_VAL(a_d + b_d);
+                }
+
+                break;
+            }
+            case OP_SUBTRACT: {
+                if (IS_NOT_NUMBER(a) || IS_NOT_NUMBER(b))
+                    return preConstant;
+
+                if (a.Type == VAL_DECIMAL || b.Type == VAL_DECIMAL) {
+                    float a_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(a));
+                    float b_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(b));
+                    out = DECIMAL_VAL(a_d - b_d);
+                }
+                else {
+                    int a_d = AS_INTEGER(a);
+                    int b_d = AS_INTEGER(b);
+                    out = INTEGER_VAL(a_d - b_d);
+                }
+
+                break;
+            }
+            case OP_MULTIPLY: {
+                if (IS_NOT_NUMBER(a) || IS_NOT_NUMBER(b))
+                    return preConstant;
+
+                if (a.Type == VAL_DECIMAL || b.Type == VAL_DECIMAL) {
+                    float a_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(a));
+                    float b_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(b));
+                    out = DECIMAL_VAL(a_d * b_d);
+                }
+                else {
+                    int a_d = AS_INTEGER(a);
+                    int b_d = AS_INTEGER(b);
+                    out = INTEGER_VAL(a_d * b_d);
+                }
+
+                break;
+            }
+            case OP_DIVIDE: {
+                if (IS_NOT_NUMBER(a) || IS_NOT_NUMBER(b))
+                    return preConstant;
+
+                if (a.Type == VAL_DECIMAL || b.Type == VAL_DECIMAL) {
+                    float a_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(a));
+                    float b_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(b));
+
+                    if (b_d == 0)
+                        return preConstant;
+                    out = DECIMAL_VAL(a_d / b_d);
+                }
+                else {
+                    int a_d = AS_INTEGER(a);
+                    int b_d = AS_INTEGER(b);
+                    if (b_d == 0)
+                        return preConstant;
+
+                    out = INTEGER_VAL(a_d / b_d);
+                }
+
+                break;
+            }
+            case OP_MODULO: {
+                if (IS_NOT_NUMBER(a) || IS_NOT_NUMBER(b))
+                    return preConstant;
+
+                if (a.Type == VAL_DECIMAL || b.Type == VAL_DECIMAL) {
+                    float a_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(a));
+                    float b_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(b));
+                    out = DECIMAL_VAL(fmod(a_d, b_d));
+                }
+                else {
+                    int a_d = AS_INTEGER(a);
+                    int b_d = AS_INTEGER(b);
+                    out = INTEGER_VAL(a_d % b_d);
+                }
+
+                break;
+            }
+                // Bitwise Operations
+            case OP_BITSHIFT_LEFT: {
+                if (IS_NOT_NUMBER(a) || IS_NOT_NUMBER(b))
+                    return preConstant;
+
+                if (a.Type == VAL_DECIMAL || b.Type == VAL_DECIMAL) {
+                    float a_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(a));
+                    float b_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(b));
+                    out = DECIMAL_VAL((float)((int)a_d << (int)b_d));
+                }
+                else {
+                    int a_d = AS_INTEGER(a);
+                    int b_d = AS_INTEGER(b);
+                    out = INTEGER_VAL(a_d << b_d);
+                }
+
+                break;
+            }
+            case OP_BITSHIFT_RIGHT: {
+                if (IS_NOT_NUMBER(a) || IS_NOT_NUMBER(b))
+                    return preConstant;
+
+                if (a.Type == VAL_DECIMAL || b.Type == VAL_DECIMAL) {
+                    float a_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(a));
+                    float b_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(b));
+                    out = DECIMAL_VAL((float)((int)a_d >> (int)b_d));
+                }
+                else {
+                    int a_d = AS_INTEGER(a);
+                    int b_d = AS_INTEGER(b);
+                    out = INTEGER_VAL(a_d >> b_d);
+                }
+
+                break;
+            }
+            case OP_BW_OR: {
+                if (IS_NOT_NUMBER(a) || IS_NOT_NUMBER(b))
+                    return preConstant;
+
+                if (a.Type == VAL_DECIMAL || b.Type == VAL_DECIMAL) {
+                    float a_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(a));
+                    float b_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(b));
+                    out = DECIMAL_VAL((float)((int)a_d | (int)b_d));
+                }
+                else {
+                    int a_d = AS_INTEGER(a);
+                    int b_d = AS_INTEGER(b);
+                    out = INTEGER_VAL(a_d | b_d);
+                }
+
+                break;
+            }
+            case OP_BW_AND: {
+                if (IS_NOT_NUMBER(a) || IS_NOT_NUMBER(b))
+                    return preConstant;
+
+                if (a.Type == VAL_DECIMAL || b.Type == VAL_DECIMAL) {
+                    float a_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(a));
+                    float b_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(b));
+                    out = DECIMAL_VAL((float)((int)a_d & (int)b_d));
+                }
+                else {
+                    int a_d = AS_INTEGER(a);
+                    int b_d = AS_INTEGER(b);
+                    out = INTEGER_VAL(a_d & b_d);
+                }
+
+                break;
+            }
+            case OP_BW_XOR: {
+                if (IS_NOT_NUMBER(a) || IS_NOT_NUMBER(b))
+                    return preConstant;
+
+                if (a.Type == VAL_DECIMAL || b.Type == VAL_DECIMAL) {
+                    float a_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(a));
+                    float b_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(b));
+                    out = DECIMAL_VAL((float)((int)a_d ^ (int)b_d));
+                }
+                else {
+                    int a_d = AS_INTEGER(a);
+                    int b_d = AS_INTEGER(b);
+                    out = INTEGER_VAL(a_d ^ b_d);
+                }
+
+                break;
+            }
+                // Equality and Comparison Operators
+            case OP_EQUAL_NOT:
+            case OP_EQUAL: {
+                bool equal = ScriptManager::ValuesSortaEqual(a, b);
+                if (opB == OP_EQUAL_NOT)
+                    equal = !equal;
+                out = INTEGER_VAL(equal ? 1 : 0);
+                break;
+            }
+            case OP_GREATER: {
+                if (IS_NOT_NUMBER(a) || IS_NOT_NUMBER(b))
+                    return preConstant;
+
+                if (a.Type == VAL_DECIMAL || b.Type == VAL_DECIMAL) {
+                    float a_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(a));
+                    float b_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(b));
+                    out = DECIMAL_VAL(a_d > b_d);
+                }
+                else {
+                    int a_d = AS_INTEGER(a);
+                    int b_d = AS_INTEGER(b);
+                    out = INTEGER_VAL(a_d > b_d);
+                }
+
+                break;
+            }
+            case OP_GREATER_EQUAL: {
+                if (IS_NOT_NUMBER(a) || IS_NOT_NUMBER(b))
+                    return preConstant;
+
+                if (a.Type == VAL_DECIMAL || b.Type == VAL_DECIMAL) {
+                    float a_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(a));
+                    float b_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(b));
+                    out = DECIMAL_VAL(a_d >= b_d);
+                }
+                else {
+                    int a_d = AS_INTEGER(a);
+                    int b_d = AS_INTEGER(b);
+                    out = INTEGER_VAL(a_d >= b_d);
+                }
+
+                break;
+            }
+            case OP_LESS: {
+                if (IS_NOT_NUMBER(a) || IS_NOT_NUMBER(b))
+                    return preConstant;
+
+                if (a.Type == VAL_DECIMAL || b.Type == VAL_DECIMAL) {
+                    float a_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(a));
+                    float b_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(b));
+                    out = DECIMAL_VAL(a_d < b_d);
+                }
+                else {
+                    int a_d = AS_INTEGER(a);
+                    int b_d = AS_INTEGER(b);
+                    out = INTEGER_VAL(a_d < b_d);
+                }
+
+                break;
+            }
+            case OP_LESS_EQUAL: {
+                if (IS_NOT_NUMBER(a) || IS_NOT_NUMBER(b))
+                    return preConstant;
+
+                if (a.Type == VAL_DECIMAL || b.Type == VAL_DECIMAL) {
+                    float a_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(a));
+                    float b_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(b));
+                    out = DECIMAL_VAL(a_d <= b_d);
+                }
+                else {
+                    int a_d = AS_INTEGER(a);
+                    int b_d = AS_INTEGER(b);
+                    out = INTEGER_VAL(a_d <= b_d);
+                }
+
+                break;
+            }
+        }
+
+        CurrentChunk()->Count = preCount;
+        if (checkConstantA >= preConstant)
+            CurrentChunk()->Constants->pop_back();
+        if (checkConstantB >= preConstant && checkConstantA != checkConstantB)
+            CurrentChunk()->Constants->pop_back();
+        //Log::PrintSimple("Constants eaten: %d %d\n", checkConstantA, checkConstantB);
+
+        preConstant = CurrentChunk()->Constants->size();
+        EmitConstant(out);
+        if (out.Type == VAL_INTEGER)
+            preConstant = CheckPrefixOptimize(preCount, preConstant, &Compiler::GetInteger);
+        return preConstant;
+    }
+
+    ///////////
+    //printf("------AFTER : @ %d %d\n", preCount, CurrentChunk()->Constants->size());
+    //for (int i = preCount; i < CurrentChunk()->Count;)
+    //    i = DebugInstruction(CurrentChunk(), i);
+    //printf("----------------- @ %d\n", preCount);
+    ///////////
+}
+
+int    Compiler::GetTotalOpcodeSize(uint8_t op) {
+    switch (op) {
+        // ConstantInstruction
+        case OP_CONSTANT:
+        case OP_IMPORT:
+        case OP_IMPORT_MODULE:
+            return 5;
+        case OP_NULL:
+        case OP_TRUE:
+        case OP_FALSE:
+        case OP_POP:
+        case OP_INCREMENT:
+        case OP_DECREMENT:
+        case OP_BITSHIFT_LEFT:
+        case OP_BITSHIFT_RIGHT:
+        case OP_EQUAL:
+        case OP_EQUAL_NOT:
+        case OP_LESS:
+        case OP_LESS_EQUAL:
+        case OP_GREATER:
+        case OP_GREATER_EQUAL:
+        case OP_ADD:
+        case OP_SUBTRACT:
+        case OP_MULTIPLY:
+        case OP_MODULO:
+        case OP_DIVIDE:
+        case OP_BW_NOT:
+        case OP_BW_AND:
+        case OP_BW_OR:
+        case OP_BW_XOR:
+        case OP_LG_NOT:
+        case OP_LG_AND:
+        case OP_LG_OR:
+        case OP_GET_ELEMENT:
+        case OP_SET_ELEMENT:
+        case OP_NEGATE:
+        case OP_PRINT:
+        case OP_TYPEOF:
+        case OP_RETURN:
+        case OP_SAVE_VALUE:
+        case OP_LOAD_VALUE:
+        case OP_GET_SUPERCLASS:
+        case OP_DEFINE_MODULE_LOCAL:
+        case OP_ENUM_NEXT:
+            return 1;
+        case OP_COPY:
+        case OP_CALL:
+        case OP_NEW:
+        case OP_EVENT:
+        case OP_POPN:
+            return 2;
+        case OP_GET_LOCAL:
+        case OP_SET_LOCAL:
+            return 2;
+        case OP_GET_GLOBAL:
+        case OP_DEFINE_GLOBAL:
+        case OP_SET_GLOBAL:
+        case OP_GET_PROPERTY:
+        case OP_SET_PROPERTY:
+        case OP_HAS_PROPERTY:
+        case OP_USE_NAMESPACE:
+        case OP_INHERIT:
+            return 5;
+        case OP_SET_MODULE_LOCAL:
+        case OP_GET_MODULE_LOCAL:
+            return 3;
+        case OP_NEW_ARRAY:
+        case OP_NEW_MAP:
+            return 5;
+        case OP_JUMP:
+        case OP_JUMP_IF_FALSE:
+        case OP_JUMP_BACK:
+            return 3;
+        case OP_INVOKE:
+            return 7;
+        case OP_WITH:
+            return 4;
+        case OP_CLASS:
+            return 6;
+        case OP_ADD_ENUM:
+        case OP_NEW_ENUM:
+            return 5;
+        case OP_METHOD:
+            return 6;
+    }
+    return 1;
+}
+
+
 // Debugging functions
 int    Compiler::HashInstruction(uint8_t opcode, Chunk* chunk, int offset) {
     uint32_t hash = *(uint32_t*)&chunk->Code[offset + 1];
@@ -2879,28 +3436,28 @@ int    Compiler::HashInstruction(uint8_t opcode, Chunk* chunk, int offset) {
         Log::PrintSimple(" (%.*s)", (int)t.Length, t.Start);
     }
     Log::PrintSimple("\n");
-    return offset + 5;
+    return offset + GetTotalOpcodeSize(opcode);
 }
 int    Compiler::ConstantInstruction(uint8_t opcode, Chunk* chunk, int offset) {
     int constant = *(int*)&chunk->Code[offset + 1];
     Log::PrintSimple("%-16s %9d '", opcodeNames[opcode], constant);
     Values::PrintValue(NULL, (*chunk->Constants)[constant]);
     Log::PrintSimple("'\n");
-    return offset + 5;
+    return offset + GetTotalOpcodeSize(opcode);
 }
 int    Compiler::SimpleInstruction(uint8_t opcode, int offset) {
     Log::PrintSimple("%s\n", opcodeNames[opcode]);
-    return offset + 1;
+    return offset + GetTotalOpcodeSize(opcode);
 }
 int    Compiler::ByteInstruction(uint8_t opcode, Chunk* chunk, int offset) {
     Log::PrintSimple("%-16s %9d\n", opcodeNames[opcode], chunk->Code[offset + 1]);
-    return offset + 2;
+    return offset + GetTotalOpcodeSize(opcode);
 }
 int    Compiler::ShortInstruction(uint8_t opcode, Chunk* chunk, int offset) {
     uint16_t data = (uint16_t)(chunk->Code[offset + 1]);
     data |= chunk->Code[offset + 2] << 8;
     Log::PrintSimple("%-16s %9d\n", opcodeNames[opcode], data);
-    return offset + 3;
+    return offset + GetTotalOpcodeSize(opcode);
 }
 int    Compiler::LocalInstruction(uint8_t opcode, Chunk* chunk, int offset) {
     uint8_t slot = chunk->Code[offset + 1];
@@ -2908,7 +3465,7 @@ int    Compiler::LocalInstruction(uint8_t opcode, Chunk* chunk, int offset) {
         Log::PrintSimple("%-16s %9d\n", opcodeNames[opcode], slot);
     else
         Log::PrintSimple("%-16s %9d 'this'\n", opcodeNames[opcode], slot);
-    return offset + 2;
+    return offset + GetTotalOpcodeSize(opcode);
 }
 int    Compiler::MethodInstruction(uint8_t opcode, Chunk* chunk, int offset) {
     uint8_t slot = chunk->Code[offset + 1];
@@ -2920,19 +3477,19 @@ int    Compiler::MethodInstruction(uint8_t opcode, Chunk* chunk, int offset) {
         Log::PrintSimple(" (%.*s)", (int)t.Length, t.Start);
     }
     Log::PrintSimple("\n");
-    return offset + 6;
+    return offset + GetTotalOpcodeSize(opcode);
 }
 int    Compiler::InvokeInstruction(uint8_t opcode, Chunk* chunk, int offset) {
-    return Compiler::MethodInstruction(opcode, chunk, offset) + 1;
+    return Compiler::MethodInstruction(opcode, chunk, offset);
 }
 int    Compiler::JumpInstruction(uint8_t opcode, int sign, Chunk* chunk, int offset) {
     uint16_t jump = (uint16_t)(chunk->Code[offset + 1]);
     jump |= chunk->Code[offset + 2] << 8;
     Log::PrintSimple("%-16s %9d -> %d\n", opcodeNames[opcode], offset, offset + 3 + sign * jump);
-    return offset + 3;
+    return offset + GetTotalOpcodeSize(opcode);
 }
 int    Compiler::ClassInstruction(uint8_t opcode, Chunk* chunk, int offset) {
-    return Compiler::HashInstruction(opcode, chunk, offset) + 1;
+    return Compiler::HashInstruction(opcode, chunk, offset);
 }
 int    Compiler::EnumInstruction(uint8_t opcode, Chunk* chunk, int offset) {
     return Compiler::HashInstruction(opcode, chunk, offset);
@@ -2950,7 +3507,7 @@ int    Compiler::WithInstruction(uint8_t opcode, Chunk* chunk, int offset) {
         Log::PrintSimple("%-16s %1d %7d -> %d\n", opcodeNames[opcode], type, slot, jump);
     else
         Log::PrintSimple("%-16s %1d %7d 'this' -> %d\n", opcodeNames[opcode], type, slot, jump);
-    return offset + 4;
+    return offset + GetTotalOpcodeSize(opcode);
 }
 int    Compiler::DebugInstruction(Chunk* chunk, int offset) {
     Log::PrintSimple("%04d ", offset);

--- a/source/Engine/Bytecode/Compiler.cpp
+++ b/source/Engine/Bytecode/Compiler.cpp
@@ -3253,7 +3253,7 @@ int    Compiler::CheckInfixOptimize(int preCount, int preConstant, ParseFn fn)
                 if (a.Type == VAL_DECIMAL || b.Type == VAL_DECIMAL) {
                     float a_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(a));
                     float b_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(b));
-                    out = DECIMAL_VAL(a_d > b_d);
+                    out = INTEGER_VAL(a_d > b_d);
                 }
                 else {
                     int a_d = AS_INTEGER(a);
@@ -3270,7 +3270,7 @@ int    Compiler::CheckInfixOptimize(int preCount, int preConstant, ParseFn fn)
                 if (a.Type == VAL_DECIMAL || b.Type == VAL_DECIMAL) {
                     float a_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(a));
                     float b_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(b));
-                    out = DECIMAL_VAL(a_d >= b_d);
+                    out = INTEGER_VAL(a_d >= b_d);
                 }
                 else {
                     int a_d = AS_INTEGER(a);
@@ -3287,7 +3287,7 @@ int    Compiler::CheckInfixOptimize(int preCount, int preConstant, ParseFn fn)
                 if (a.Type == VAL_DECIMAL || b.Type == VAL_DECIMAL) {
                     float a_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(a));
                     float b_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(b));
-                    out = DECIMAL_VAL(a_d < b_d);
+                    out = INTEGER_VAL(a_d < b_d);
                 }
                 else {
                     int a_d = AS_INTEGER(a);
@@ -3304,7 +3304,7 @@ int    Compiler::CheckInfixOptimize(int preCount, int preConstant, ParseFn fn)
                 if (a.Type == VAL_DECIMAL || b.Type == VAL_DECIMAL) {
                     float a_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(a));
                     float b_d = AS_DECIMAL(ScriptManager::CastValueAsDecimal(b));
-                    out = DECIMAL_VAL(a_d <= b_d);
+                    out = INTEGER_VAL(a_d <= b_d);
                 }
                 else {
                     int a_d = AS_INTEGER(a);

--- a/source/Engine/Bytecode/Compiler.cpp
+++ b/source/Engine/Bytecode/Compiler.cpp
@@ -3327,7 +3327,6 @@ int    Compiler::CheckInfixOptimize(int preCount, int preConstant, ParseFn fn)
         EmitConstant(out);
         if (out.Type == VAL_INTEGER)
             preConstant = CheckPrefixOptimize(preCount, preConstant, &Compiler::GetInteger);
-        return preConstant;
     }
 
     ///////////
@@ -3336,6 +3335,7 @@ int    Compiler::CheckInfixOptimize(int preCount, int preConstant, ParseFn fn)
     //    i = DebugInstruction(CurrentChunk(), i);
     //printf("----------------- @ %d\n", preCount);
     ///////////
+    return preConstant;
 }
 
 int    Compiler::GetTotalOpcodeSize(uint8_t op) {

--- a/source/Engine/Bytecode/Compiler.cpp
+++ b/source/Engine/Bytecode/Compiler.cpp
@@ -3654,6 +3654,7 @@ void   Compiler::Init() {
     Compiler::ShowWarnings = false;
     Compiler::WriteDebugInfo = true;
     Compiler::WriteSourceFilename = true;
+    Compiler::DoOptimizations = true;
 
     Application::Settings->GetBool("compiler", "log", &Compiler::DoLogging);
     if (Compiler::DoLogging) {
@@ -3662,6 +3663,7 @@ void   Compiler::Init() {
 
     Application::Settings->GetBool("compiler", "writeDebugInfo", &Compiler::WriteDebugInfo);
     Application::Settings->GetBool("compiler", "writeSourceFilename", &Compiler::WriteSourceFilename);
+    Application::Settings->GetBool("compiler", "optimizations", &Compiler::DoOptimizations);
 }
 void   Compiler::PrepareCompiling() {
     if (Compiler::TokenMap == NULL) {

--- a/source/Engine/Bytecode/Types.cpp
+++ b/source/Engine/Bytecode/Types.cpp
@@ -16,7 +16,7 @@
 #define ALLOCATE(type, size) \
     (type*)Memory::TrackedMalloc(#type, sizeof(type) * size)
 
-#define GROW_CAPACITY(val) ((val) < 8 ? 8 : val * 2)
+#define GROW_CAPACITY(val) ((val) < 8 ? 8 : val << 1)
 
 static Obj*       AllocateObject(size_t size, ObjType type) {
     // Only do this when allocating more memory

--- a/source/Engine/Bytecode/VMThread.cpp
+++ b/source/Engine/Bytecode/VMThread.cpp
@@ -2643,6 +2643,9 @@ VMValue VMThread::Values_LogicalNOT() {
 }
 VMValue VMThread::Values_BitwiseNOT() {
     VMValue a = Pop();
+
+    CHECK_IS_NUM(a, "bitwise NOT", INTEGER_VAL(0));
+
     if (a.Type == VAL_DECIMAL) {
         return DECIMAL_VAL((float)(~(int)AS_DECIMAL(a)));
     }


### PR DESCRIPTION
This PR lays out a general structure to begin the process of *compiler optimizations*. Currently, two optimization funcs have been added, both having the same arguments:
- `CheckPrefixOptimize` is called after a prefix function from a rule, intaking the code position before any modifications to the compiled code (e.g. by the prefix function or by another optimization), the amount of constants before any modifications to the compiled code, and the function called to check how to optimize it. Currently supports the `GetInteger` and `GetUnary` prefix functions.
- `CheckInfixOptimize` does the same exact thing but for infix functions. Currently supports the `GetBinary` infix function.

This PR also adds a helper function `Compiler::GetTotalOpcodeSize`, used by `CheckInfixOptimize` and the debug functions. It also adds a `IS_NUMBER` check to `BITWISE_NOT` (which I imagine was definitely supposed to have it) and does the tiniest of optimizations changing a `* 2` to a `<< 1` (which the compiler probably made into a `<< 1` anyway but I kept it in this PR just because I had already took an eye to it before.)