### PR TITLE
Rework Music.Play into a single function

### DIFF
--- a/guides/Documentation.htm
+++ b/guides/Documentation.htm
@@ -127,6 +127,7 @@
             <li><a href="#Reference_InputDevice_*">InputDevice_*</a></li>
             <li><a href="#Reference_KeyBind_*">KeyBind_*</a></li>
             <li><a href="#Reference_Key_*">Key_*</a></li>
+            <li><a href="#Reference_MUSIC_*">MUSIC_*</a></li>
             <li><a href="#Reference_Persistence_*">Persistence_*</a></li>
             <li><a href="#Reference_Platform_*">Platform_*</a></li>
             <li><a href="#Reference_SCOPE_*">SCOPE_*</a></li>
@@ -799,6 +800,8 @@
                     <li><a href="#Reference_functions_Music_IsPlaying">Music.IsPlaying</a></li>
                     <li><a href="#Reference_functions_Music_GetPosition">Music.GetPosition</a></li>
                     <li><a href="#Reference_functions_Music_Alter">Music.Alter</a></li>
+                    <li><a href="#Reference_functions_Music_GetLoopPoint">Music.GetLoopPoint</a></li>
+                    <li><a href="#Reference_functions_Music_SetLoopPoint">Music.SetLoopPoint</a></li>
                 </ul>
             </p>
             <p id="Reference_Number">
@@ -1894,6 +1897,13 @@
                     <li><a href="#Reference_enums_Key_RSHIFT">Key_RSHIFT</a></li>
                     <li><a href="#Reference_enums_Key_RALT">Key_RALT</a></li>
                     <li><a href="#Reference_enums_Key_RGUI">Key_RGUI</a></li>
+                </ul>
+            </p>
+            <p id="Reference_MUSIC_*">
+                <h2><code>MUSIC_*</code></h2>
+                <ul>
+                    <li><a href="#Reference_enums_MUSIC_LOOP_NONE">MUSIC_LOOP_NONE</a></li>
+                    <li><a href="#Reference_enums_MUSIC_LOOP_DEFAULT">MUSIC_LOOP_DEFAULT</a></li>
                 </ul>
             </p>
             <p id="Reference_Persistence_*">
@@ -6021,6 +6031,27 @@
         <li>volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume.</li>
         </ul>
         </p>
+        <p id="Reference_functions_Music_GetLoopPoint">
+        <h2 style="margin-bottom: 8px;">Music.GetLoopPoint</h2>
+        <code>Music.GetLoopPoint(music)</code>
+        <div style="margin-top: 8px; font-size: 14px;">Gets the loop point of a music index, if it has one.</div>
+        <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
+        <ul style="margin-top: 0px; font-size: 14px;">
+        <li>music (Integer): The music index to get the loop point.</li>
+        </ul>
+        <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
+        <div style="font-size: 14px;">Returns an Integer value.</div>
+        </p>
+        <p id="Reference_functions_Music_SetLoopPoint">
+        <h2 style="margin-bottom: 8px;">Music.SetLoopPoint</h2>
+        <code>Music.SetLoopPoint(music, loopPoint)</code>
+        <div style="margin-top: 8px; font-size: 14px;">Sets the loop point of a music index.</div>
+        <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
+        <ul style="margin-top: 0px; font-size: 14px;">
+        <li>music (Integer): The music index to set the loop point.</li>
+        <li>loopPoint (Integer): The loop point, in samples.</li>
+        </ul>
+        </p>
         <p id="Reference_functions_Number_ToString">
         <h2 style="margin-bottom: 8px;">Number.ToString</h2>
         <code>Number.ToString(n[, base])</code>
@@ -10077,7 +10108,7 @@
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns a Map value if the text can be decoded, otherwise returns <code>null</code>.</div>
         </p>
-        <p>726 out of 785 functions have descriptions. </p>
+        <p>728 out of 787 functions have descriptions. </p>
         <hr/>
         <h3>Instance methods</h3>
         <p id="Reference_methods_instance_SetAnimation">
@@ -11803,6 +11834,14 @@
         <h3 style="margin-bottom: 8px;"><code>Key_RGUI</code></h2>
         <div style="margin-top: 8px; font-size: 14px;">Right GUI key.</div>
         </p>
+        <p id="Reference_enums_MUSIC_LOOP_NONE">
+        <h3 style="margin-bottom: 8px;"><code>MUSIC_LOOP_NONE</code></h2>
+        <div style="margin-top: 8px; font-size: 14px;">Will not loop a currently playing music index.</div>
+        </p>
+        <p id="Reference_enums_MUSIC_LOOP_DEFAULT">
+        <h3 style="margin-bottom: 8px;"><code>MUSIC_LOOP_DEFAULT</code></h2>
+        <div style="margin-top: 8px; font-size: 14px;">Uses the loop point defined in the metadata of a music index.</div>
+        </p>
         <p id="Reference_enums_Persistence_NONE">
         <h3 style="margin-bottom: 8px;"><code>Persistence_NONE</code></h2>
         <div style="margin-top: 8px; font-size: 14px;">Doesn't persist between scenes.</div>
@@ -12011,7 +12050,7 @@
         <h3 style="margin-bottom: 8px;"><code>WEEKDAY_SATURDAY</code></h2>
         <div style="margin-top: 8px; font-size: 14px;">The seventh day of the week.</div>
         </p>
-        <p>298 out of 298 enums have descriptions. </p>
+        <p>300 out of 300 enums have descriptions. </p>
         <hr/>
         <h3>Constants</h3>
         <p id="Reference_constants_NUM_CONTROLLER_BUTTONS">

--- a/guides/Documentation.htm
+++ b/guides/Documentation.htm
@@ -802,6 +802,8 @@
                     <li><a href="#Reference_functions_Music_Alter">Music.Alter</a></li>
                     <li><a href="#Reference_functions_Music_GetLoopPoint">Music.GetLoopPoint</a></li>
                     <li><a href="#Reference_functions_Music_SetLoopPoint">Music.SetLoopPoint</a></li>
+                    <li><a href="#Reference_functions_Sound_GetLoopPoint">Sound.GetLoopPoint</a></li>
+                    <li><a href="#Reference_functions_Music_SetLoopPoint">Music.SetLoopPoint</a></li>
                 </ul>
             </p>
             <p id="Reference_Number">
@@ -6052,6 +6054,27 @@
         <li>loopPoint (Integer): The loop point, in samples.</li>
         </ul>
         </p>
+        <p id="Reference_functions_Sound_GetLoopPoint">
+        <h2 style="margin-bottom: 8px;">Sound.GetLoopPoint</h2>
+        <code>Sound.GetLoopPoint(sound)</code>
+        <div style="margin-top: 8px; font-size: 14px;">Gets the loop point of a sound index, if it has one.</div>
+        <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
+        <ul style="margin-top: 0px; font-size: 14px;">
+        <li>sound (Integer): The sound index to get the loop point.</li>
+        </ul>
+        <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
+        <div style="font-size: 14px;">Returns the loop point in samples, as an Integer value.</div>
+        </p>
+        <p id="Reference_functions_Music_SetLoopPoint">
+        <h2 style="margin-bottom: 8px;">Music.SetLoopPoint</h2>
+        <code>Music.SetLoopPoint(sound, loopPoint)</code>
+        <div style="margin-top: 8px; font-size: 14px;">Sets the loop point of a sound index.</div>
+        <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
+        <ul style="margin-top: 0px; font-size: 14px;">
+        <li>sound (Integer): The sound index to set the loop point.</li>
+        <li>loopPoint (Integer): The loop point, in samples.</li>
+        </ul>
+        </p>
         <p id="Reference_functions_Number_ToString">
         <h2 style="margin-bottom: 8px;">Number.ToString</h2>
         <code>Number.ToString(n[, base])</code>
@@ -10108,7 +10131,7 @@
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns a Map value if the text can be decoded, otherwise returns <code>null</code>.</div>
         </p>
