### PR TITLE
Fix crash when trying to spawn an object without a scene

### DIFF
--- a/include/Engine/Bytecode/SourceFileMap.h
+++ b/include/Engine/Bytecode/SourceFileMap.h
@@ -18,7 +18,7 @@ public:
 	static bool DoLogging;
 
 	static void CheckInit();
-	static void CheckForUpdate();
+	static bool CheckForUpdate();
 	static void Dispose();
 };
 

--- a/include/Engine/Scene.h
+++ b/include/Engine/Scene.h
@@ -36,8 +36,8 @@ private:
 	static void DeleteObjects(Entity** first, Entity** last, int* count);
 	static void RemoveNonPersistentObjects(Entity** first, Entity** last, int* count);
 	static void DeleteAllObjects();
+	static void ReadSceneFile(const char* filename);
 	static void AddStaticClass();
-	static void CallGameStart();
 	static void SpawnStaticObject(const char* objectName);
 	static void ReadRSDKTile(TileConfig* tile, Uint8* line);
 	static void LoadRSDKTileConfig(int tilesetID, Stream* tileColReader);
@@ -97,8 +97,8 @@ public:
 	static int ObjectViewRenderFlag;
 	static int TileViewRenderFlag;
 	static Perf_ViewRender PERF_ViewRender[MAX_SCENE_VIEWS];
-	static char NextScene[256];
-	static char CurrentScene[256];
+	static char NextScene[MAX_RESOURCE_PATH_LENGTH];
+	static char CurrentScene[MAX_RESOURCE_PATH_LENGTH];
 	static bool DoRestart;
 	static bool NoPersistency;
 	static int TimeEnabled;
@@ -157,7 +157,9 @@ public:
 	static void Render();
 	static void AfterScene();
 	static void Restart();
+	static void Prepare();
 	static void LoadScene(const char* filename);
+	static void CallGameStart();
 	static void ProcessSceneTimer();
 	static ObjectList* NewObjectList(const char* objectName);
 	static ObjectList* GetObjectList(const char* objectName, bool callListLoadFunction);

--- a/include/Engine/Scene.h
+++ b/include/Engine/Scene.h
@@ -37,7 +37,6 @@ private:
 	static void RemoveNonPersistentObjects(Entity** first, Entity** last, int* count);
 	static void DeleteAllObjects();
 	static void ReadSceneFile(const char* filename);
-	static void AddStaticClass();
 	static void SpawnStaticObject(const char* objectName);
 	static void ReadRSDKTile(TileConfig* tile, Uint8* line);
 	static void LoadRSDKTileConfig(int tilesetID, Stream* tileColReader);
@@ -157,8 +156,10 @@ public:
 	static void Render();
 	static void AfterScene();
 	static void Restart();
+	static void Unload();
 	static void Prepare();
 	static void LoadScene(const char* filename);
+	static void AddStaticClass();
 	static void CallGameStart();
 	static void ProcessSceneTimer();
 	static ObjectList* NewObjectList(const char* objectName);

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -1530,6 +1530,11 @@ void Application::Run(int argc, char* args[]) {
 		ScriptManager::LoadClasses();
 	}
 
+	// Load Static class
+	if (Application::GameStart) {
+		Scene::AddStaticClass();
+	}
+
 	if (argc > 1 && AllowCmdLineSceneLoad) {
 		char* pathStart = StringUtils::StrCaseStr(args[1], "/Resources/");
 		if (pathStart == NULL) {
@@ -1551,7 +1556,8 @@ void Application::Run(int argc, char* args[]) {
 				args[1]);
 		}
 	}
