### PR TITLE
Editable frameskip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -462,3 +462,4 @@ lint/tmp/
 
 # Android Profiling
 *.hprof
+compile_commands.json

--- a/include/Engine/Application.h
+++ b/include/Engine/Application.h
@@ -56,6 +56,7 @@ public:
 	static char GameVersion[256];
 	static char GameDescription[256];
 	static int UpdatesPerFrame;
+	static int FrameSkip;
 	static bool Stepper;
 	static bool Step;
 	static int MasterVolume;

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -40,7 +40,7 @@ extern "C" {
 #endif
 
 #define DEFAULT_SETTINGS_FILENAME "config://config.ini"
-#define DEFUALT_MAX_FRAMESKIP 15
+#define DEFAULT_MAX_FRAMESKIP 15
 
 #if WIN32
 Platforms Application::Platform = Platforms::Windows;
@@ -90,7 +90,7 @@ char Application::GameVersion[256];
 char Application::GameDescription[256];
 
 int Application::UpdatesPerFrame = 1;
-int Application::FrameSkip = DEFUALT_MAX_FRAMESKIP;
+int Application::FrameSkip = DEFAULT_MAX_FRAMESKIP;
 bool Application::Stepper = false;
 bool Application::Step = false;
 
@@ -658,8 +658,8 @@ void Application::LoadVideoSettings() {
 	Application::Settings->GetBool("display", "vsync", &Graphics::VsyncEnabled);
 	Application::Settings->GetInteger("display", "frameSkip", &Application::FrameSkip);
 
-	if (Application::FrameSkip > DEFUALT_MAX_FRAMESKIP){
-		Application::FrameSkip = DEFUALT_MAX_FRAMESKIP;
+	if (Application::FrameSkip > DEFAULT_MAX_FRAMESKIP){
+		Application::FrameSkip = DEFAULT_MAX_FRAMESKIP;
 	}
 
 	if (Graphics::Initialized) {
@@ -1851,7 +1851,7 @@ void Application::InitSettings(const char* filename) {
 
 	Application::Settings->SetBool("display", "fullscreen", false);
 	Application::Settings->SetBool("display", "vsync", false);
-	Application::Settings->SetInteger("display", "frameSkip", DEFUALT_MAX_FRAMESKIP);
+	Application::Settings->SetInteger("display", "frameSkip", DEFAULT_MAX_FRAMESKIP);
 }
 void Application::SaveSettings() {
 	if (Application::Settings) {

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -90,6 +90,7 @@ char Application::GameVersion[256];
 char Application::GameDescription[256];
 
 int Application::UpdatesPerFrame = 1;
+int Application::FrameSkip = DEFUALT_MAX_FRAMESKIP;
 bool Application::Stepper = false;
 bool Application::Step = false;
 
@@ -656,6 +657,10 @@ void Application::LoadVideoSettings() {
 	bool vsyncEnabled;
 	Application::Settings->GetBool("display", "vsync", &Graphics::VsyncEnabled);
 	Application::Settings->GetInteger("display", "frame_skip", &Application::FrameSkip);
+
+	if (Application::FrameSkip > DEFUALT_MAX_FRAMESKIP){
+		Application::FrameSkip = DEFUALT_MAX_FRAMESKIP;
+	}
 
 	if (Graphics::Initialized) {
 		Graphics::SetVSync(vsyncEnabled);
@@ -1405,7 +1410,9 @@ void Application::Run(int argc, char* args[]) {
 			if (FrameSkip > 0){
 				// Compensate for lag
 				int lagFrames = ( (int) round(timeTaken / FrameTimeDesired) ) - 1;
-				lagFrames = FrameSkip < DEFUALT_MAX_FRAMESKIP ? FrameSkip : DEFUALT_MAX_FRAMESKIP;
+				if (lagFrames > Application::FrameSkip){
+					lagFrames = Application::FrameSkip;
+				}
 
 				if (!FirstFrame && lagFrames > 0) {
 					updateFrames += lagFrames;

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -40,6 +40,7 @@ extern "C" {
 #endif
 
 #define DEFAULT_SETTINGS_FILENAME "config://config.ini"
+#define DEFUALT_MAX_FRAMESKIP 15
 
 #if WIN32
 Platforms Application::Platform = Platforms::Windows;
@@ -654,6 +655,7 @@ void Application::Restart() {
 void Application::LoadVideoSettings() {
 	bool vsyncEnabled;
 	Application::Settings->GetBool("display", "vsync", &Graphics::VsyncEnabled);
+	Application::Settings->GetInteger("display", "frame_skip", &Application::FrameSkip);
 
 	if (Graphics::Initialized) {
 		Graphics::SetVSync(vsyncEnabled);
@@ -1400,14 +1402,14 @@ void Application::Run(int argc, char* args[]) {
 
 		int updateFrames = UpdatesPerFrame;
 		if (updateFrames == 1) {
-			// Compensate for lag
-			int lagFrames = ((int)round(timeTaken / FrameTimeDesired)) - 1;
-			if (lagFrames > 15) {
-				lagFrames = 15;
-			}
+			if (FrameSkip > 0){
+				// Compensate for lag
+				int lagFrames = ( (int) round(timeTaken / FrameTimeDesired) ) - 1;
+				lagFrames = FrameSkip < DEFUALT_MAX_FRAMESKIP ? FrameSkip : DEFUALT_MAX_FRAMESKIP;
 
-			if (!FirstFrame && lagFrames > 0) {
-				updateFrames += lagFrames;
+				if (!FirstFrame && lagFrames > 0) {
+					updateFrames += lagFrames;
+				}
 			}
 		}
 
@@ -1843,6 +1845,7 @@ void Application::InitSettings(const char* filename) {
 
 	Application::Settings->SetBool("display", "fullscreen", false);
 	Application::Settings->SetBool("display", "vsync", false);
+	Application::Settings->SetInteger("display", "frame_skip", DEFUALT_MAX_FRAMESKIP);
 }
 void Application::SaveSettings() {
 	if (Application::Settings) {
@@ -1891,3 +1894,4 @@ int Application::HandleAppEvents(void* data, SDL_Event* event) {
 		return 1;
 	}
 }
+

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -656,7 +656,7 @@ void Application::Restart() {
 void Application::LoadVideoSettings() {
 	bool vsyncEnabled;
 	Application::Settings->GetBool("display", "vsync", &Graphics::VsyncEnabled);
-	Application::Settings->GetInteger("display", "frame_skip", &Application::FrameSkip);
+	Application::Settings->GetInteger("display", "frameSkip", &Application::FrameSkip);
 
 	if (Application::FrameSkip > DEFUALT_MAX_FRAMESKIP){
 		Application::FrameSkip = DEFUALT_MAX_FRAMESKIP;
@@ -1407,17 +1407,16 @@ void Application::Run(int argc, char* args[]) {
 
 		int updateFrames = UpdatesPerFrame;
 		if (updateFrames == 1) {
-			if (FrameSkip > 0){
-				// Compensate for lag
-				int lagFrames = ( (int) round(timeTaken / FrameTimeDesired) ) - 1;
-				if (lagFrames > Application::FrameSkip){
-					lagFrames = Application::FrameSkip;
-				}
-
-				if (!FirstFrame && lagFrames > 0) {
-					updateFrames += lagFrames;
-				}
+			// Compensate for lag
+			int lagFrames = ( (int) round(timeTaken / FrameTimeDesired) ) - 1;
+			if (lagFrames > Application::FrameSkip){
+				lagFrames = Application::FrameSkip;
 			}
+
+			if (!FirstFrame && lagFrames > 0) {
+				updateFrames += lagFrames;
+			}
+
 		}
 
 		if (BenchmarkFrameCount == 0) {
@@ -1852,7 +1851,7 @@ void Application::InitSettings(const char* filename) {
 
 	Application::Settings->SetBool("display", "fullscreen", false);
 	Application::Settings->SetBool("display", "vsync", false);
-	Application::Settings->SetInteger("display", "frame_skip", DEFUALT_MAX_FRAMESKIP);
+	Application::Settings->SetInteger("display", "frameSkip", DEFUALT_MAX_FRAMESKIP);
 }
 void Application::SaveSettings() {
 	if (Application::Settings) {


### PR DESCRIPTION
On older hardware where lag compensation ends up being quite heavy (which can end up making gameplay very choppy and thus unplayable) in some situations (eg. background apps doing heavy tasks at inopportune times), it may be preferable to control or disable it. This PR makes it configurable through the config.ini file, under the setting `frameSkip` in the `display` category. I *would* put it's setting under something like `application` if such a section existed and had more entries than just this, but for now it's under `display`.

P.S. I also added `compile_commands.json` to the gitignore.