-        <p>728 out of 787 functions have descriptions. </p>
+        <p>730 out of 789 functions have descriptions. </p>
         <hr/>
         <h3>Instance methods</h3>
         <p id="Reference_methods_instance_SetAnimation">

--- a/guides/Documentation.htm
+++ b/guides/Documentation.htm
@@ -6042,7 +6042,7 @@
         <li>music (Integer): The music index to get the loop point.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
-        <div style="font-size: 14px;">Returns the loop point in samples, as an Integer value.</div>
+        <div style="font-size: 14px;">Returns the loop point in samples, as an Integer value, or <code>null</code> if the index does not have one.</div>
         </p>
         <p id="Reference_functions_Music_SetLoopPoint">
         <h2 style="margin-bottom: 8px;">Music.SetLoopPoint</h2>
@@ -6051,7 +6051,7 @@
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>music (Integer): The music index to set the loop point.</li>
-        <li>loopPoint (Integer): The loop point, in samples.</li>
+        <li>loopPoint (Integer): The loop point in samples, or <code>null</code> to remove the index's loop point.</li>
         </ul>
         </p>
         <p id="Reference_functions_Sound_GetLoopPoint">
@@ -6063,7 +6063,7 @@
         <li>sound (Integer): The sound index to get the loop point.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
-        <div style="font-size: 14px;">Returns the loop point in samples, as an Integer value.</div>
+        <div style="font-size: 14px;">Returns the loop point in samples, as an Integer value, or <code>null</code> if the index does not have one.</div>
         </p>
         <p id="Reference_functions_Music_SetLoopPoint">
         <h2 style="margin-bottom: 8px;">Music.SetLoopPoint</h2>
@@ -6072,7 +6072,7 @@
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>sound (Integer): The sound index to set the loop point.</li>
-        <li>loopPoint (Integer): The loop point, in samples.</li>
+        <li>loopPoint (Integer): The loop point in samples, or <code>null</code> to remove the index's loop point.</li>
         </ul>
         </p>
         <p id="Reference_functions_Number_ToString">

--- a/guides/Documentation.htm
+++ b/guides/Documentation.htm
@@ -106,6 +106,7 @@
         <h3>Enums</h3>
         <ul>
             <li><a href="#Reference_ACTIVE_*">ACTIVE_*</a></li>
+            <li><a href="#Reference_AUDIO_*">AUDIO_*</a></li>
             <li><a href="#Reference_Axis_*">Axis_*</a></li>
             <li><a href="#Reference_BlendFactor_*">BlendFactor_*</a></li>
             <li><a href="#Reference_BlendMode_*">BlendMode_*</a></li>
@@ -127,7 +128,6 @@
             <li><a href="#Reference_InputDevice_*">InputDevice_*</a></li>
             <li><a href="#Reference_KeyBind_*">KeyBind_*</a></li>
             <li><a href="#Reference_Key_*">Key_*</a></li>
-            <li><a href="#Reference_MUSIC_*">MUSIC_*</a></li>
             <li><a href="#Reference_Persistence_*">Persistence_*</a></li>
             <li><a href="#Reference_Platform_*">Platform_*</a></li>
             <li><a href="#Reference_SCOPE_*">SCOPE_*</a></li>
@@ -1556,6 +1556,13 @@
                     <li><a href="#Reference_enums_ACTIVE_RBOUNDS">ACTIVE_RBOUNDS</a></li>
                 </ul>
             </p>
+            <p id="Reference_AUDIO_*">
+                <h2><code>AUDIO_*</code></h2>
+                <ul>
+                    <li><a href="#Reference_enums_AUDIO_LOOP_NONE">AUDIO_LOOP_NONE</a></li>
+                    <li><a href="#Reference_enums_AUDIO_LOOP_DEFAULT">AUDIO_LOOP_DEFAULT</a></li>
+                </ul>
+            </p>
             <p id="Reference_Axis_*">
                 <h2><code>Axis_*</code></h2>
                 <ul>
@@ -1897,13 +1904,6 @@
                     <li><a href="#Reference_enums_Key_RSHIFT">Key_RSHIFT</a></li>
                     <li><a href="#Reference_enums_Key_RALT">Key_RALT</a></li>
                     <li><a href="#Reference_enums_Key_RGUI">Key_RGUI</a></li>
-                </ul>
-            </p>
-            <p id="Reference_MUSIC_*">
-                <h2><code>MUSIC_*</code></h2>
-                <ul>
-                    <li><a href="#Reference_enums_MUSIC_LOOP_NONE">MUSIC_LOOP_NONE</a></li>
-                    <li><a href="#Reference_enums_MUSIC_LOOP_DEFAULT">MUSIC_LOOP_DEFAULT</a></li>
                 </ul>
             </p>
             <p id="Reference_Persistence_*">
@@ -5957,7 +5957,7 @@
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>music (Integer): The music index to play.</li>
-        <li>loopPoint (Integer): The sample index to loop back to, or <code>-1</code> if the music should only play once. (-1 is the default).</li>
+        <li>loopPoint (Integer): Loop point in samples. Use <code><a href="#Reference_enums_AUDIO_LOOP_NONE">AUDIO_LOOP_NONE</a></code> to play the track once or <code><a href="#Reference_enums_AUDIO_LOOP_DEFAULT">AUDIO_LOOP_DEFAULT</a></code> to use the audio file's metadata. (<code><a href="#Reference_enums_AUDIO_LOOP_DEFAULT">AUDIO_LOOP_DEFAULT</a></code> is the default).</li>
         <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default).</li>
         <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default).</li>
         <li>volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default).</li>
@@ -6040,7 +6040,7 @@
         <li>music (Integer): The music index to get the loop point.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
-        <div style="font-size: 14px;">Returns an Integer value.</div>
+        <div style="font-size: 14px;">Returns the loop point in samples, as an Integer value.</div>
         </p>
         <p id="Reference_functions_Music_SetLoopPoint">
         <h2 style="margin-bottom: 8px;">Music.SetLoopPoint</h2>
@@ -8440,7 +8440,7 @@
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>sound (Integer): The sound index to play.</li>
-        <li>loopPoint (Integer): Loop point in samples. (-1 is the default, will not loop.)</li>
+        <li>loopPoint (Integer): Loop point in samples. Use <code><a href="#Reference_enums_AUDIO_LOOP_NONE">AUDIO_LOOP_NONE</a></code> to play the sound once or <code><a href="#Reference_enums_AUDIO_LOOP_DEFAULT">AUDIO_LOOP_DEFAULT</a></code> to use the audio file's metadata. (<code><a href="#Reference_enums_AUDIO_LOOP_DEFAULT">AUDIO_LOOP_DEFAULT</a></code> is the default).</li>
         <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)</li>
         <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)</li>
         <li>volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default.)</li>
@@ -8508,7 +8508,7 @@
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>sound (Integer): The sound index to play.</li>
-        <li>loopPoint (Integer): Loop point in samples. (-1 is the default, will not loop.)</li>
+        <li>loopPoint (Integer): Loop point in samples. Use <code><a href="#Reference_enums_AUDIO_LOOP_NONE">AUDIO_LOOP_NONE</a></code> to play the sound once or <code><a href="#Reference_enums_AUDIO_LOOP_DEFAULT">AUDIO_LOOP_DEFAULT</a></code> to use the audio file's metadata. (<code><a href="#Reference_enums_AUDIO_LOOP_DEFAULT">AUDIO_LOOP_DEFAULT</a></code> is the default).</li>
         <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)</li>
         <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)</li>
         <li>volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default.)</li>
@@ -8524,7 +8524,7 @@
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>channel (Integer): The channel index.</li>
         <li>sound (Integer): The sound index to play.</li>
