### PR TITLE
Misc memory usage improvements and fixes

### DIFF
--- a/include/Engine/Graphics.h
+++ b/include/Engine/Graphics.h
@@ -38,7 +38,8 @@ public:
     static vector<VertexBuffer*> VertexBuffers;
     static Scene3D              Scene3Ds[MAX_3D_SCENES];
     static stack<GraphicsState> StateStack;
-    static stack<Matrix4x4*>    MatrixStack;
+    static Matrix4x4            MatrixStack[MATRIX_STACK_SIZE];
+    static size_t               MatrixStackID;
     static Matrix4x4*           ModelViewMatrix;
     static Viewport             CurrentViewport;
     static Viewport             BackupViewport;

--- a/source/Engine/Bytecode/Bytecode.cpp
+++ b/source/Engine/Bytecode/Bytecode.cpp
@@ -33,6 +33,7 @@ bool        Bytecode::Read(BytecodeContainer bytecode, HashMap<char*>* tokens) {
 
     if (Version > BYTECODE_VERSION) {
         Log::Print(Log::LOG_ERROR, "Unsupported bytecode version 0x%02X!", Version);
+        stream->Close();
         return false;
     }
 
@@ -129,6 +130,7 @@ bool        Bytecode::Read(BytecodeContainer bytecode, HashMap<char*>* tokens) {
     if (hasSourceFilename)
         SourceFilename = stream->ReadString();
 
+    stream->Close();
     return true;
 }
 

--- a/source/Engine/Bytecode/Compiler.cpp
+++ b/source/Engine/Bytecode/Compiler.cpp
@@ -800,7 +800,7 @@ void          Compiler::ErrorAt(Token* token, const char* message, bool fatal) {
     }
 
     if (token->Type == TOKEN_EOF)
-        ReportError(token->Line, fatal, " at end of file: %s", message);
+        ReportError(token->Line, (int)token->Pos, fatal, " at end of file: %s", message);
     else if (token->Type == TOKEN_ERROR)
         ReportError(token->Line, (int)token->Pos, fatal, "%s", message);
     else

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -5388,6 +5388,7 @@ VMValue File_WriteAllText(int argCount, VMValue* args, Uint32 threadID) {
 // #region Geometry
 static vector<FVector2> GetPolygonPoints(ObjArray *array, const char *arrName, int threadID) {
     vector<FVector2> input;
+    input.reserve(array->Values->size());
 
     for (unsigned i = 0; i < array->Values->size(); i++) {
         VMValue vtxVal = (*array->Values)[i];

--- a/source/Engine/Bytecode/VMThread.cpp
+++ b/source/Engine/Bytecode/VMThread.cpp
@@ -1144,6 +1144,7 @@ SUCCESS_OP_SET_PROPERTY:
             Uint32 count = ReadUInt32(frame);
             if (ScriptManager::Lock()) {
                 ObjArray* array = NewArray();
+                array->Values->reserve(count);
                 for (int i = count - 1; i >= 0; i--)
                     array->Values->push_back(Peek(i));
                 for (int i = count - 1; i >= 0; i--)

--- a/source/Engine/Includes/Standard.h
+++ b/source/Engine/Includes/Standard.h
@@ -78,6 +78,8 @@ enum class KeyBind {
 
 #define MAX_TARGET_FRAMERATE 240
 
+#define MATRIX_STACK_SIZE 256
+
 #define MAX_SCENE_VIEWS 8
 #define MAX_PALETTE_COUNT 256
 #define MAX_DEFORM_LINES 0x400

--- a/source/Engine/Math/GeometryTypes.h
+++ b/source/Engine/Math/GeometryTypes.h
@@ -33,8 +33,7 @@ struct Polygon2D {
         MaxY = 0.0;
     }
 
-    Polygon2D(vector<FVector2> input) {
-        Points = input;
+    Polygon2D(vector<FVector2> input) : Points(std::move(input)) {
         CalcBounds();
     }
 

--- a/source/Engine/Rendering/GL/GLRenderer.cpp
+++ b/source/Engine/Rendering/GL/GLRenderer.cpp
@@ -948,14 +948,14 @@ void GL_DrawBatchedScene3D(GL_VertexBuffer *driverData, vector<Uint32>* vertexIn
     size_t capacity = numIndices * GL_VertexIndexBufferStride;
     if (driverData->VertexIndexBuffer == nullptr) {
         driverData->VertexIndexBuffer = (void*)Memory::Malloc(capacity);
+        driverData->VertexIndexBufferCapacity = capacity;
         remakeVtxIdxBuf = true;
     }
     else if (capacity > driverData->VertexIndexBufferCapacity) {
         driverData->VertexIndexBuffer = (void*)Memory::Realloc(driverData->VertexIndexBuffer, capacity);
+        driverData->VertexIndexBufferCapacity = capacity;
         remakeVtxIdxBuf = true;
     }
-
-    driverData->VertexIndexBufferCapacity = capacity;
 
     // This can take enough time to matter with buffers that have a lot of vertices, so this is only done when needed.
     if (remakeVtxIdxBuf) {


### PR DESCRIPTION
This PR is a follow-up to https://github.com/HatchGameEngine/HatchGameEngine/pull/11.
These patches aim to significantly reduce the amount of temporary allocations happening during gameplay in order to improve performance + an extra memory leak fix.

All commits are independent from each other and can be reviewed separately, detailed info can be found in the commit descriptions.