-	else {
+	else if (StartingScene[0] != '\0') {
+		// Don't prepare the scene twice if there is no scene to load.
 		Scene::LoadScene(StartingScene);
 	}
 

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -948,6 +948,7 @@ void Application::LoadDevSettings() {
 	Application::Settings->GetInteger("dev", "fastforward", &UpdatesPerFastForward);
 	Application::Settings->GetBool("dev", "convertModels", &Application::DevConvertModels);
 	Application::Settings->GetBool("dev", "useMemoryFileCache", &UseMemoryFileCache);
+	Application::Settings->GetBool("dev", "loadAllClasses", &ScriptManager::LoadAllClasses);
 
 	int logLevel = 0;
 #ifdef DEBUG
@@ -1066,9 +1067,7 @@ void Application::PollEvents() {
 					Application::Restart();
 
 					Scene::Init();
-					if (*StartingScene) {
-						Scene::LoadScene(StartingScene);
-					}
+					Scene::LoadScene(StartingScene);
 					Scene::Restart();
 					Application::UpdateWindowTitle();
 					break;
@@ -1103,12 +1102,12 @@ void Application::PollEvents() {
 				else if (key == KeyBindsSDL[(int)KeyBind::DevRecompile]) {
 					Application::Restart();
 
-					char temp[256];
-					memcpy(temp, Scene::CurrentScene, 256);
+					char temp[MAX_RESOURCE_PATH_LENGTH];
+					memcpy(temp, Scene::CurrentScene, MAX_RESOURCE_PATH_LENGTH);
 
 					Scene::Init();
 
-					memcpy(Scene::CurrentScene, temp, 256);
+					memcpy(Scene::CurrentScene, temp, MAX_RESOURCE_PATH_LENGTH);
 					Scene::LoadScene(Scene::CurrentScene);
 
 					Scene::Restart();
@@ -1523,6 +1522,13 @@ void Application::Run(int argc, char* args[]) {
 	}
 
 	Scene::Init();
+	Scene::Prepare();
+
+	ScriptManager::LoadScript("init.hsl");
+
+	if (ScriptManager::LoadAllClasses) {
+		ScriptManager::LoadClasses();
+	}
 
 	if (argc > 1 && AllowCmdLineSceneLoad) {
 		char* pathStart = StringUtils::StrCaseStr(args[1], "/Resources/");
@@ -1545,8 +1551,14 @@ void Application::Run(int argc, char* args[]) {
 				args[1]);
 		}
 	}
-	else if (*StartingScene) {
+	else {
 		Scene::LoadScene(StartingScene);
+	}
+
+	// Call Static's GameStart here
+	if (Application::GameStart) {
+		Scene::CallGameStart();
+		Application::GameStart = false;
 	}
 
 	Scene::Restart();

--- a/source/Engine/Bytecode/SourceFileMap.cpp
+++ b/source/Engine/Bytecode/SourceFileMap.cpp
@@ -81,22 +81,22 @@ void SourceFileMap::CheckInit() {
 
 	SourceFileMap::Initialized = true;
 }
-void SourceFileMap::CheckForUpdate() {
+bool SourceFileMap::CheckForUpdate() {
 	SourceFileMap::CheckInit();
 
+#ifndef NO_SCRIPT_COMPILING
 	VFSProvider* mainVfs = ResourceManager::GetMainResource();
 	if (!mainVfs || !mainVfs->IsWritable()) {
-		return;
+		return false;
 	}
 
-#ifndef NO_SCRIPT_COMPILING
 	bool anyChanges = false;
 
 	const char* scriptFolder = "Scripts";
 	size_t scriptFolderNameLen = strlen(scriptFolder);
 
 	if (!Directory::Exists(scriptFolder)) {
-		return;
+		return false;
 	}
 
 	vector<std::filesystem::path> list;
@@ -105,7 +105,7 @@ void SourceFileMap::CheckForUpdate() {
 	if (list.size() == 0) {
 		list.clear();
 		list.shrink_to_fit();
-		return;
+		return false;
 	}
 
 	if (!mainVfs->HasFile(OBJECTS_HCM_NAME)) {
@@ -269,6 +269,10 @@ void SourceFileMap::CheckForUpdate() {
 
 	list.clear();
 	list.shrink_to_fit();
+
+	return anyChanges;
+#else
+	return false;
 #endif
 }
 void SourceFileMap::AddToList(Compiler* compiler, Uint32 filenameHash) {

--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -1663,6 +1663,8 @@ void Scene::Unload() {
 		Scene::Layers[i].Dispose();
 	}
 	Scene::Layers.clear();
+
+	Scene::Loaded = false;
 }
 void Scene::Prepare() {
 	Scene::TileWidth = Scene::TileHeight = 16;
@@ -1671,8 +1673,6 @@ void Scene::Prepare() {
 	Scene::InitObjectListsAndRegistries();
 
 	memset(Scene::CurrentScene, '\0', sizeof Scene::CurrentScene);
-
-	Scene::Loaded = false;
 }
 void Scene::LoadScene(const char* sceneFilename) {
 	Scene::Unload();


### PR DESCRIPTION
Hatch crashes spectacularly if you try to spawn an object in an unloaded scene — for example, during `init.hsl`. This PR fixes that.