-        <li>loopPoint (Integer): Loop point in samples. (-1 is the default, will not loop.)</li>
+        <li>loopPoint (Integer): Loop point in samples. Use <code><a href="#Reference_enums_AUDIO_LOOP_NONE">AUDIO_LOOP_NONE</a></code> to play the sound once or <code><a href="#Reference_enums_AUDIO_LOOP_DEFAULT">AUDIO_LOOP_DEFAULT</a></code> to use the audio file's metadata. (<code><a href="#Reference_enums_AUDIO_LOOP_DEFAULT">AUDIO_LOOP_DEFAULT</a></code> is the default).</li>
         <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)</li>
         <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)</li>
         <li>volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default.)</li>
@@ -10882,6 +10882,14 @@
         <h3 style="margin-bottom: 8px;"><code>ACTIVE_RBOUNDS</code></h2>
         <div style="margin-top: 8px; font-size: 14px;">Entity updates within a radius. (uses UpdateRegionW)</div>
         </p>
+        <p id="Reference_enums_AUDIO_LOOP_NONE">
+        <h3 style="margin-bottom: 8px;"><code>AUDIO_LOOP_NONE</code></h2>
+        <div style="margin-top: 8px; font-size: 14px;">When used as the `loopPoint` argument in <code><a href="#Reference_functions_Music_Play">Music.Play</a></code> or <code><a href="#Reference_functions_Sound_Play">Sound.Play</a></code>, specifies that the audio should not loop, even if the audio file has a loop point.</div>
+        </p>
+        <p id="Reference_enums_AUDIO_LOOP_DEFAULT">
+        <h3 style="margin-bottom: 8px;"><code>AUDIO_LOOP_DEFAULT</code></h2>
+        <div style="margin-top: 8px; font-size: 14px;">When used as the `loopPoint` argument in <code><a href="#Reference_functions_Music_Play">Music.Play</a></code> or <code><a href="#Reference_functions_Sound_Play">Sound.Play</a></code>, specifies that the audio should use loop point defined in the metadata of the audio file.</div>
+        </p>
         <p id="Reference_enums_Axis_LEFTX">
         <h3 style="margin-bottom: 8px;"><code>Axis_LEFTX</code></h2>
         <div style="margin-top: 8px; font-size: 14px;">Left controller stick X.</div>
@@ -11833,14 +11841,6 @@
         <p id="Reference_enums_Key_RGUI">
         <h3 style="margin-bottom: 8px;"><code>Key_RGUI</code></h2>
         <div style="margin-top: 8px; font-size: 14px;">Right GUI key.</div>
-        </p>
-        <p id="Reference_enums_MUSIC_LOOP_NONE">
-        <h3 style="margin-bottom: 8px;"><code>MUSIC_LOOP_NONE</code></h2>
-        <div style="margin-top: 8px; font-size: 14px;">Will not loop a currently playing music index.</div>
-        </p>
-        <p id="Reference_enums_MUSIC_LOOP_DEFAULT">
-        <h3 style="margin-bottom: 8px;"><code>MUSIC_LOOP_DEFAULT</code></h2>
-        <div style="margin-top: 8px; font-size: 14px;">Uses the loop point defined in the metadata of a music index.</div>
         </p>
         <p id="Reference_enums_Persistence_NONE">
         <h3 style="margin-bottom: 8px;"><code>Persistence_NONE</code></h2>

--- a/guides/Documentation.htm
+++ b/guides/Documentation.htm
@@ -791,14 +791,11 @@
                 <i>Class methods:</i>
                 <ul>
                     <li><a href="#Reference_functions_Music_Play">Music.Play</a></li>
-                    <li><a href="#Reference_functions_Music_PlayAtTime">Music.PlayAtTime</a></li>
                     <li><a href="#Reference_functions_Music_Stop">Music.Stop</a></li>
                     <li><a href="#Reference_functions_Music_StopWithFadeOut">Music.StopWithFadeOut</a></li>
                     <li><a href="#Reference_functions_Music_Pause">Music.Pause</a></li>
                     <li><a href="#Reference_functions_Music_Resume">Music.Resume</a></li>
                     <li><a href="#Reference_functions_Music_Clear">Music.Clear</a></li>
-                    <li><a href="#Reference_functions_Music_Loop">Music.Loop</a></li>
-                    <li><a href="#Reference_functions_Music_LoopAtTime">Music.LoopAtTime</a></li>
                     <li><a href="#Reference_functions_Music_IsPlaying">Music.IsPlaying</a></li>
                     <li><a href="#Reference_functions_Music_GetPosition">Music.GetPosition</a></li>
                     <li><a href="#Reference_functions_Music_Alter">Music.Alter</a></li>
@@ -5948,29 +5945,17 @@
         </p>
         <p id="Reference_functions_Music_Play">
         <h2 style="margin-bottom: 8px;">Music.Play</h2>
-        <code>Music.Play(music[, panning, speed, volume, fadeInAfterFinished])</code>
+        <code>Music.Play(music[, loopPoint, panning, speed, volume, startPoint, fadeInAfterFinished])</code>
         <div style="margin-top: 8px; font-size: 14px;">Places the music onto the music stack and plays it.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>music (Integer): The music index to play.</li>
-        <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)</li>
-        <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)</li>
-        <li>volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default.)</li>
-        <li>fadeInAfterFinished (Decimal): The time period to fade in the previous music track after the currently playing track finishes playing, in seconds. (0.0 disables this.)</li>
-        </ul>
-        </p>
-        <p id="Reference_functions_Music_PlayAtTime">
-        <h2 style="margin-bottom: 8px;">Music.PlayAtTime</h2>
-        <code>Music.PlayAtTime(music, startPoint[, panning, speed, volume, fadeInAfterFinished])</code>
-        <div style="margin-top: 8px; font-size: 14px;">Places the music onto the music stack and plays it at a time (in seconds).</div>
-        <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
-        <ul style="margin-top: 0px; font-size: 14px;">
-        <li>music (Integer): The music index to play.</li>
-        <li>startPoint (Decimal): The time (in seconds) to start the music at.</li>
-        <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)</li>
-        <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)</li>
-        <li>volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default.)</li>
-        <li>fadeInAfterFinished (Decimal): The time period to fade in the previous music track after the currently playing track finishes playing, in seconds. (0.0 disables this.)</li>
+        <li>loopPoint (Integer): The sample index to loop back to, or <code>-1</code> if the music should only play once. (-1 is the default).</li>
+        <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default).</li>
+        <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default).</li>
+        <li>volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default).</li>
+        <li>startPoint (Decimal): The time (in seconds) to start the music at. (0.0 is the default).</li>
+        <li>fadeInAfterFinished (Decimal): The time period to fade in the previous music track after the currently playing track finishes playing, in seconds. (0.0 is the default, which disables it).</li>
         </ul>
         </p>
         <p id="Reference_functions_Music_Stop">
@@ -6005,37 +5990,6 @@
         <h2 style="margin-bottom: 8px;">Music.Clear</h2>
         <code>Music.Clear()</code>
         <div style="margin-top: 8px; font-size: 14px;">Completely clears the music stack, stopping all music.</div>
