### PR TITLE
Fixup SoftwareRenderer Parallax + memory leak fixes

### DIFF
--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -1632,6 +1632,10 @@ void Application::Cleanup() {
 		DEBUG_fontSprite = NULL;
 	}
 
+	if (Application::Settings) {
+		Application::Settings->Dispose();
+	}
+
 	MemoryCache::Dispose();
 	ResourceManager::Dispose();
 	AudioManager::Dispose();

--- a/source/Engine/Bytecode/ScriptManager.cpp
+++ b/source/Engine/Bytecode/ScriptManager.cpp
@@ -167,11 +167,11 @@ void ScriptManager::Dispose() {
 	ClassImplList.clear();
 	AllNamespaces.clear();
 
-	FreeModules();
-
 	Threads[0].FrameCount = 0;
 	Threads[0].ResetStack();
 	ForceGarbageCollection();
+
+	FreeModules();
 
 	FreedGlobals.clear();
 
@@ -266,6 +266,9 @@ void ScriptManager::FreeFunction(ObjFunction* function) {
 	FREE_OBJ(function, ObjFunction);
 }
 void ScriptManager::FreeModule(ObjModule* module) {
+	for (size_t i = 0; i < module->Functions->size(); i++) {
+		FreeFunction((*module->Functions)[i]);
+	}
 	delete module->Functions;
 	delete module->Locals;
 }

--- a/source/Engine/Diagnostics/Log.cpp
+++ b/source/Engine/Diagnostics/Log.cpp
@@ -80,6 +80,7 @@ void Log::Close() {
 		fclose(File);
 		File = nullptr;
 	}
+	free(Buffer);
 }
 
 bool Log::ResizeBuffer(int written_chars) {

--- a/source/Engine/InputManager.cpp
+++ b/source/Engine/InputManager.cpp
@@ -1277,4 +1277,8 @@ void InputManager::Dispose() {
 
 	InputManager::ClearPlayers();
 	InputManager::ClearInputs();
+
+	delete NameMap::Keys;
+	delete NameMap::Buttons;
+	delete NameMap::Axes;
 }

--- a/source/Engine/Rendering/Software/SoftwareRenderer.cpp
+++ b/source/Engine/Rendering/Software/SoftwareRenderer.cpp
@@ -3882,6 +3882,10 @@ void SoftwareRenderer::DrawSceneLayer_HorizontalParallax(SceneLayer* layer, View
 	static vector<Uint32*> tileSources;
 	static vector<Uint8> isPalettedSources;
 	static vector<unsigned> paletteIDs;
+	srcStrides.clear();
+	tileSources.clear();
+	isPalettedSources.clear();
+	paletteIDs.clear();
 	srcStrides.reserve(Scene::TileSpriteInfos.size());
 	tileSources.reserve(Scene::TileSpriteInfos.size());
 	isPalettedSources.reserve(Scene::TileSpriteInfos.size());
@@ -3962,10 +3966,10 @@ void SoftwareRenderer::DrawSceneLayer_HorizontalParallax(SceneLayer* layer, View
 		AnimFrame& frameStr =
 			info.Sprite->Animations[info.AnimationIndex].Frames[info.FrameIndex];
 		Texture* texture = info.Sprite->Spritesheets[frameStr.SheetNumber];
-		srcStrides[i] = srcStride = texture->Width;
-		tileSources[i] = (&((Uint32*)texture->Pixels)[frameStr.X + frameStr.Y * srcStride]);
-		isPalettedSources[i] = Graphics::UsePalettes && texture->Paletted;
-		paletteIDs[i] = Scene::Tilesets[info.TilesetID].PaletteID;
+		srcStrides.push_back(srcStride = texture->Width);
+		tileSources.push_back((&((Uint32*)texture->Pixels)[frameStr.X + frameStr.Y * srcStride]));
+		isPalettedSources.push_back(Graphics::UsePalettes && texture->Paletted);
+		paletteIDs.push_back(Scene::Tilesets[info.TilesetID].PaletteID);
 	}
 
 	Uint32 DRAW_COLLISION = 0;
@@ -4501,6 +4505,10 @@ void SoftwareRenderer::DrawSceneLayer_CustomTileScanLines(SceneLayer* layer, Vie
 	static vector<Uint32*> tileSources;
 	static vector<Uint8> isPalettedSources;
 	static vector<unsigned> paletteIDs;
+	srcStrides.clear();
+	tileSources.clear();
+	isPalettedSources.clear();
+	paletteIDs.clear();
 	srcStrides.reserve(Scene::TileSpriteInfos.size());
 	tileSources.reserve(Scene::TileSpriteInfos.size());
 	isPalettedSources.reserve(Scene::TileSpriteInfos.size());
@@ -4556,10 +4564,10 @@ void SoftwareRenderer::DrawSceneLayer_CustomTileScanLines(SceneLayer* layer, Vie
 		AnimFrame& frameStr =
 			info.Sprite->Animations[info.AnimationIndex].Frames[info.FrameIndex];
 		Texture* texture = info.Sprite->Spritesheets[frameStr.SheetNumber];
-		srcStrides[i] = srcStride = texture->Width;
-		tileSources[i] = (&((Uint32*)texture->Pixels)[frameStr.X + frameStr.Y * srcStride]);
-		isPalettedSources[i] = Graphics::UsePalettes && texture->Paletted;
-		paletteIDs[i] = Scene::Tilesets[info.TilesetID].PaletteID;
+		srcStrides.push_back(srcStride = texture->Width);
+		tileSources.push_back((&((Uint32*)texture->Pixels)[frameStr.X + frameStr.Y * srcStride]));
+		isPalettedSources.push_back(Graphics::UsePalettes && texture->Paletted);
+		paletteIDs.push_back(Scene::Tilesets[info.TilesetID].PaletteID);
 	}
 
 	bool usePaletteIndexLines = Graphics::UsePaletteIndexLines && layer->UsePaletteIndexLines;


### PR DESCRIPTION
This PR fixes an error I introduced in PR #15, leading to asserts firing in the STL due to the wrong use of static `std::vector` and `reserve()`: `operator[]` is not valid for initialization even if we reserved space, so `push_back()` is necessary.

Also plug a bunch of small-ish memory leaks happening on exit.