### PR TITLE
Misc memory leaks & undefined behavior bugfixes

### DIFF
--- a/include/Engine/Rendering/GameTexture.h
+++ b/include/Engine/Rendering/GameTexture.h
@@ -14,7 +14,7 @@ public:
     GameTexture(Uint32 width, Uint32 height, int unloadPolicy);
     virtual Texture* GetTexture();
     virtual int GetID();
-    ~GameTexture();
+    virtual ~GameTexture();
 };
 
 #endif /* ENGINE_RENDERING_GAMETEXTURE_H */

--- a/include/Engine/Types/Entity.h
+++ b/include/Engine/Types/Entity.h
@@ -99,6 +99,7 @@ public:
     Entity* PrevSceneEntity = NULL;
     Entity* NextSceneEntity = NULL;
 
+    virtual ~Entity() = default;
     void ApplyMotion();
     void Animate();
     void SetAnimation(int animation, int frame);

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -1,3 +1,4 @@
+#include "Engine/Diagnostics/Log.h"
 #include <Engine/Bytecode/StandardLibrary.h>
 
 #include <Engine/Graphics.h>
@@ -16335,7 +16336,7 @@ VMValue XML_Parse(int argCount, VMValue* args, Uint32 threadID) {
 
             // XMLParser will realloc text, so the stream needs to free it.
             stream->owns_memory = true;
-            stream->Close();
+            XMLParser::Free(xmlRoot);
         }
         else
             Memory::Free(text);

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -15333,11 +15333,11 @@ VMValue Video_Close(int argCount, VMValue* args, Uint32 threadID) {
 
     if (!resource)
         return NULL_VAL;
-    delete resource;
 
-    if (!resource->AsMedia)
-        return NULL_VAL;
-    delete resource->AsMedia;
+    if (resource->AsMedia)
+        delete resource->AsMedia;
+
+    delete resource;
 
     return NULL_VAL;
 }

--- a/source/Engine/Rendering/GL/GLRenderer.cpp
+++ b/source/Engine/Rendering/GL/GLRenderer.cpp
@@ -372,8 +372,8 @@ void   GL_DrawTextureBuffered(Texture* texture, GLuint buffer, int offset, int f
     }
 
     glBindBuffer(GL_ARRAY_BUFFER, buffer);
-    glVertexAttribPointer(GLRenderer::CurrentShader->LocPosition, 2, GL_FLOAT, GL_FALSE, sizeof(GL_AnimFrameVert), (char*)offset);
-    glVertexAttribPointer(GLRenderer::CurrentShader->LocTexCoord, 2, GL_FLOAT, GL_FALSE, sizeof(GL_AnimFrameVert), (char*)offset + 8);
+    glVertexAttribPointer(GLRenderer::CurrentShader->LocPosition, 2, GL_FLOAT, GL_FALSE, sizeof(GL_AnimFrameVert), (void*)(uintptr_t)offset);
+    glVertexAttribPointer(GLRenderer::CurrentShader->LocTexCoord, 2, GL_FLOAT, GL_FALSE, sizeof(GL_AnimFrameVert), (void*)((uintptr_t)offset + 8));
 
     glDrawArrays(GL_TRIANGLE_STRIP, flip << 2, 4); CHECK_GL();
 }

--- a/source/Engine/ResourceTypes/SceneFormats/RSDKSceneReader.cpp
+++ b/source/Engine/ResourceTypes/SceneFormats/RSDKSceneReader.cpp
@@ -513,7 +513,7 @@ bool RSDKSceneReader::Read(Stream* r, const char* parentFolder) {
         Scene::AddManagers();
 
         int maxObjSlots = 0x940;
-        Entity** objSlots = (Entity**)calloc(sizeof(Entity*), maxObjSlots);
+        Entity** objSlots = (Entity**)calloc(maxObjSlots, sizeof(Entity*));
         if (!objSlots) {
             Log::Print(Log::LOG_ERROR, "Could not allocate memory for object slots!");
             r->Close();

--- a/source/Engine/Scene/SceneInfo.cpp
+++ b/source/Engine/Scene/SceneInfo.cpp
@@ -254,7 +254,7 @@ SceneListEntry SceneInfo::ParseEntry(XMLNode* node, size_t id) {
     // ID
     if (node->attributes.Exists("id"))
         entry.ID = XMLParser::TokenToString(node->attributes.Get("id"));
-    else if (entry.Filetype == "bin") {
+    else if (strcmp(entry.Filetype, "bin") == 0) {
         // RSDK compatibility.
         char buf[16];
         snprintf(buf, sizeof(buf), "%d", ((int)id) + 1);

--- a/source/Engine/TextFormats/XML/XMLParser.cpp
+++ b/source/Engine/TextFormats/XML/XMLParser.cpp
@@ -375,6 +375,11 @@ void     GetInstruction() {
 bool     XMLParser::MatchToken(Token tok, const char* string) {
     if (tok.Length == 0)
         return false;
+
+    size_t len = strlen(string);
+    if (tok.Length != len)
+        return false;
+
     return memcmp(string, tok.Start, tok.Length) == 0;
 }
 float    XMLParser::TokenToNumber(Token tok) {


### PR DESCRIPTION
This PR is a follow-up to https://github.com/HatchGameEngine/HatchGameEngine/pull/8, with even more bugfixes and memory leak plugged.
Most of it were found by following GCC warnings (`-Wall -Wextra`), others were found using AddressSanitizer.
There's still a lot more leaks going on, which I'm hopefully gonna address in a future PR.

All commits are independent from each other and can be reviewed separately, detailed info can be found in the commit descriptions.