-        </p>
-        <p id="Reference_functions_Music_Loop">
-        <h2 style="margin-bottom: 8px;">Music.Loop</h2>
-        <code>Music.Loop(music, loop, loopPoint[, panning, speed, volume, fadeInAfterFinished])</code>
-        <div style="margin-top: 8px; font-size: 14px;">Places the music onto the music stack and plays it, looping back to the specified sample index if it reaches the end of playback.</div>
-        <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
-        <ul style="margin-top: 0px; font-size: 14px;">
-        <li>music (Integer): The music index to play.</li>
-        <li>loop (Boolean): Unused.</li>
-        <li>loopPoint (Integer): The sample index to loop back to.</li>
-        <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)</li>
-        <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)</li>
-        <li>volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default.)</li>
-        <li>fadeInAfterFinished (Decimal): The time period to fade in the previous music track after the currently playing track is interrupted, in seconds. (0.0 disables this.)</li>
-        </ul>
-        </p>
-        <p id="Reference_functions_Music_LoopAtTime">
-        <h2 style="margin-bottom: 8px;">Music.LoopAtTime</h2>
-        <code>Music.LoopAtTime(music, startPoint, loop, loopPoint[, panning, speed, volume, fadeInAfterFinished])</code>
-        <div style="margin-top: 8px; font-size: 14px;">Places the music onto the music stack and plays it, looping back to the specified sample index if it reaches the end of playback.</div>
-        <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
-        <ul style="margin-top: 0px; font-size: 14px;">
-        <li>music (Integer): The music index to play.</li>
-        <li>startPoint (Decimal): The time (in seconds) to start the music at.</li>
-        <li>loop (Boolean): Unused.</li>
-        <li>loopPoint (Integer): The sample index to loop back to.</li>
-        <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)</li>
-        <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)</li>
-        <li>volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default.)</li>
-        <li>fadeInAfterFinished (Decimal): The time period to fade in the previous music track after the currently playing track is interrupted, in seconds. (0.0 disables this.)</li>
-        </ul>
         </p>
         <p id="Reference_functions_Music_IsPlaying">
         <h2 style="margin-bottom: 8px;">Music.IsPlaying</h2>
@@ -10167,7 +10121,7 @@
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns a Map value if the text can be decoded, otherwise returns <code>null</code>.</div>
         </p>
-        <p>732 out of 791 functions have descriptions. </p>
+        <p>729 out of 788 functions have descriptions. </p>
         <hr/>
         <h3>Instance methods</h3>
         <p id="Reference_methods_instance_SetAnimation">

--- a/guides/Documentation.htm
+++ b/guides/Documentation.htm
@@ -1128,7 +1128,6 @@
                 <i>Class methods:</i>
                 <ul>
                     <li><a href="#Reference_functions_Sound_Play">Sound.Play</a></li>
-                    <li><a href="#Reference_functions_Sound_Loop">Sound.Loop</a></li>
                     <li><a href="#Reference_functions_Sound_Stop">Sound.Stop</a></li>
                     <li><a href="#Reference_functions_Sound_Pause">Sound.Pause</a></li>
                     <li><a href="#Reference_functions_Sound_Resume">Sound.Resume</a></li>
@@ -1137,9 +1136,7 @@
                     <li><a href="#Reference_functions_Sound_ResumeAll">Sound.ResumeAll</a></li>
                     <li><a href="#Reference_functions_Sound_IsPlaying">Sound.IsPlaying</a></li>
                     <li><a href="#Reference_functions_Sound_PlayMultiple">Sound.PlayMultiple</a></li>
-                    <li><a href="#Reference_functions_Sound_LoopMultiple">Sound.LoopMultiple</a></li>
                     <li><a href="#Reference_functions_Sound_PlayAtChannel">Sound.PlayAtChannel</a></li>
-                    <li><a href="#Reference_functions_Sound_LoopAtChannel">Sound.LoopAtChannel</a></li>
                     <li><a href="#Reference_functions_Sound_StopChannel">Sound.StopChannel</a></li>
                     <li><a href="#Reference_functions_Sound_PauseChannel">Sound.PauseChannel</a></li>
                     <li><a href="#Reference_functions_Sound_ResumeChannel">Sound.ResumeChannel</a></li>
@@ -8407,26 +8404,12 @@
         </p>
         <p id="Reference_functions_Sound_Play">
         <h2 style="margin-bottom: 8px;">Sound.Play</h2>
-        <code>Sound.Play(sound[, panning, speed, volume])</code>
-        <div style="margin-top: 8px; font-size: 14px;">Plays a sound once.</div>
+        <code>Sound.Play(sound[, loopPoint, panning, speed, volume])</code>
+        <div style="margin-top: 8px; font-size: 14px;">Plays a sound either once or in a loop.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>sound (Integer): The sound index to play.</li>
-        <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)</li>
-        <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)</li>
-        <li>volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default.)</li>
-        </ul>
-        <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
-        <div style="font-size: 14px;">Returns the channel index where the sound began to play, or <code>-1</code> if no channel was available.</div>
-        </p>
-        <p id="Reference_functions_Sound_Loop">
-        <h2 style="margin-bottom: 8px;">Sound.Loop</h2>
-        <code>Sound.Loop(sound[, loopPoint, panning, speed, volume])</code>
-        <div style="margin-top: 8px; font-size: 14px;">Plays a sound, looping back when it ends.</div>
-        <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
-        <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sound (Integer): The sound index to play.</li>
-        <li>loopPoint (Integer): Loop point in samples.</li>
+        <li>loopPoint (Integer): Loop point in samples. (-1 is the default, will not loop.)</li>
         <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)</li>
         <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)</li>
         <li>volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default.)</li>
@@ -8489,26 +8472,12 @@
         </p>
         <p id="Reference_functions_Sound_PlayMultiple">
         <h2 style="margin-bottom: 8px;">Sound.PlayMultiple</h2>
-        <code>Sound.PlayMultiple(sound[, panning, speed, volume])</code>
-        <div style="margin-top: 8px; font-size: 14px;">Plays a sound once, without interrupting channels playing the same sound.</div>
+        <code>Sound.PlayMultiple(sound[, loopPoint, panning, speed, volume])</code>
+        <div style="margin-top: 8px; font-size: 14px;">Plays a sound once or loops it, without interrupting channels playing the same sound.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>sound (Integer): The sound index to play.</li>
-        <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)</li>
-        <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)</li>
-        <li>volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default.)</li>
-        </ul>
-        <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
-        <div style="font-size: 14px;">Returns the channel index where the sound began to play, or <code>-1</code> if no channel was available.</div>
-        </p>
-        <p id="Reference_functions_Sound_LoopMultiple">
-        <h2 style="margin-bottom: 8px;">Sound.LoopMultiple</h2>
-        <code>Sound.LoopMultiple(sound[, loopPoint, panning, speed, volume])</code>
-        <div style="margin-top: 8px; font-size: 14px;">Plays a sound, looping back when it ends, without interrupting channels playing the same sound.</div>
-        <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
-        <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sound (Integer): The sound index to play.</li>
-        <li>loopPoint (Integer): Loop point in samples.</li>
+        <li>loopPoint (Integer): Loop point in samples. (-1 is the default, will not loop.)</li>
         <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)</li>
         <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)</li>
         <li>volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default.)</li>
@@ -8518,26 +8487,13 @@
         </p>
         <p id="Reference_functions_Sound_PlayAtChannel">
         <h2 style="margin-bottom: 8px;">Sound.PlayAtChannel</h2>
-        <code>Sound.PlayAtChannel(channel, sound[, panning, speed, volume])</code>
-        <div style="margin-top: 8px; font-size: 14px;">Plays a sound at the specified channel.</div>
+        <code>Sound.PlayAtChannel(channel, sound[, loopPoint, panning, speed, volume])</code>
+        <div style="margin-top: 8px; font-size: 14px;">Plays or loops a sound at the specified channel.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>channel (Integer): The channel index.</li>
         <li>sound (Integer): The sound index to play.</li>
-        <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)</li>
-        <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)</li>
-        <li>volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default.)</li>
-        </ul>
-        </p>
-        <p id="Reference_functions_Sound_LoopAtChannel">
-        <h2 style="margin-bottom: 8px;">Sound.LoopAtChannel</h2>
-        <code>Sound.LoopAtChannel(channel, sound[, loopPoint, panning, speed, volume])</code>
-        <div style="margin-top: 8px; font-size: 14px;">Plays a sound at the specified channel, looping back when it ends.</div>
-        <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
-        <ul style="margin-top: 0px; font-size: 14px;">
-        <li>channel (Integer): The channel index.</li>
-        <li>sound (Integer): The sound index to play.</li>
-        <li>loopPoint (Integer): Loop point in samples.</li>
+        <li>loopPoint (Integer): Loop point in samples. (-1 is the default, will not loop.)</li>
         <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)</li>
         <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)</li>
         <li>volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default.)</li>
