### PR TITLE
GL: Potentially fix crash and optimize some more

### DIFF
--- a/include/Engine/Rendering/GL/GLShader.h
+++ b/include/Engine/Rendering/GL/GLShader.h
@@ -10,7 +10,7 @@
 #define GL_DO_ERROR_CHECKING 
 #endif
 
-#if GL_DO_ERROR_CHECKING
+#ifdef GL_DO_ERROR_CHECKING
 #define CHECK_GL() GLShader::CheckGLError(__LINE__)
 #else
 #define CHECK_GL()

--- a/include/Engine/Rendering/GL/GLShader.h
+++ b/include/Engine/Rendering/GL/GLShader.h
@@ -6,6 +6,16 @@
 #include <Engine/Math/Matrix4x4.h>
 #include <Engine/IO/Stream.h>
 
+#ifdef DEBUG
+#define GL_DO_ERROR_CHECKING 
+#endif
+
+#if GL_DO_ERROR_CHECKING
+#define CHECK_GL() GLShader::CheckGLError(__LINE__)
+#else
+#define CHECK_GL()
+#endif
+
 class GLShader {
 private:
     void AttachAndLink();

--- a/source/Engine/Rendering/GL/GLRenderer.cpp
+++ b/source/Engine/Rendering/GL/GLRenderer.cpp
@@ -813,10 +813,6 @@ void GL_SetState(GL_State& state, GL_VertexBuffer *driverData, Matrix4x4* projMa
             glDisable(GL_CULL_FACE);
     }
 
-    // this one's a little bit SILLY
-    // i don't know why but it is
-    if (GL_ActiveCullMode != state.CullMode)
-        glCullFace(GL_ActiveCullMode = state.CullMode);
     if (SETSTATE_COMPARE_LAST_VAL(WindingOrder))
         glFrontFace(state.WindingOrder);
 
@@ -2076,7 +2072,11 @@ void     GLRenderer::DrawScene3D(Uint32 sceneIndex, Uint32 drawMode) {
 
             if (useBatching) {
                 if (stateChanged) {
-                    // the most common state change is ONLY a texture change. check
+                    // the most common state change is ONLY a texture change. check it and cull mode, save a round trip
+                    if (GL_ActiveCullMode != lastState.CullMode)
+                        glCullFace(GL_ActiveCullMode = lastState.CullMode);
+
+                    lastStateCMP.CullMode = lastState.CullMode;
                     lastStateCMP.TexturePtr = lastState.TexturePtr;
                     if (memcmp(&lastState, &lastStateCMP, sizeof(GL_State))) {
                         GL_SetState(lastState, driverData, &projMat, &viewMat, lastStateCMP.VertexAtrribs == NULL ? NULL : &lastStateCMP);

--- a/source/Engine/Rendering/GL/GLRenderer.cpp
+++ b/source/Engine/Rendering/GL/GLRenderer.cpp
@@ -998,7 +998,7 @@ void     GLRenderer::Init() {
     Log::Print(Log::LOG_INFO, "Renderer: OpenGL");
 
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
 
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
 

--- a/source/Engine/Rendering/GL/GLShader.cpp
+++ b/source/Engine/Rendering/GL/GLShader.cpp
@@ -4,9 +4,6 @@
 
 #include <Engine/Diagnostics/Log.h>
 
-#define CHECK_GL() \
-    GLShader::CheckGLError(__LINE__)
-
 GLShader::GLShader(std::string vertexShaderSource, std::string fragmentShaderSource) {
     GLint compiled = GL_FALSE;
     ProgramID = glCreateProgram();


### PR DESCRIPTION
This PR attempts to fix the GL crash by disabling vertex attribs that aren't in use, alongside a couple other small things:
- Cull mode optimization has been reworked and now keeps track of it on its own, since it's such a common change.
  - Clipping now tracks as well since it used to love to spam it. 
- Active texture now also keeps track of its own, alongside moving texture binding to its own check as well.
- `GL_SetState`, even if not called as often, got a few small, tiny changes that should play better with the compiler.
- Texture wrapping is now handled differently: the default of `GL_CLAMP_TO_EDGE` has been removed and a new function `GL_SetTextureWrap` is now available. 
  - `GL_TextureData` now has a bool `Accessed` that is currently used by `GL_BindTexture` to check its wrapping and set it using `GL_SetTextureWrap`. Sets to true when it is bound when it hasn't been before.
- A new define `GL_DO_ERROR_CHECKING` has been added in `GLShader.h` that disables `CHECK_GL`. Currently, it turns itself on on debug builds.