### PR TITLE
Implement separate opcode for super invocations

### DIFF
--- a/include/Engine/Bytecode/Compiler.h
+++ b/include/Engine/Bytecode/Compiler.h
@@ -87,6 +87,7 @@ public:
 	void EmitCopy(Uint8 count);
 	void EmitCall(const char* name, int argCount, bool isSuper);
 	void EmitCall(Token name, int argCount, bool isSuper);
+	void EmitCallOpcode(int argCount, bool isSuper);
 	void NamedVariable(Token name, bool canAssign);
 	void ScopeBegin();
 	void ScopeEnd();
@@ -207,6 +208,7 @@ public:
 	static int LocalInstruction(uint8_t opcode, Chunk* chunk, int offset);
 	static int MethodInstruction(uint8_t opcode, Chunk* chunk, int offset);
 	static int InvokeInstruction(uint8_t opcode, Chunk* chunk, int offset);
+	static int InvokeInstructionV3(uint8_t opcode, Chunk* chunk, int offset);
 	static int JumpInstruction(uint8_t opcode, int sign, Chunk* chunk, int offset);
 	static int ClassInstruction(uint8_t opcode, Chunk* chunk, int offset);
 	static int EnumInstruction(uint8_t opcode, Chunk* chunk, int offset);

--- a/include/Engine/Bytecode/VMThread.h
+++ b/include/Engine/Bytecode/VMThread.h
@@ -74,12 +74,14 @@ public:
 	void RunInstructionSet();
 	void RunValue(VMValue value, int argCount);
 	void RunFunction(ObjFunction* func, int argCount);
+	int Invoke(VMValue receiver, Uint8 argCount, Uint32 hash);
+	int SuperInvoke(VMValue receiver, Uint8 argCount, Uint32 hash);
 	void InvokeForEntity(VMValue value, int argCount);
 	VMValue RunEntityFunction(ObjFunction* function, int argCount);
 	void CallInitializer(VMValue value);
 	bool Call(ObjFunction* function, int argCount);
 	bool InvokeFromClass(ObjClass* klass, Uint32 hash, int argCount);
-	bool InvokeForInstance(Uint32 hash, int argCount, bool isSuper);
+	bool InvokeForInstance(ObjInstance* instance, Uint32 hash, int argCount);
 	bool Import(VMValue value);
 	bool ImportModule(VMValue value);
 	VMValue Values_Multiply();
@@ -125,7 +127,7 @@ public:
 	VM_ADD_OPFUNC(OP_CLASS);
 	VM_ADD_OPFUNC(OP_CALL);
 	VM_ADD_OPFUNC(OP_SUPER);
-	VM_ADD_OPFUNC(OP_INVOKE);
+	VM_ADD_OPFUNC(OP_INVOKE_V3);
 	VM_ADD_OPFUNC(OP_JUMP);
 	VM_ADD_OPFUNC(OP_JUMP_IF_FALSE);
 	VM_ADD_OPFUNC(OP_JUMP_BACK);
@@ -186,6 +188,8 @@ public:
 	VM_ADD_OPFUNC(OP_DEFINE_CONSTANT);
 	VM_ADD_OPFUNC(OP_INTEGER);
 	VM_ADD_OPFUNC(OP_DECIMAL);
+	VM_ADD_OPFUNC(OP_INVOKE);
+	VM_ADD_OPFUNC(OP_SUPER_INVOKE);
 #endif
 };
 

--- a/source/Engine/Bytecode/Bytecode.cpp
+++ b/source/Engine/Bytecode/Bytecode.cpp
@@ -2,7 +2,7 @@
 #include <Engine/IO/MemoryStream.h>
 #include <Engine/Utilities/StringUtils.h>
 
-#define BYTECODE_VERSION 0x0003
+#define BYTECODE_VERSION 0x0004
 
 const char* Bytecode::Magic = "HTVM";
 Uint32 Bytecode::LatestVersion = BYTECODE_VERSION;