@@ -10121,7 +10077,7 @@
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns a Map value if the text can be decoded, otherwise returns <code>null</code>.</div>
         </p>
-        <p>729 out of 788 functions have descriptions. </p>
+        <p>726 out of 785 functions have descriptions. </p>
         <hr/>
         <h3>Instance methods</h3>
         <p id="Reference_methods_instance_SetAnimation">

--- a/guides/Documentation.htm
+++ b/guides/Documentation.htm
@@ -804,8 +804,6 @@
                     <li><a href="#Reference_functions_Music_Alter">Music.Alter</a></li>
                     <li><a href="#Reference_functions_Music_GetLoopPoint">Music.GetLoopPoint</a></li>
                     <li><a href="#Reference_functions_Music_SetLoopPoint">Music.SetLoopPoint</a></li>
-                    <li><a href="#Reference_functions_Sound_GetLoopPoint">Sound.GetLoopPoint</a></li>
-                    <li><a href="#Reference_functions_Music_SetLoopPoint">Music.SetLoopPoint</a></li>
                 </ul>
             </p>
             <p id="Reference_Number">
@@ -1150,6 +1148,8 @@
                     <li><a href="#Reference_functions_Sound_AlterChannel">Sound.AlterChannel</a></li>
                     <li><a href="#Reference_functions_Sound_GetFreeChannel">Sound.GetFreeChannel</a></li>
                     <li><a href="#Reference_functions_Sound_IsChannelFree">Sound.IsChannelFree</a></li>
+                    <li><a href="#Reference_functions_Sound_GetLoopPoint">Sound.GetLoopPoint</a></li>
+                    <li><a href="#Reference_functions_Sound_SetLoopPoint">Sound.SetLoopPoint</a></li>
                 </ul>
             </p>
             <p id="Reference_Sprite">
@@ -6058,7 +6058,7 @@
         <li>music (Integer): The music index to get the loop point.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
-        <div style="font-size: 14px;">Returns the loop point in samples, as an Integer value, or <code>null</code> if the index does not have one.</div>
+        <div style="font-size: 14px;">Returns the loop point in samples, as an Integer value, or <code>null</code> if the audio does not have one.</div>
         </p>
         <p id="Reference_functions_Music_SetLoopPoint">
         <h2 style="margin-bottom: 8px;">Music.SetLoopPoint</h2>
@@ -6067,28 +6067,7 @@
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>music (Integer): The music index to set the loop point.</li>
-        <li>loopPoint (Integer): The loop point in samples, or <code>null</code> to remove the index's loop point.</li>
-        </ul>
-        </p>
-        <p id="Reference_functions_Sound_GetLoopPoint">
-        <h2 style="margin-bottom: 8px;">Sound.GetLoopPoint</h2>
-        <code>Sound.GetLoopPoint(sound)</code>
-        <div style="margin-top: 8px; font-size: 14px;">Gets the loop point of a sound index, if it has one.</div>
-        <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
-        <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sound (Integer): The sound index to get the loop point.</li>
-        </ul>
-        <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
-        <div style="font-size: 14px;">Returns the loop point in samples, as an Integer value, or <code>null</code> if the index does not have one.</div>
-        </p>
-        <p id="Reference_functions_Music_SetLoopPoint">
-        <h2 style="margin-bottom: 8px;">Music.SetLoopPoint</h2>
-        <code>Music.SetLoopPoint(sound, loopPoint)</code>
-        <div style="margin-top: 8px; font-size: 14px;">Sets the loop point of a sound index.</div>
-        <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
-        <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sound (Integer): The sound index to set the loop point.</li>
-        <li>loopPoint (Integer): The loop point in samples, or <code>null</code> to remove the index's loop point.</li>
+        <li>loopPoint (Integer): The loop point in samples, or <code>null</code> to remove the audio's loop point.</li>
         </ul>
         </p>
         <p id="Reference_functions_Number_ToString">
@@ -8622,6 +8601,27 @@
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>sound (Integer): The channel index.</li>
+        </ul>
+        </p>
+        <p id="Reference_functions_Sound_GetLoopPoint">
+        <h2 style="margin-bottom: 8px;">Sound.GetLoopPoint</h2>
+        <code>Sound.GetLoopPoint(sound)</code>
+        <div style="margin-top: 8px; font-size: 14px;">Gets the loop point of a sound index, if it has one.</div>
+        <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
+        <ul style="margin-top: 0px; font-size: 14px;">
+        <li>sound (Integer): The sound index to get the loop point.</li>
+        </ul>
+        <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
+        <div style="font-size: 14px;">Returns the loop point in samples, as an Integer value, or <code>null</code> if the audio does not have one.</div>
+        </p>
+        <p id="Reference_functions_Sound_SetLoopPoint">
+        <h2 style="margin-bottom: 8px;">Sound.SetLoopPoint</h2>
+        <code>Sound.SetLoopPoint(sound, loopPoint)</code>
+        <div style="margin-top: 8px; font-size: 14px;">Sets the loop point of a sound index.</div>
+        <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
+        <ul style="margin-top: 0px; font-size: 14px;">
+        <li>sound (Integer): The sound index to set the loop point.</li>
+        <li>loopPoint (Integer): The loop point in samples, or <code>null</code> to remove the audio's loop point.</li>
         </ul>
         </p>
         <p id="Reference_functions_Sprite_GetAnimationCount">

--- a/include/Engine/ResourceTypes/ISound.h
+++ b/include/Engine/ResourceTypes/ISound.h
@@ -7,10 +7,14 @@
 #include <Engine/Includes/StandardSDL2.h>
 #include <Engine/ResourceTypes/SoundFormats/SoundFormat.h>
 
+#define MUSIC_LOOP_NONE -2
+#define MUSIC_LOOP_DEFAULT -1
+
 class ISound {
 public:
 	SDL_AudioSpec Format;
 	int BytesPerSample;
+	int LoopPoint = MUSIC_LOOP_NONE;
 	SoundFormat* SoundData = NULL;
 	char* Filename = NULL;
 	bool LoadFailed = false;

--- a/include/Engine/ResourceTypes/ISound.h
+++ b/include/Engine/ResourceTypes/ISound.h
@@ -7,14 +7,14 @@
 #include <Engine/Includes/StandardSDL2.h>
 #include <Engine/ResourceTypes/SoundFormats/SoundFormat.h>
 
-#define MUSIC_LOOP_NONE -2
-#define MUSIC_LOOP_DEFAULT -1
+#define AUDIO_LOOP_NONE -2
+#define AUDIO_LOOP_DEFAULT -1
 
 class ISound {
 public:
 	SDL_AudioSpec Format;
 	int BytesPerSample;
-	int LoopPoint = MUSIC_LOOP_NONE;
+	int LoopPoint = AUDIO_LOOP_NONE;
 	SoundFormat* SoundData = NULL;
 	char* Filename = NULL;
 	bool LoadFailed = false;

--- a/include/Engine/ResourceTypes/ISound.h
+++ b/include/Engine/ResourceTypes/ISound.h
@@ -7,8 +7,8 @@
 #include <Engine/Includes/StandardSDL2.h>
 #include <Engine/ResourceTypes/SoundFormats/SoundFormat.h>
 
-#define AUDIO_LOOP_NONE -2
-#define AUDIO_LOOP_DEFAULT -1
+#define AUDIO_LOOP_NONE (-2)
+#define AUDIO_LOOP_DEFAULT (-1)
 
 class ISound {
 public:

--- a/include/Engine/ResourceTypes/SoundFormats/SoundFormat.h
+++ b/include/Engine/ResourceTypes/SoundFormats/SoundFormat.h
@@ -15,6 +15,7 @@ public:
 	size_t SampleIndex = 0;
 	int TotalPossibleSamples;
 	Uint8* SampleBuffer = NULL;
+	int LoopPoint = -1;
 
 	virtual int LoadSamples(size_t count);
 	virtual int GetSamples(Uint8* buffer, size_t count, Sint32 loopIndex);

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -9783,54 +9783,27 @@ VMValue Model_DeleteArmature(int argCount, VMValue* args, Uint32 threadID) {
  * Music.Play
  * \desc Places the music onto the music stack and plays it.
  * \param music (Integer): The music index to play.
- * \paramOpt panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)
- * \paramOpt speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)
- * \paramOpt volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default.)
- * \paramOpt fadeInAfterFinished (Decimal): The time period to fade in the previous music track after the currently playing track finishes playing, in seconds. (0.0 disables this.)
+ * \paramOpt loopPoint (Integer): The sample index to loop back to, or <code>-1</code> if the music should only play once. (-1 is the default).
+ * \paramOpt panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default).
+ * \paramOpt speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default).
+ * \paramOpt volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default).
+ * \paramOpt startPoint (Decimal): The time (in seconds) to start the music at. (0.0 is the default).
+ * \paramOpt fadeInAfterFinished (Decimal): The time period to fade in the previous music track after the currently playing track finishes playing, in seconds. (0.0 is the default, which disables it).
  * \ns Music
  */
 VMValue Music_Play(int argCount, VMValue* args, Uint32 threadID) {
 	CHECK_AT_LEAST_ARGCOUNT(1);
 	ISound* audio = GET_ARG(0, GetMusic);
-	float panning = GET_ARG_OPT(1, GetDecimal, 0.0f);
-	float speed = GET_ARG_OPT(2, GetDecimal, 1.0f);
-	float volume = GET_ARG_OPT(3, GetDecimal, 1.0f);
-	float fadeInAfterFinished = GET_ARG_OPT(4, GetDecimal, 0.0f);
-	if (fadeInAfterFinished < 0.f) {
-		fadeInAfterFinished = 0.f;
-	}
-	if (audio) {
-		AudioManager::PushMusicAt(
-			audio, 0.0, false, 0, panning, speed, volume, fadeInAfterFinished);
-	}
-	return NULL_VAL;
-}
-/***
- * Music.PlayAtTime
- * \desc Places the music onto the music stack and plays it at a time (in seconds).
- * \param music (Integer): The music index to play.
- * \param startPoint (Decimal): The time (in seconds) to start the music at.
- * \paramOpt panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)
- * \paramOpt speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)
- * \paramOpt volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default.)
- * \paramOpt fadeInAfterFinished (Decimal): The time period to fade in the previous music track after the currently playing track finishes playing, in seconds. (0.0 disables this.)
- * \ns Music
- */
-VMValue Music_PlayAtTime(int argCount, VMValue* args, Uint32 threadID) {
-	CHECK_AT_LEAST_ARGCOUNT(2);
-	ISound* audio = GET_ARG(0, GetMusic);
-	double start_point = GET_ARG(1, GetDecimal);
+	int loopPoint = GET_ARG_OPT(1, GetInteger, -1);
 	float panning = GET_ARG_OPT(2, GetDecimal, 0.0f);
 	float speed = GET_ARG_OPT(3, GetDecimal, 1.0f);
 	float volume = GET_ARG_OPT(4, GetDecimal, 1.0f);
-	float fadeInAfterFinished = GET_ARG_OPT(5, GetDecimal, 0.0f);
-	if (fadeInAfterFinished < 0.f) {
+	double startPoint = GET_ARG_OPT(5, GetDecimal, 0.0);
+	float fadeInAfterFinished = GET_ARG_OPT(6, GetDecimal, 0.0f);
+	if (fadeInAfterFinished < 0.f)
 		fadeInAfterFinished = 0.f;
-	}
-	if (audio) {
-		AudioManager::PushMusicAt(
-			audio, start_point, false, 0, panning, speed, volume, fadeInAfterFinished);
-	}
+	if (audio)
+		AudioManager::PushMusicAt(audio, startPoint, (loopPoint >= 0) ? true : false, loopPoint, panning, speed, volume, fadeInAfterFinished);
 	return NULL_VAL;
 }
 /***
@@ -9900,74 +9873,6 @@ VMValue Music_Resume(int argCount, VMValue* args, Uint32 threadID) {
 VMValue Music_Clear(int argCount, VMValue* args, Uint32 threadID) {
 	CHECK_ARGCOUNT(0);
 	AudioManager::ClearMusic();
-	return NULL_VAL;
-}
-/***
- * Music.Loop
- * \desc Places the music onto the music stack and plays it, looping back to the specified sample index if it reaches the end of playback.
- * \param music (Integer): The music index to play.
- * \param loop (Boolean): Unused.
- * \param loopPoint (Integer): The sample index to loop back to.
- * \paramOpt panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)
- * \paramOpt speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)
- * \paramOpt volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default.)
- * \paramOpt fadeInAfterFinished (Decimal): The time period to fade in the previous music track after the currently playing track is interrupted, in seconds. (0.0 disables this.)
- * \ns Music
- */
-VMValue Music_Loop(int argCount, VMValue* args, Uint32 threadID) {
-	CHECK_AT_LEAST_ARGCOUNT(3);
-	ISound* audio = GET_ARG(0, GetMusic);
-	// int loop = GET_ARG(1, GetInteger);
-	int loop_point = GET_ARG(2, GetInteger);
-	float panning = GET_ARG_OPT(3, GetDecimal, 0.0f);
-	float speed = GET_ARG_OPT(4, GetDecimal, 1.0f);
-	float volume = GET_ARG_OPT(5, GetDecimal, 1.0f);
-	float fadeInAfterFinished = GET_ARG_OPT(6, GetDecimal, 0.0f);
-	if (fadeInAfterFinished < 0.f) {
-		fadeInAfterFinished = 0.f;
-	}
-	if (audio) {
-		AudioManager::PushMusic(
-			audio, true, loop_point, panning, speed, volume, fadeInAfterFinished);
-	}
-	return NULL_VAL;
-}
-/***
- * Music.LoopAtTime
- * \desc Places the music onto the music stack and plays it, looping back to the specified sample index if it reaches the end of playback.
- * \param music (Integer): The music index to play.
- * \param startPoint (Decimal): The time (in seconds) to start the music at.
- * \param loop (Boolean): Unused.
- * \param loopPoint (Integer): The sample index to loop back to.
- * \paramOpt panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)
- * \paramOpt speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)
- * \paramOpt volume (Decimal): Controls the volume of the audio. 0.0 is muted, 1.0 is normal volume. (1.0 is the default.)
- * \paramOpt fadeInAfterFinished (Decimal): The time period to fade in the previous music track after the currently playing track is interrupted, in seconds. (0.0 disables this.)
- * \ns Music
- */
-VMValue Music_LoopAtTime(int argCount, VMValue* args, Uint32 threadID) {
-	CHECK_AT_LEAST_ARGCOUNT(4);
-	ISound* audio = GET_ARG(0, GetMusic);
-	double start_point = GET_ARG(1, GetDecimal);
-	// int loop = GET_ARG(2, GetInteger);
-	int loop_point = GET_ARG(3, GetInteger);
-	float panning = GET_ARG_OPT(4, GetDecimal, 0.0f);
-	float speed = GET_ARG_OPT(5, GetDecimal, 1.0f);
-	float volume = GET_ARG_OPT(6, GetDecimal, 1.0f);
-	float fadeInAfterFinished = GET_ARG_OPT(7, GetDecimal, 0.0f);
-	if (fadeInAfterFinished < 0.f) {
-		fadeInAfterFinished = 0.f;
-	}
-	if (audio) {
-		AudioManager::PushMusicAt(audio,
-			start_point,
-			true,
-			loop_point,
-			panning,
-			speed,
-			volume,
-			fadeInAfterFinished);
-	}
 	return NULL_VAL;
 }
 /***

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -18913,14 +18913,11 @@ void StandardLibrary::Link() {
 	// #region Music
 	INIT_CLASS(Music);
 	DEF_NATIVE(Music, Play);
-	DEF_NATIVE(Music, PlayAtTime);
 	DEF_NATIVE(Music, Stop);
 	DEF_NATIVE(Music, StopWithFadeOut);
 	DEF_NATIVE(Music, Pause);
 	DEF_NATIVE(Music, Resume);
 	DEF_NATIVE(Music, Clear);
-	DEF_NATIVE(Music, Loop);
-	DEF_NATIVE(Music, LoopAtTime);
 	DEF_NATIVE(Music, IsPlaying);
 	DEF_NATIVE(Music, GetPosition);
 	DEF_NATIVE(Music, Alter);

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -14618,6 +14618,38 @@ VMValue Sound_IsChannelFree(int argCount, VMValue* args, Uint32 threadID) {
 	}
 	return INTEGER_VAL(AudioManager::AudioIsPlaying(channel % AudioManager::SoundArrayLength));
 }
+/***
+ * Sound.GetLoopPoint
+ * \desc Gets the loop point of a sound index, if it has one.
+ * \param sound (Integer): The sound index to get the loop point.
+ * \return Returns the loop point in samples, as an Integer value.
+ * \ns Music
+ */
+VMValue Sound_GetLoopPoint(int argCount, VMValue* args, Uint32 threadID) {
+	CHECK_ARGCOUNT(1);
+	ISound* audio = GET_ARG(0, GetSound);
+	if (!audio) {
+		return NULL_VAL;
+	}
+	return INTEGER_VAL(audio->LoopPoint);
+}
+/***
+ * Music.SetLoopPoint
+ * \desc Sets the loop point of a sound index.
+ * \param sound (Integer): The sound index to set the loop point.
+ * \param loopPoint (Integer): The loop point, in samples.
+ * \ns Music
+ */
+VMValue Sound_SetLoopPoint(int argCount, VMValue* args, Uint32 threadID) {
+	CHECK_ARGCOUNT(1);
+	ISound* audio = GET_ARG(0, GetSound);
+	int loopPoint = GET_ARG(1, GetInteger);
+	if (!audio) {
+		return NULL_VAL;
+	}
+	audio->LoopPoint = loopPoint;
+	return NULL_VAL;
+}
 // #endregion
 
 // #region Sprite