--- a/source/Engine/Bytecode/Compiler.cpp
+++ b/source/Engine/Bytecode/Compiler.cpp
@@ -50,7 +50,7 @@ static const char* opcodeNames[] = {"OP_ERROR",
 	"OP_CLASS",
 	"OP_CALL",
 	"OP_SUPER",
-	"OP_INVOKE",
+	"OP_INVOKE_V3",
 	"OP_JUMP",
 	"OP_JUMP_IF_FALSE",
 	"OP_JUMP_BACK",
@@ -110,7 +110,9 @@ static const char* opcodeNames[] = {"OP_ERROR",
 	"OP_USE_NAMESPACE",
 	"OP_DEFINE_CONSTANT",
 	"OP_INTEGER",
-	"OP_DECIMAL"};
+	"OP_DECIMAL",
+	"OP_INVOKE",
+	"OP_SUPER_INVOKE"};
 
 // Order these by C/C++ precedence operators
 enum TokenTYPE {
@@ -1221,14 +1223,16 @@ void Compiler::EmitCopy(Uint8 count) {
 }
 
 void Compiler::EmitCall(const char* name, int argCount, bool isSuper) {
-	EmitBytes(OP_INVOKE, argCount);
+	EmitCallOpcode(argCount, isSuper);
 	EmitStringHash(name);
-	EmitByte(isSuper ? 1 : 0);
 }
 void Compiler::EmitCall(Token name, int argCount, bool isSuper) {
-	EmitBytes(OP_INVOKE, argCount);
+	EmitCallOpcode(argCount, isSuper);
 	EmitStringHash(name);
-	EmitByte(isSuper ? 1 : 0);
+}
+void Compiler::EmitCallOpcode(int argCount, bool isSuper) {
+	EmitByte(isSuper ? OP_SUPER_INVOKE : OP_INVOKE);
+	EmitByte(argCount);
 }
 
 void Compiler::NamedVariable(Token name, bool canAssign) {
@@ -4055,6 +4059,9 @@ int Compiler::GetTotalOpcodeSize(uint8_t* op) {
 	case OP_JUMP_BACK:
 		return 3;
 	case OP_INVOKE:
+	case OP_SUPER_INVOKE:
+		return 6;
+	case OP_INVOKE_V3:
 		return 7;
 	case OP_WITH:
 		if (*(op + 1) == 3) {
@@ -4140,6 +4147,9 @@ int Compiler::MethodInstruction(uint8_t opcode, Chunk* chunk, int offset) {
 	return offset + GetTotalOpcodeSize(chunk->Code + offset);
 }
 int Compiler::InvokeInstruction(uint8_t opcode, Chunk* chunk, int offset) {
+	return Compiler::MethodInstruction(opcode, chunk, offset);
+}
+int Compiler::InvokeInstructionV3(uint8_t opcode, Chunk* chunk, int offset) {
 	return Compiler::MethodInstruction(opcode, chunk, offset);
 }
 int Compiler::JumpInstruction(uint8_t opcode, int sign, Chunk* chunk, int offset) {
@@ -4262,7 +4272,10 @@ int Compiler::DebugInstruction(Chunk* chunk, int offset) {
 	case OP_JUMP_BACK:
 		return JumpInstruction(instruction, -1, chunk, offset);
 	case OP_INVOKE:
+	case OP_SUPER_INVOKE:
 		return InvokeInstruction(instruction, chunk, offset);
+	case OP_INVOKE_V3:
+		return InvokeInstructionV3(instruction, chunk, offset);
 
 	case OP_PRINT_STACK: {
 		offset++;

--- a/source/Engine/Bytecode/Types.cpp
+++ b/source/Engine/Bytecode/Types.cpp
@@ -381,7 +381,7 @@ void Chunk::SetupOpfuncs() {
 			OPCASE(OP_CLASS);
 			OPCASE(OP_CALL);
 			OPCASE(OP_SUPER);
-			OPCASE(OP_INVOKE);
+			OPCASE(OP_INVOKE_V3);
 			OPCASE(OP_JUMP);
 			OPCASE(OP_JUMP_IF_FALSE);
 			OPCASE(OP_JUMP_BACK);
@@ -442,6 +442,8 @@ void Chunk::SetupOpfuncs() {
 			OPCASE(OP_DEFINE_CONSTANT);
 			OPCASE(OP_INTEGER);
 			OPCASE(OP_DECIMAL);
+			OPCASE(OP_INVOKE);
+			OPCASE(OP_SUPER_INVOKE);
 		}
 		assert((func != NULL));
 		OpcodeFuncs[i] = func;

--- a/source/Engine/Bytecode/Types.h
+++ b/source/Engine/Bytecode/Types.h
@@ -408,7 +408,7 @@ enum OpCode : uint8_t {
 	// Function Operations
 	OP_CALL,
 	OP_SUPER,
-	OP_INVOKE,
+	OP_INVOKE_V3,
 	// Jumping
 	OP_JUMP,
 	OP_JUMP_IF_FALSE,
@@ -476,10 +476,11 @@ enum OpCode : uint8_t {
 	OP_SET_MODULE_LOCAL,
 	OP_DEFINE_MODULE_LOCAL,
 	OP_USE_NAMESPACE,
-	// New constant opcodes
 	OP_DEFINE_CONSTANT,
 	OP_INTEGER,
 	OP_DECIMAL,
+	OP_INVOKE,
+	OP_SUPER_INVOKE,
 
 	OP_LAST
 };


### PR DESCRIPTION
`OP_INVOKE` reads an additional byte for discerning super calls; this is not necessary, as most invocations aren't done through `super`. This splits the opcode into two, `OP_INVOKE` and `OP_SUPER_INVOKE`. This eliminates a check that needed to be done for determining the correct method to call on the object. The old opcode still exists as `OP_INVOKE_V3`, so that bytecode version 3 and earlier can still be executed correctly.

Additionally, this fixes a bug where `super` wouldn't correctly use the parent class for objects that weren't instances (such as doing `super` within a class.)