@@ -19245,6 +19277,8 @@ void StandardLibrary::Link() {
 	DEF_NATIVE(Sound, AlterChannel);
 	DEF_NATIVE(Sound, GetFreeChannel);
 	DEF_NATIVE(Sound, IsChannelFree);
+	DEF_NATIVE(Sound, GetLoopPoint);
+	DEF_NATIVE(Sound, SetLoopPoint);
 	// #endregion
 
 	// #region Sprite

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -9972,7 +9972,7 @@ VMValue Music_Alter(int argCount, VMValue* args, Uint32 threadID) {
  * Music.GetLoopPoint
  * \desc Gets the loop point of a music index, if it has one.
  * \param music (Integer): The music index to get the loop point.
- * \return Returns the loop point in samples, as an Integer value, or <code>null</code> if the index does not have one.
+ * \return Returns the loop point in samples, as an Integer value, or <code>null</code> if the audio does not have one.
  * \ns Music
  */
 VMValue Music_GetLoopPoint(int argCount, VMValue* args, Uint32 threadID) {
@@ -9987,7 +9987,7 @@ VMValue Music_GetLoopPoint(int argCount, VMValue* args, Uint32 threadID) {
  * Music.SetLoopPoint
  * \desc Sets the loop point of a music index.
  * \param music (Integer): The music index to set the loop point.
- * \param loopPoint (Integer): The loop point in samples, or <code>null</code> to remove the index's loop point.
+ * \param loopPoint (Integer): The loop point in samples, or <code>null</code> to remove the audio's loop point.
  * \ns Music
  */
 VMValue Music_SetLoopPoint(int argCount, VMValue* args, Uint32 threadID) {
@@ -9997,8 +9997,9 @@ VMValue Music_SetLoopPoint(int argCount, VMValue* args, Uint32 threadID) {
 	if (!audio) {
 		return NULL_VAL;
 	}
-	if (loopPoint > 0)
+	if (loopPoint >= -1) {
 		audio->LoopPoint = loopPoint;
+	}
 	return NULL_VAL;
 }
 // #endregion
@@ -14658,8 +14659,8 @@ VMValue Sound_IsChannelFree(int argCount, VMValue* args, Uint32 threadID) {
  * Sound.GetLoopPoint
  * \desc Gets the loop point of a sound index, if it has one.
  * \param sound (Integer): The sound index to get the loop point.
- * \return Returns the loop point in samples, as an Integer value, or <code>null</code> if the index does not have one.
- * \ns Music
+ * \return Returns the loop point in samples, as an Integer value, or <code>null</code> if the audio does not have one.
+ * \ns Sound
  */
 VMValue Sound_GetLoopPoint(int argCount, VMValue* args, Uint32 threadID) {
 	CHECK_ARGCOUNT(1);
@@ -14670,11 +14671,11 @@ VMValue Sound_GetLoopPoint(int argCount, VMValue* args, Uint32 threadID) {
 	return INTEGER_VAL(audio->LoopPoint);
 }
 /***
- * Music.SetLoopPoint
+ * Sound.SetLoopPoint
  * \desc Sets the loop point of a sound index.
  * \param sound (Integer): The sound index to set the loop point.
- * \param loopPoint (Integer): The loop point in samples, or <code>null</code> to remove the index's loop point.
- * \ns Music
+ * \param loopPoint (Integer): The loop point in samples, or <code>null</code> to remove the audio's loop point.
+ * \ns Sound
  */
 VMValue Sound_SetLoopPoint(int argCount, VMValue* args, Uint32 threadID) {
 	CHECK_ARGCOUNT(1);
@@ -14683,8 +14684,9 @@ VMValue Sound_SetLoopPoint(int argCount, VMValue* args, Uint32 threadID) {
 	if (!audio) {
 		return NULL_VAL;
 	}
-	if (loopPoint > 0)
+	if (loopPoint >= -1) {
 		audio->LoopPoint = loopPoint;
+	}
 	return NULL_VAL;
 }
 // #endregion

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -9805,7 +9805,7 @@ VMValue Music_Play(int argCount, VMValue* args, Uint32 threadID) {
 		fadeInAfterFinished = 0.f;
 
 	if (loopPoint < AUDIO_LOOP_NONE) {
-		THROW_ERROR("Audio loop value cannot be lower than -2, received %d", loopPoint);
+		THROW_ERROR("Audio loop point value should be AUDIO_LOOP_DEFAULT, AUDIO_LOOP_NONE, or a number higher than zero, received %d", loopPoint);
 		return NULL_VAL;
 	}
 
@@ -9937,13 +9937,13 @@ VMValue Music_Alter(int argCount, VMValue* args, Uint32 threadID) {
  * Music.GetLoopPoint
  * \desc Gets the loop point of a music index, if it has one.
  * \param music (Integer): The music index to get the loop point.
- * \return Returns the loop point in samples, as an Integer value.
+ * \return Returns the loop point in samples, as an Integer value, or <code>null</code> if the index does not have one.
  * \ns Music
  */
 VMValue Music_GetLoopPoint(int argCount, VMValue* args, Uint32 threadID) {
 	CHECK_ARGCOUNT(1);
 	ISound* audio = GET_ARG(0, GetMusic);
-	if (!audio) {
+	if (!audio || audio->LoopPoint == -1) {
 		return NULL_VAL;
 	}
 	return INTEGER_VAL(audio->LoopPoint);
@@ -9952,17 +9952,18 @@ VMValue Music_GetLoopPoint(int argCount, VMValue* args, Uint32 threadID) {
  * Music.SetLoopPoint
  * \desc Sets the loop point of a music index.
  * \param music (Integer): The music index to set the loop point.
- * \param loopPoint (Integer): The loop point, in samples.
+ * \param loopPoint (Integer): The loop point in samples, or <code>null</code> to remove the index's loop point.
  * \ns Music
  */
 VMValue Music_SetLoopPoint(int argCount, VMValue* args, Uint32 threadID) {
 	CHECK_ARGCOUNT(1);
 	ISound* audio = GET_ARG(0, GetMusic);
-	int loopPoint = GET_ARG(1, GetInteger);
+	int loopPoint = IS_NULL(args[1]) ? -1 : GET_ARG(1, GetInteger);
 	if (!audio) {
 		return NULL_VAL;
 	}
-	audio->LoopPoint = loopPoint;
+	if (loopPoint > 0)
+		audio->LoopPoint = loopPoint;
 	return NULL_VAL;
 }
 // #endregion
@@ -14346,7 +14347,7 @@ VMValue Sound_Play(int argCount, VMValue* args, Uint32 threadID) {
 	int channel = -1;
 
 	if (loopPoint < AUDIO_LOOP_NONE) {
-		THROW_ERROR("Audio loop value cannot be lower than -2, received %d", loopPoint);
+		THROW_ERROR("Audio loop point value should be AUDIO_LOOP_DEFAULT, AUDIO_LOOP_NONE, or a number higher than zero, received %d", loopPoint);
 		return NULL_VAL;
 	}
 
@@ -14467,7 +14468,7 @@ VMValue Sound_PlayMultiple(int argCount, VMValue* args, Uint32 threadID) {
 	int channel = -1;
 
 	if (loopPoint < AUDIO_LOOP_NONE) {
-		THROW_ERROR("Audio loop value cannot be lower than -2, received %d", loopPoint);
+		THROW_ERROR("Audio loop point value should be AUDIO_LOOP_DEFAULT, AUDIO_LOOP_NONE, or a number higher than zero, received %d", loopPoint);
 		return NULL_VAL;
 	}
 
@@ -14506,7 +14507,7 @@ VMValue Sound_PlayAtChannel(int argCount, VMValue* args, Uint32 threadID) {
 	}
 
 	if (loopPoint < AUDIO_LOOP_NONE) {
-		THROW_ERROR("Audio loop value cannot be lower than -2, received %d", loopPoint);
+		THROW_ERROR("Audio loop point value should be AUDIO_LOOP_DEFAULT, AUDIO_LOOP_NONE, or a number higher than zero, received %d", loopPoint);
 		return NULL_VAL;
 	}
 
@@ -14622,13 +14623,13 @@ VMValue Sound_IsChannelFree(int argCount, VMValue* args, Uint32 threadID) {
  * Sound.GetLoopPoint
  * \desc Gets the loop point of a sound index, if it has one.
  * \param sound (Integer): The sound index to get the loop point.
- * \return Returns the loop point in samples, as an Integer value.
+ * \return Returns the loop point in samples, as an Integer value, or <code>null</code> if the index does not have one.
  * \ns Music
  */
 VMValue Sound_GetLoopPoint(int argCount, VMValue* args, Uint32 threadID) {
 	CHECK_ARGCOUNT(1);
 	ISound* audio = GET_ARG(0, GetSound);
-	if (!audio) {
+	if (!audio || audio->LoopPoint == -1) {
 		return NULL_VAL;
 	}
 	return INTEGER_VAL(audio->LoopPoint);
@@ -14637,17 +14638,18 @@ VMValue Sound_GetLoopPoint(int argCount, VMValue* args, Uint32 threadID) {
  * Music.SetLoopPoint
  * \desc Sets the loop point of a sound index.
  * \param sound (Integer): The sound index to set the loop point.
- * \param loopPoint (Integer): The loop point, in samples.
+ * \param loopPoint (Integer): The loop point in samples, or <code>null</code> to remove the index's loop point.
  * \ns Music
  */
 VMValue Sound_SetLoopPoint(int argCount, VMValue* args, Uint32 threadID) {
 	CHECK_ARGCOUNT(1);
 	ISound* audio = GET_ARG(0, GetSound);
-	int loopPoint = GET_ARG(1, GetInteger);
+	int loopPoint = IS_NULL(args[1]) ? -1 : GET_ARG(1, GetInteger);
 	if (!audio) {
 		return NULL_VAL;
 	}
-	audio->LoopPoint = loopPoint;
+	if (loopPoint > 0)
+		audio->LoopPoint = loopPoint;
 	return NULL_VAL;
 }
 // #endregion

--- a/source/Engine/ResourceTypes/ISound.cpp
+++ b/source/Engine/ResourceTypes/ISound.cpp
@@ -33,6 +33,8 @@ void ISound::Load(const char* filename, bool streamFromFile) {
 
 		Format = SoundData->InputFormat;
 
+		LoopPoint = SoundData->LoopPoint;
+
 		Log::Print(Log::LOG_VERBOSE,
 			"OGG load took %.3f ms (%s)",
 			Clock::GetTicks() - ticks,

--- a/source/Engine/ResourceTypes/SoundFormats/OGG.cpp
+++ b/source/Engine/ResourceTypes/SoundFormats/OGG.cpp
@@ -230,6 +230,33 @@ SoundFormat* OGG::Load(const char* filename) {
 
 		auto info = stb_vorbis_get_info(vorbis->VorbisSTB);
 
+		stb_vorbis_comment comment = stb_vorbis_get_comment(vorbis->VorbisSTB);
+
+		for (int i = 0; i < comment.comment_list_length; i++) {
+			const char* entry = (const char*)comment.comment_list[i];
+
+			if (strncmp(entry, "LOOPPOINT=", 10) == 0) {
+				const char* valueStr = entry + 10;
+
+				int loopPoint = -1;
+				if (StringUtils::ToNumber(&loopPoint, valueStr) && loopPoint >= 0) {
+					ogg->LoopPoint = loopPoint;
+				}
+
+				break;
+			}
+			if (strncmp(entry, "Loop Point=", 11) == 0) {
+				const char* valueStr = entry + 11;
+
+				int loopPoint = -1;
+				if (StringUtils::ToNumber(&loopPoint, valueStr) && loopPoint >= 0) {
+					ogg->LoopPoint = loopPoint;
+				}
+
+				break;
+			}
+		}
+
 		memset(&ogg->InputFormat, 0, sizeof(SDL_AudioSpec));
 		ogg->InputFormat.format = AUDIO_S16SYS;
 		ogg->InputFormat.channels = info.channels;
@@ -386,6 +413,7 @@ int OGG::GetSamples(Uint8* buffer, size_t count, Sint32 loopIndex) {
 	total /= SampleSize;
 
 	SampleIndex += total;
+
 	return total;
 #endif
 	return 0;

--- a/source/Engine/ResourceTypes/SoundFormats/OGG.cpp
+++ b/source/Engine/ResourceTypes/SoundFormats/OGG.cpp
@@ -235,7 +235,7 @@ SoundFormat* OGG::Load(const char* filename) {
 		for (int i = 0; i < comment.comment_list_length; i++) {
 			const char* entry = (const char*)comment.comment_list[i];
 
-			if (strncmp(entry, "LOOPPOINT=", 10) == 0) {
+			if (StringUtils::StartsWith(entry, "LOOPPOINT=")) {
 				const char* valueStr = entry + 10;
 
 				int loopPoint = -1;
@@ -245,7 +245,7 @@ SoundFormat* OGG::Load(const char* filename) {
 
 				break;
 			}
-			if (strncmp(entry, "Loop Point=", 11) == 0) {
+			if (StringUtils::StartsWith(entry, "Loop Point=")) {
 				const char* valueStr = entry + 11;
 
 				int loopPoint = -1;


### PR DESCRIPTION
- Removes Music.PlayAtTime, Music.LoopAtTime, and Music.Loop and folds their functionality into the existing Music.Play function, as per the 1.4.0 to-do list