### PR TITLE
Resource refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ CPPFILES := \
 	source/Engine/Bytecode/TypeImpl/FunctionImpl.cpp \
 	source/Engine/Bytecode/TypeImpl/MapImpl.cpp \
 	source/Engine/Bytecode/TypeImpl/MaterialImpl.cpp \
+	source/Engine/Bytecode/TypeImpl/ResourceImpl.cpp \
 	source/Engine/Bytecode/TypeImpl/StringImpl.cpp \
 	source/Engine/Bytecode/Types.cpp \
 	source/Engine/Bytecode/Values.cpp \
@@ -146,6 +147,7 @@ CPPFILES := \
 	source/Engine/ResourceTypes/ModelFormats/Importer.cpp \
 	source/Engine/ResourceTypes/ModelFormats/MD3Model.cpp \
 	source/Engine/ResourceTypes/ModelFormats/RSDKModel.cpp \
+	source/Engine/ResourceTypes/Resource.cpp \
 	source/Engine/ResourceTypes/ResourceManager.cpp \
 	source/Engine/ResourceTypes/SceneFormats/HatchSceneReader.cpp \
 	source/Engine/ResourceTypes/SceneFormats/RSDKSceneReader.cpp \
@@ -220,6 +222,7 @@ PRVHFILES := \
 	source/Engine/Rendering/SDL2/SDL2MetalFunc.h \
 	source/Engine/Rendering/Software/Contour.h \
 	source/Engine/Rendering/Software/SoftwareEnums.h \
+	source/Engine/ResourceTypes/Resource.h \
 	source/Engine/ResourceTypes/ResourceType.h \
 	source/Engine/ResourceTypes/SceneFormats/HatchSceneTypes.h \
 	source/Engine/Scene/SceneConfig.h \
@@ -267,6 +270,7 @@ PUBHFILES := \
 	include/Engine/Bytecode/TypeImpl/FunctionImpl.h \
 	include/Engine/Bytecode/TypeImpl/MapImpl.h \
 	include/Engine/Bytecode/TypeImpl/MaterialImpl.h \
+	include/Engine/Bytecode/TypeImpl/ResourceImpl.h \
 	include/Engine/Bytecode/TypeImpl/StringImpl.h \
 	include/Engine/Bytecode/Values.h \
 	include/Engine/Bytecode/VMThread.h \

--- a/VisualC/HatchGameEngine.vcxproj
+++ b/VisualC/HatchGameEngine.vcxproj
@@ -162,6 +162,7 @@ copy "$(TargetPath)" "$(SolutionDir)..\builds\win\$(TargetName)-Release.exe"</Co
     <ClCompile Include="..\source\engine\bytecode\TypeImpl\FunctionImpl.cpp" />
     <ClCompile Include="..\source\engine\bytecode\TypeImpl\MapImpl.cpp" />
     <ClCompile Include="..\source\engine\bytecode\TypeImpl\MaterialImpl.cpp" />
+    <ClCompile Include="..\source\engine\bytecode\TypeImpl\ResourceImpl.cpp" />
     <ClCompile Include="..\source\engine\bytecode\TypeImpl\StringImpl.cpp" />
     <ClCompile Include="..\source\engine\bytecode\Bytecode.cpp" />
     <ClCompile Include="..\source\engine\bytecode\Compiler.cpp" />
@@ -267,6 +268,7 @@ copy "$(TargetPath)" "$(SolutionDir)..\builds\win\$(TargetName)-Release.exe"</Co
     <ClCompile Include="..\source\engine\resourcetypes\modelformats\Importer.cpp" />
     <ClCompile Include="..\source\engine\resourcetypes\modelformats\MD3Model.cpp" />
     <ClCompile Include="..\source\engine\resourcetypes\modelformats\RSDKModel.cpp" />
+    <ClCompile Include="..\source\engine\resourcetypes\Resource.cpp" />
     <ClCompile Include="..\source\engine\resourcetypes\ResourceManager.cpp" />
     <ClCompile Include="..\source\engine\resourcetypes\SceneFormats\HatchSceneReader.cpp" />
     <ClCompile Include="..\source\engine\resourcetypes\sceneformats\RSDKSceneReader.cpp" />
@@ -326,6 +328,7 @@ copy "$(TargetPath)" "$(SolutionDir)..\builds\win\$(TargetName)-Release.exe"</Co
     <ClInclude Include="..\include\engine\rendering\metal\MetalFuncs.h" />
     <ClInclude Include="..\include\engine\rendering\sdl2\SDL2MetalFunc.h" />
     <ClInclude Include="..\include\engine\resourcetypes\modelformats\Importer.h" />
+    <ClInclude Include="..\include\engine\resourcetypes\Resource.h" />
     <ClInclude Include="..\include\engine\resourcetypes\ResourceType.h" />
     <ClInclude Include="..\include\engine\sprites\Animation.h" />
     <ClInclude Include="..\include\engine\textformats\ini\INIStructs.h" />

--- a/VisualC/HatchGameEngine.vcxproj.filters
+++ b/VisualC/HatchGameEngine.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClCompile Include="..\source\engine\bytecode\TypeImpl\MaterialImpl.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\source\engine\bytecode\TypeImpl\ResourceImpl.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\source\engine\bytecode\TypeImpl\StringImpl.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -348,6 +351,9 @@
     <ClCompile Include="..\source\engine\resourcetypes\modelformats\RSDKModel.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\source\engine\resourcetypes\Resource.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\source\engine\resourcetypes\ResourceManager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -528,6 +534,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\include\engine\resourcetypes\modelformats\Importer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\engine\resourcetypes\Resource.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\include\engine\resourcetypes\ResourceType.h">

--- a/guides/Documentation.htm
+++ b/guides/Documentation.htm
@@ -1815,7 +1815,8 @@
                     <li><a href="#Reference_enums_KeyBind_DevRestartScene">KeyBind_DevRestartScene</a></li>
                     <li><a href="#Reference_enums_KeyBind_DevRecompile">KeyBind_DevRecompile</a></li>
                     <li><a href="#Reference_enums_KeyBind_DevPerfSnapshot">KeyBind_DevPerfSnapshot</a></li>
-                    <li><a href="#Reference_enums_KeyBind_Fullscreen">KeyBind_Fullscreen</a></li>
+                    <li><a href="#Reference_enums_KeyBind_DevLayerInfo">KeyBind_DevLayerInfo</a></li>
+                    <li><a href="#Reference_enums_KeyBind_DevResourceInfo">KeyBind_DevResourceInfo</a></li>
                     <li><a href="#Reference_enums_KeyBind_DevFastForward">KeyBind_DevFastForward</a></li>
                     <li><a href="#Reference_enums_KeyBind_DevFrameStepper">KeyBind_DevFrameStepper</a></li>
                     <li><a href="#Reference_enums_KeyBind_DevStepFrame">KeyBind_DevStepFrame</a></li>
@@ -11579,9 +11580,13 @@
         <h3 style="margin-bottom: 8px;"><code>KeyBind_DevPerfSnapshot</code></h2>
         <div style="margin-top: 8px; font-size: 14px;">Performance snapshot keybind. (dev)</div>
         </p>
-        <p id="Reference_enums_KeyBind_Fullscreen">
-        <h3 style="margin-bottom: 8px;"><code>KeyBind_Fullscreen</code></h2>
+        <p id="Reference_enums_KeyBind_DevLayerInfo">
+        <h3 style="margin-bottom: 8px;"><code>KeyBind_DevLayerInfo</code></h2>
         <div style="margin-top: 8px; font-size: 14px;">Scene layer info keybind. (dev)</div>
+        </p>
+        <p id="Reference_enums_KeyBind_DevResourceInfo">
+        <h3 style="margin-bottom: 8px;"><code>KeyBind_DevResourceInfo</code></h2>
+        <div style="margin-top: 8px; font-size: 14px;">Resource info keybind. (dev)</div>
         </p>
         <p id="Reference_enums_KeyBind_DevFastForward">
         <h3 style="margin-bottom: 8px;"><code>KeyBind_DevFastForward</code></h2>
@@ -12271,7 +12276,7 @@
         <h3 style="margin-bottom: 8px;"><code>WEEKDAY_SATURDAY</code></h2>
         <div style="margin-top: 8px; font-size: 14px;">The seventh day of the week.</div>
         </p>
-        <p>311 out of 311 enums have descriptions. </p>
+        <p>312 out of 312 enums have descriptions. </p>
         <hr/>
         <h3>Constants</h3>
         <p id="Reference_constants_NUM_CONTROLLER_BUTTONS">

--- a/guides/Documentation.htm
+++ b/guides/Documentation.htm
@@ -2065,10 +2065,10 @@
         <div style="margin-top: 8px; font-size: 14px;">Creates a new animator.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): The index of the sprite.</li>
+        <li>sprite (Resource): The index of the sprite.</li>
         <li>animationID (Integer): Which animation to use.</li>
         <li>frameID (Integer): Which frame to use.</li>
-        <li>unloadPolicy (Integer): When to unload the animator.</li>
+        <li>unloadPolicy (Integer): The <a href="#Reference_SCOPE_*">unload policy</a> of the animator.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns the index of the Animator.</div>
@@ -2089,7 +2089,7 @@
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>animator (Integer): The index of the animator.</li>
-        <li>sprite (Integer): The index of the sprite.</li>
+        <li>sprite (Resource): The index of the sprite.</li>
         <li>animationID (Integer): The animator's changed animation ID.</li>
         <li>frameID (Integer): The animator's changed frame ID.</li>
         <li>forceApply (Boolean): Whether to force the animation to go back to the frame if the animation is the same as the current animation.</li>
@@ -2107,13 +2107,13 @@
         <p id="Reference_functions_Animator_GetSprite">
         <h2 style="margin-bottom: 8px;">Animator.GetSprite</h2>
         <code>Animator.GetSprite(animator)</code>
-        <div style="margin-top: 8px; font-size: 14px;">Gets the sprite index of an animator.</div>
+        <div style="margin-top: 8px; font-size: 14px;">Gets the sprite of an animator.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>animator (Integer): The index of the animator.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
-        <div style="font-size: 14px;">Returns an Integer value.</div>
+        <div style="font-size: 14px;">Returns a Resource.</div>
         </p>
         <p id="Reference_functions_Animator_GetCurrentAnimation">
         <h2 style="margin-bottom: 8px;">Animator.GetCurrentAnimation</h2>
@@ -2228,12 +2228,12 @@
         </p>
         <p id="Reference_functions_Animator_SetSprite">
         <h2 style="margin-bottom: 8px;">Animator.SetSprite</h2>
-        <code>Animator.SetSprite(animator, spriteID)</code>
-        <div style="margin-top: 8px; font-size: 14px;">Sets the sprite index of an animator.</div>
+        <code>Animator.SetSprite(animator, sprite)</code>
+        <div style="margin-top: 8px; font-size: 14px;">Sets the sprite of an animator.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>animator (Integer): The animator index to change.</li>
-        <li>spriteID (Integer): The sprite ID.</li>
+        <li>sprite (Resource): A sprite resource, or <code>null</code>.</li>
         </ul>
         </p>
         <p id="Reference_functions_Animator_SetCurrentAnimation">
@@ -3226,7 +3226,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Draws a sprite.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): Index of the loaded sprite.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animation (Integer): Index of the animation entry.</li>
         <li>frame (Integer): Index of the frame in the animation entry.</li>
         <li>x (Number): X position of where to draw the sprite.</li>
@@ -3285,7 +3285,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Draws part of a sprite.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): Index of the loaded sprite.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animation (Integer): Index of the animation entry.</li>
         <li>frame (Integer): Index of the frame in the animation entry.</li>
         <li>x (Number): X position of where to draw the sprite.</li>
@@ -3309,7 +3309,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Draws an image.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>image (Integer): Index of the loaded image.</li>
+        <li>image (Resoure): An image resource.</li>
         <li>x (Number): X position of where to draw the image.</li>
         <li>y (Number): Y position of where to draw the image.</li>
         </ul>
@@ -3320,7 +3320,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Draws part of an image.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>image (Integer): Index of the loaded image.</li>
+        <li>image (Resource): An image resource.</li>
         <li>partX (Integer): X coordinate of part of image to draw.</li>
         <li>partY (Integer): Y coordinate of part of image to draw.</li>
         <li>partW (Integer): Width of part of image to draw.</li>
@@ -3335,7 +3335,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Draws an image, but sized.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>image (Integer): Index of the loaded image.</li>
+        <li>image (Resource): An image resource.</li>
         <li>x (Number): X position of where to draw the image.</li>
         <li>y (Number): Y position of where to draw the image.</li>
         <li>width (Number): Width to draw the image.</li>
@@ -3348,7 +3348,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Draws part of an image, but sized.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>image (Integer): Index of the loaded image.</li>
+        <li>image (Resource): An image resource.</li>
         <li>partX (Integer): X coordinate of part of image to draw.</li>
         <li>partY (Integer): Y coordinate of part of image to draw.</li>
         <li>partW (Integer): Width of part of image to draw.</li>
@@ -3541,7 +3541,7 @@
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>outArray (Array): Array to output size values to.</li>
-        <li>sprite (Integer): Index of the loaded sprite to be used as text.</li>
+        <li>sprite (Resource): The sprite resource to be used as text.</li>
         <li>text (String): Text to measure.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
@@ -3554,7 +3554,7 @@
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>outArray (Array): Array to output size values to.</li>
-        <li>sprite (Integer): Index of the loaded sprite to be used as text.</li>
+        <li>sprite (Resource): The sprite resource to be used as text.</li>
         <li>text (String): Text to measure.</li>
         <li>maxWidth (Number): Max width that a line can be.</li>
         <li>maxLines (Integer): Max number of lines to measure.</li>
@@ -3568,7 +3568,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Draws Extended UTF8 text using a sprite or font.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): Index of the loaded sprite to be used as text.</li>
+        <li>sprite (Resource): The sprite resource to be used as text.</li>
         <li>text (String): Text to draw.</li>
         <li>x (Number): X position of where to draw the text.</li>
         <li>y (Number): Y position of where to draw the text.</li>
@@ -3580,7 +3580,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Draws wrapped Extended UTF8 text using a sprite or font.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): Index of the loaded sprite to be used as text.</li>
+        <li>sprite (Resource): The sprite resource to be used as text.</li>
         <li>text (String): Text to draw.</li>
         <li>x (Number): X position of where to draw the tile.</li>
         <li>y (Number): Y position of where to draw the tile.</li>
@@ -3900,7 +3900,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Draws a textured triangle.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>image (Integer): Image to draw triangle with.</li>
+        <li>image (Resource): Image to draw triangle with.</li>
         <li>x1 (Number): X position of the first vertex.</li>
         <li>y1 (Number): Y position of the first vertex.</li>
         <li>x2 (Number): X position of the second vertex.</li>
@@ -3924,7 +3924,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Draws a textured quad.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>image (Integer): Image to draw quad with.</li>
+        <li>image (Resource): Image to draw quad with.</li>
         <li>x1 (Number): X position of the first vertex.</li>
         <li>y1 (Number): Y position of the first vertex.</li>
         <li>x2 (Number): X position of the second vertex.</li>
@@ -4173,11 +4173,11 @@
         </p>
         <p id="Reference_functions_Draw3D_Model">
         <h2 style="margin-bottom: 8px;">Draw3D.Model</h2>
-        <code>Draw3D.Model(modelIndex, animation, frame[, matrixModel, matrixNormal])</code>
+        <code>Draw3D.Model(model, animation, frame[, matrixModel, matrixNormal])</code>
         <div style="margin-top: 8px; font-size: 14px;">Draws a model.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>modelIndex (Integer): Index of loaded model.</li>
+        <li>model (Resource): A model resource.</li>
         <li>animation (Integer): Animation of model to draw.</li>
         <li>frame (Decimal): Frame of model to draw.</li>
         <li>matrixModel (Matrix): Matrix for transforming model coordinates to world space.</li>
@@ -4186,11 +4186,11 @@
         </p>
         <p id="Reference_functions_Draw3D_ModelSkinned">
         <h2 style="margin-bottom: 8px;">Draw3D.ModelSkinned</h2>
-        <code>Draw3D.ModelSkinned(modelIndex, armatureIndex[, matrixModel, matrixNormal])</code>
+        <code>Draw3D.ModelSkinned(model, armatureIndex[, matrixModel, matrixNormal])</code>
         <div style="margin-top: 8px; font-size: 14px;">Draws a skinned model.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>modelIndex (Integer): Index of loaded model.</li>
+        <li>model (Resource): A model resource.</li>
         <li>armatureIndex (Integer): Armature index to skin the model.</li>
         <li>matrixModel (Matrix): Matrix for transforming model coordinates to world space.</li>
         <li>matrixNormal (Matrix): Matrix for transforming model normals.</li>
@@ -4198,11 +4198,11 @@
         </p>
         <p id="Reference_functions_Draw3D_ModelSimple">
         <h2 style="margin-bottom: 8px;">Draw3D.ModelSimple</h2>
-        <code>Draw3D.ModelSimple(modelIndex, animation, frame, x, y, scale, rx, ry, rz)</code>
+        <code>Draw3D.ModelSimple(model, animation, frame, x, y, scale, rx, ry, rz)</code>
         <div style="margin-top: 8px; font-size: 14px;">Draws a model without using matrices.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>modelIndex (Integer): Index of loaded model.</li>
+        <li>model (Resource): A model resource.</li>
         <li>animation (Integer): Animation of model to draw.</li>
         <li>frame (Integer): Frame of model to draw.</li>
         <li>x (Number): X position</li>
@@ -4267,7 +4267,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Draws a sprite in 3D space.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): Index of the loaded sprite.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animation (Integer): Index of the animation entry.</li>
         <li>frame (Integer): Index of the frame in the animation entry.</li>
         <li>x (Number): X position of where to draw the sprite.</li>
@@ -4287,7 +4287,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Draws part of a sprite in 3D space.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): Index of the loaded sprite.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animation (Integer): Index of the animation entry.</li>
         <li>frame (Integer): Index of the frame in the animation entry.</li>
         <li>x (Number): X position of where to draw the sprite.</li>
@@ -4311,7 +4311,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Draws an image in 3D space.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>image (Integer): Index of the loaded image.</li>
+        <li>image (Resource): Index of the loaded image.</li>
         <li>x (Number): X position of where to draw the image.</li>
         <li>y (Number): Y position of where to draw the image.</li>
         <li>z (Number): Z position of where to draw the image.</li>
@@ -4325,7 +4325,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Draws part of an image in 3D space.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>image (Integer): Index of the loaded image.</li>
+        <li>image (Resource): Index of the loaded image.</li>
         <li>x (Number): X position of where to draw the image.</li>
         <li>y (Number): Y position of where to draw the image.</li>
         <li>z (Number): Z position of where to draw the image.</li>
@@ -4359,7 +4359,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Draws a textured triangle in 3D space. The texture source should be an image.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>image (Integer): Index of the loaded image.</li>
+        <li>image (Resource): Index of the loaded image.</li>
         <li>x1 (Number): X position of the first vertex.</li>
         <li>y1 (Number): Y position of the first vertex.</li>
         <li>z1 (Number): Z position of the first vertex.</li>
@@ -4388,7 +4388,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Draws a textured quad in 3D space. The texture source should be an image.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>image (Integer): Index of the loaded image.</li>
+        <li>image (Resource): Index of the loaded image.</li>
         <li>x1 (Number): X position of the first vertex.</li>
         <li>y1 (Number): Y position of the first vertex.</li>
         <li>z1 (Number): Z position of the first vertex.</li>
@@ -4423,7 +4423,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Draws a textured rectangle in 3D space. The texture source should be a sprite.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): Index of the loaded sprite.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animation (Integer): Index of the animation entry.</li>
         <li>frame (Integer): Index of the frame in the animation entry.</li>
         <li>flipX (Integer): Whether or not to flip the sprite horizontally.</li>
@@ -4967,7 +4967,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the width of the specified image.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>image (Integer): The image index to check.</li>
+        <li>image (Resource): An image resource.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns an Integer value.</div>
@@ -4978,7 +4978,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the height of the specified image.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>image (Integer): The image index to check.</li>
+        <li>image (Resource): An image resource.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns an Integer value.</div>
@@ -5997,7 +5997,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Returns how many vertices are in the model.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>model (Integer): The model index to check.</li>
+        <li>model (Resource): A model resource.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">The vertex count.</div>
@@ -6008,7 +6008,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Returns how many animations exist in the model.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>model (Integer): The model index to check.</li>
+        <li>model (Resource): A model resource.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns an Integer value.</div>
@@ -6019,7 +6019,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the name of the model animation with the specified index.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>model (Integer): The model index to check.</li>
+        <li>model (Resource): A model resource.</li>
         <li>animation (Integer): Index of the animation.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
@@ -6031,7 +6031,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the index of the model animation with the specified name.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>model (Integer): The model index to check.</li>
+        <li>model (Resource): A model resource.</li>
         <li>animationName (String): Name of the animation to find.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
@@ -6043,7 +6043,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Returns how many frames exist in the model. (Deprecated; use <code><a href="#Reference_functions_Model_GetAnimationLength">Model.GetAnimationLength</a></code> instead.)</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>model (Integer): The model index to check.</li>
+        <li>model (Resource): A model resource.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns an Integer value.</div>
@@ -6054,7 +6054,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Returns the length of the animation.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>model (Integer): The model index to check.</li>
+        <li>model (Resource): A model resource.</li>
         <li>animation (Integer): The animation index to check.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
@@ -6066,7 +6066,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Checks to see if the model has materials.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>model (Integer): The model index to check.</li>
+        <li>model (Resource): A model resource.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns <code>true</code> if the model has materials, <code>false</code> if otherwise. (Deprecated; use <code><a href="#Reference_functions_Model_GetMaterialCount">Model.GetMaterialCount</a></code> instead.)</div>
@@ -6077,7 +6077,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Checks to see if the model has bones.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>model (Integer): The model index to check.</li>
+        <li>model (Resource): A model resource.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns <code>true</code> if the model has bones, <code>false</code> if otherwise.</div>
@@ -6088,7 +6088,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Returns the amount of materials in the model.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>model (Integer): The model index to check.</li>
+        <li>model (Resource): A model resource.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns an Integer value.</div>
@@ -6099,7 +6099,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets a material from a model.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>model (Integer): The model index to check.</li>
+        <li>model (Resource): A model resource.</li>
         <li>material (String or Integer): The material name or ID to get.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
@@ -6111,7 +6111,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Creates an armature from the model.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>model (Integer): The model index.</li>
+        <li>model (Resource): A model resource.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns the index of the armature.</div>
@@ -6122,7 +6122,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Poses an armature.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>model (Integer): The model index.</li>
+        <li>model (Resource): A model resource.</li>
         <li>armature (Integer): The armature index to pose.</li>
         <li>animation (Integer): Animation to pose the armature.</li>
         <li>frame (Decimal): Frame to pose the armature.</li>
@@ -6134,7 +6134,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Resets an armature to its default pose.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>model (Integer): The model index.</li>
+        <li>model (Resource): A model resource.</li>
         <li>armature (Integer): The armature index to reset.</li>
         </ul>
         </p>
@@ -6144,7 +6144,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Deletes an armature from the model.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>model (Integer): The model index.</li>
+        <li>model (Resource): A model resource.</li>
         <li>armature (Integer): The armature index to delete.</li>
         </ul>
         </p>
@@ -6154,7 +6154,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Places the music onto the music stack and plays it.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>music (Integer): The music index to play.</li>
+        <li>music (Resource): The audio resource to play as music.</li>
         <li>loopPoint (Integer): Loop point in samples. Use <code><a href="#Reference_enums_AUDIO_LOOP_NONE">AUDIO_LOOP_NONE</a></code> to play the track once or <code><a href="#Reference_enums_AUDIO_LOOP_DEFAULT">AUDIO_LOOP_DEFAULT</a></code> to use the audio file's metadata. (<code><a href="#Reference_enums_AUDIO_LOOP_DEFAULT">AUDIO_LOOP_DEFAULT</a></code> is the default).</li>
         <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default).</li>
         <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default).</li>
@@ -6169,7 +6169,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Removes the music from the music stack, stopping it if currently playing.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>music (Integer): The music index to stop.</li>
+        <li>music (Resource): The music to stop.</li>
         </ul>
         </p>
         <p id="Reference_functions_Music_StopWithFadeOut">
@@ -6202,7 +6202,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Checks to see if the specified music is currently playing.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>music (Integer): The music index to play.</li>
+        <li>music (Resource): The music to play.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns a Boolean value.</div>
@@ -6213,7 +6213,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the position of the current track playing.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>music (Integer): The music index to get the current position (in seconds) of.</li>
+        <li>music (Resource): The music to get the current position (in seconds) of.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns a Decimal value.</div>
@@ -6232,10 +6232,10 @@
         <p id="Reference_functions_Music_GetLoopPoint">
         <h2 style="margin-bottom: 8px;">Music.GetLoopPoint</h2>
         <code>Music.GetLoopPoint(music)</code>
-        <div style="margin-top: 8px; font-size: 14px;">Gets the loop point of a music index, if it has one.</div>
+        <div style="margin-top: 8px; font-size: 14px;">Gets the loop point of an audio resource, if it has one.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>music (Integer): The music index to get the loop point.</li>
+        <li>music (Resource): The audio resource to get the loop point of.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns the loop point in samples, as an Integer value, or <code>null</code> if the audio does not have one.</div>
@@ -6243,10 +6243,10 @@
         <p id="Reference_functions_Music_SetLoopPoint">
         <h2 style="margin-bottom: 8px;">Music.SetLoopPoint</h2>
         <code>Music.SetLoopPoint(music, loopPoint)</code>
-        <div style="margin-top: 8px; font-size: 14px;">Sets the loop point of a music index.</div>
+        <div style="margin-top: 8px; font-size: 14px;">Sets the loop point of an audio resource.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>music (Integer): The music index to set the loop point.</li>
+        <li>music (Resource): The audio resource to set the loop point of.</li>
         <li>loopPoint (Integer): The loop point in samples, or <code>null</code> to remove the audio's loop point.</li>
         </ul>
         </p>
@@ -6343,7 +6343,7 @@
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>paletteIndex (Integer): Index of palette to load to.</li>
-        <li>image (Integer): Index of the loaded image.</li>
+        <li>image (Resource): An image resource.</li>
         </ul>
         </p>
         <p id="Reference_functions_Palette_GetColor">
@@ -6825,14 +6825,14 @@
         <p id="Reference_functions_Resources_LoadSprite">
         <h2 style="margin-bottom: 8px;">Resources.LoadSprite</h2>
         <code>Resources.LoadSprite(filename, unloadPolicy)</code>
-        <div style="margin-top: 8px; font-size: 14px;">Loads a Sprite resource, returning its Sprite index.</div>
+        <div style="margin-top: 8px; font-size: 14px;">Loads a Sprite resource.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>filename (String): Filename of the resource.</li>
-        <li>unloadPolicy (Integer): Whether to unload the resource at the end of the current Scene, or the game end.</li>
+        <li>unloadPolicy (Integer): The <a href="#Reference_SCOPE_*">unload policy</a> of the resource.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
-        <div style="font-size: 14px;">Returns the index of the Resource.</div>
+        <div style="font-size: 14px;">Returns a resource.</div>
         </p>
         <p id="Reference_functions_Resources_LoadDynamicSprite">
         <h2 style="margin-bottom: 8px;">Resources.LoadDynamicSprite</h2>
@@ -6842,92 +6842,92 @@
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>fallbackFolder (String): Folder to check if the sprite does not exist in the current Scene's resource folder.</li>
         <li>name (String): Name of the animation file within the resource folder.</li>
-        <li>unloadPolicy (Integer): Whether to unload the resource at the end of the current Scene, or the game end.</li>
+        <li>unloadPolicy (Integer): The <a href="#Reference_SCOPE_*">unload policy</a> of the resource.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
-        <div style="font-size: 14px;">Returns the index of the Resource.</div>
+        <div style="font-size: 14px;">Returns a resource.</div>
         </p>
         <p id="Reference_functions_Resources_LoadImage">
         <h2 style="margin-bottom: 8px;">Resources.LoadImage</h2>
         <code>Resources.LoadImage(filename, unloadPolicy)</code>
-        <div style="margin-top: 8px; font-size: 14px;">Loads an Image resource, returning its Image index.</div>
+        <div style="margin-top: 8px; font-size: 14px;">Loads an Image resource.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>filename (String): Filename of the resource.</li>
-        <li>unloadPolicy (Integer): Whether to unload the resource at the end of the current Scene, or the game end.</li>
+        <li>unloadPolicy (Integer): The <a href="#Reference_SCOPE_*">unload policy</a> of the resource.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
-        <div style="font-size: 14px;">Returns the index of the Resource.</div>
+        <div style="font-size: 14px;">Returns a resource.</div>
         </p>
         <p id="Reference_functions_Resources_LoadFont">
         <h2 style="margin-bottom: 8px;">Resources.LoadFont</h2>
         <code>Resources.LoadFont(filename, pixelSize, unloadPolicy)</code>
-        <div style="margin-top: 8px; font-size: 14px;">Loads a Font resource, returning its Font index.</div>
+        <div style="margin-top: 8px; font-size: 14px;">Loads a Font resource.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>filename (String):</li>
-        <li>pixelSize (Number):</li>
-        <li>unloadPolicy (Integer):</li>
+        <li>filename (String): Filename of the resource.</li>
+        <li>pixelSize (Number): The size of the font.</li>
+        <li>unloadPolicy (Integer): The <a href="#Reference_SCOPE_*">unload policy</a> of the resource.</li>
         </ul>
         </p>
         <p id="Reference_functions_Resources_LoadModel">
         <h2 style="margin-bottom: 8px;">Resources.LoadModel</h2>
         <code>Resources.LoadModel(filename, unloadPolicy)</code>
-        <div style="margin-top: 8px; font-size: 14px;">Loads Model resource, returning its Model index.</div>
+        <div style="margin-top: 8px; font-size: 14px;">Loads Model resource.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>filename (String): Filename of the resource.</li>
-        <li>unloadPolicy (Integer): Whether to unload the resource at the end of the current Scene, or the game end.</li>
+        <li>unloadPolicy (Integer): The <a href="#Reference_SCOPE_*">unload policy</a> of the resource.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
-        <div style="font-size: 14px;">Returns the index of the Resource.</div>
+        <div style="font-size: 14px;">Returns a resource.</div>
         </p>
         <p id="Reference_functions_Resources_LoadMusic">
         <h2 style="margin-bottom: 8px;">Resources.LoadMusic</h2>
         <code>Resources.LoadMusic(filename, unloadPolicy)</code>
-        <div style="margin-top: 8px; font-size: 14px;">Loads a Music resource, returning its Music index.</div>
+        <div style="margin-top: 8px; font-size: 14px;">Loads an Audio resource.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>filename (String): Filename of the resource.</li>
-        <li>unloadPolicy (Integer): Whether to unload the resource at the end of the current Scene, or the game end.</li>
+        <li>unloadPolicy (Integer): The <a href="#Reference_SCOPE_*">unload policy</a> of the resource.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
-        <div style="font-size: 14px;">Returns the index of the Resource.</div>
+        <div style="font-size: 14px;">Returns a resource.</div>
         </p>
         <p id="Reference_functions_Resources_LoadSound">
         <h2 style="margin-bottom: 8px;">Resources.LoadSound</h2>
         <code>Resources.LoadSound(filename, unloadPolicy)</code>
-        <div style="margin-top: 8px; font-size: 14px;">Loads a Sound resource, returning its Sound index.</div>
+        <div style="margin-top: 8px; font-size: 14px;">Loads an Audio resource.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>filename (String): Filename of the resource.</li>
-        <li>unloadPolicy (Integer): Whether to unload the resource at the end of the current Scene, or the game end.</li>
+        <li>unloadPolicy (Integer): The <a href="#Reference_SCOPE_*">unload policy</a> of the resource.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
-        <div style="font-size: 14px;">Returns the index of the Resource.</div>
+        <div style="font-size: 14px;">Returns a resource.</div>
         </p>
         <p id="Reference_functions_Resources_LoadVideo">
         <h2 style="margin-bottom: 8px;">Resources.LoadVideo</h2>
         <code>Resources.LoadVideo(filename, unloadPolicy)</code>
-        <div style="margin-top: 8px; font-size: 14px;">Loads a Video resource, returning its Video index.</div>
+        <div style="margin-top: 8px; font-size: 14px;">Loads a Video resource.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>filename (String): Filename of the resource.</li>
-        <li>unloadPolicy (Integer): Whether to unload the resource at the end of the current Scene, or the game end.</li>
+        <li>unloadPolicy (Integer): The <a href="#Reference_SCOPE_*">unload policy</a> of the resource.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
-        <div style="font-size: 14px;">Returns the index of the Resource.</div>
+        <div style="font-size: 14px;">Returns a resource.</div>
         </p>
         <p id="Reference_functions_Resources_FileExists">
         <h2 style="margin-bottom: 8px;">Resources.FileExists</h2>
         <code>Resources.FileExists(filename)</code>
-        <div style="margin-top: 8px; font-size: 14px;">Checks to see if a Resource exists with the given filename.</div>
+        <div style="margin-top: 8px; font-size: 14px;">Checks if a resource with the given filename exists.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>filename (String): The given filename.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
-        <div style="font-size: 14px;">Returns <code>true</code> if the Resource exists, <code>false</code> if otherwise.</div>
+        <div style="font-size: 14px;">Returns <code>true</code> if the resource exists, <code>false</code> if otherwise.</div>
         </p>
         <p id="Reference_functions_Resources_ReadAllText">
         <h2 style="margin-bottom: 8px;">Resources.ReadAllText</h2>
@@ -7612,12 +7612,12 @@
         </p>
         <p id="Reference_functions_Scene_SetTileAnimSequenceFromSprite">
         <h2 style="margin-bottom: 8px;">Scene.SetTileAnimSequenceFromSprite</h2>
-        <code>Scene.SetTileAnimSequenceFromSprite(tileID, spriteIndex, animationIndex)</code>
+        <code>Scene.SetTileAnimSequenceFromSprite(tileID, sprite, animationIndex)</code>
         <div style="margin-top: 8px; font-size: 14px;">Sets an animation sequence for a tile ID.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>tileID (Integer): Which tile ID to add an animated sequence to.</li>
-        <li>spriteIndex (Integer): Sprite index. (<code>null</code> to disable)</li>
+        <li>sprite (Resource): A sprite resource. (<code>null</code> to disable)</li>
         <li>animationIndex (Integer): Animation index in sprite.</li>
         </ul>
         </p>
@@ -7970,7 +7970,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Creates a 3D scene.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>unloadPolicy (Integer): Whether or not to delete the 3D scene at the end of the current Scene, or the game end.</li>
+        <li>unloadPolicy (Integer): The <a href="#Reference_SCOPE_*">unload policy</a> of the 3D scene.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">The index of the created 3D scene.</div>
@@ -8564,7 +8564,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Plays a sound either once or in a loop.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sound (Integer): The sound index to play.</li>
+        <li>sound (Resource): The audio resource to play as a sound.</li>
         <li>loopPoint (Integer): Loop point in samples. Use <code><a href="#Reference_enums_AUDIO_LOOP_NONE">AUDIO_LOOP_NONE</a></code> to play the sound once or <code><a href="#Reference_enums_AUDIO_LOOP_DEFAULT">AUDIO_LOOP_DEFAULT</a></code> to use the audio file's metadata. (<code><a href="#Reference_enums_AUDIO_LOOP_DEFAULT">AUDIO_LOOP_DEFAULT</a></code> is the default).</li>
         <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)</li>
         <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)</li>
@@ -8579,7 +8579,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Stops an actively playing sound.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sound (Integer): The sound index to stop.</li>
+        <li>sound (Resource): The sound to stop.</li>
         </ul>
         </p>
         <p id="Reference_functions_Sound_Pause">
@@ -8588,7 +8588,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Pauses an actively playing sound.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sound (Integer): The sound index to pause.</li>
+        <li>sound (Resource): The sound to pause.</li>
         </ul>
         </p>
         <p id="Reference_functions_Sound_Resume">
@@ -8597,7 +8597,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Unpauses a paused sound.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sound (Integer): The sound index to resume.</li>
+        <li>sound (Resource): The sound to resume.</li>
         </ul>
         </p>
         <p id="Reference_functions_Sound_StopAll">
@@ -8621,7 +8621,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Checks whether a sound is currently playing or not.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sound (Integer): The sound index.</li>
+        <li>sound (Resource): An audio resource.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns a Boolean value.</div>
@@ -8632,7 +8632,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Plays a sound once or loops it, without interrupting channels playing the same sound.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sound (Integer): The sound index to play.</li>
+        <li>sound (Resource): The audio resource to play as a sound.</li>
         <li>loopPoint (Integer): Loop point in samples. Use <code><a href="#Reference_enums_AUDIO_LOOP_NONE">AUDIO_LOOP_NONE</a></code> to play the sound once or <code><a href="#Reference_enums_AUDIO_LOOP_DEFAULT">AUDIO_LOOP_DEFAULT</a></code> to use the audio file's metadata. (<code><a href="#Reference_enums_AUDIO_LOOP_DEFAULT">AUDIO_LOOP_DEFAULT</a></code> is the default).</li>
         <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)</li>
         <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)</li>
@@ -8648,7 +8648,7 @@
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>channel (Integer): The channel index.</li>
-        <li>sound (Integer): The sound index to play.</li>
+        <li>sound (Resource): The audio resource to play as a sound.</li>
         <li>loopPoint (Integer): Loop point in samples. Use <code><a href="#Reference_enums_AUDIO_LOOP_NONE">AUDIO_LOOP_NONE</a></code> to play the sound once or <code><a href="#Reference_enums_AUDIO_LOOP_DEFAULT">AUDIO_LOOP_DEFAULT</a></code> to use the audio file's metadata. (<code><a href="#Reference_enums_AUDIO_LOOP_DEFAULT">AUDIO_LOOP_DEFAULT</a></code> is the default).</li>
         <li>panning (Decimal): Control the panning of the audio. -1.0 makes it sound in left ear only, 1.0 makes it sound in right ear, and closer to 0.0 centers it. (0.0 is the default.)</li>
         <li>speed (Decimal): Control the speed of the audio. > 1.0 makes it faster, < 1.0 is slower, 1.0 is normal speed. (1.0 is the default.)</li>
@@ -8713,10 +8713,10 @@
         <p id="Reference_functions_Sound_GetLoopPoint">
         <h2 style="margin-bottom: 8px;">Sound.GetLoopPoint</h2>
         <code>Sound.GetLoopPoint(sound)</code>
-        <div style="margin-top: 8px; font-size: 14px;">Gets the loop point of a sound index, if it has one.</div>
+        <div style="margin-top: 8px; font-size: 14px;">Gets the loop point of an audio resource, if it has one.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sound (Integer): The sound index to get the loop point.</li>
+        <li>sound (Resource): The audio resource to get the loop point of.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns the loop point in samples, as an Integer value, or <code>null</code> if the audio does not have one.</div>
@@ -8724,10 +8724,10 @@
         <p id="Reference_functions_Sound_SetLoopPoint">
         <h2 style="margin-bottom: 8px;">Sound.SetLoopPoint</h2>
         <code>Sound.SetLoopPoint(sound, loopPoint)</code>
-        <div style="margin-top: 8px; font-size: 14px;">Sets the loop point of a sound index.</div>
+        <div style="margin-top: 8px; font-size: 14px;">Sets the loop point of an audio resource.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sound (Integer): The sound index to set the loop point.</li>
+        <li>sound (Resource): The audio resource to set the loop point of.</li>
         <li>loopPoint (Integer): The loop point in samples, or <code>null</code> to remove the audio's loop point.</li>
         </ul>
         </p>
@@ -8737,7 +8737,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the amount of animations in the sprite.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): The sprite index to check.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns the amount of animations in the sprite.</div>
@@ -8748,7 +8748,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the name of the specified animation index in the sprite.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): The sprite index to check.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animationIndex (Integer): The animation index.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
@@ -8760,7 +8760,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the first animation in the sprite which matches the specified name.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): The sprite index to check.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>name (String): The animation name to search for.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
@@ -8772,9 +8772,9 @@
         <div style="margin-top: 8px; font-size: 14px;">Checks if an animation and frame is valid within a sprite.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): The sprite index to check.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animation (Integer): The animation index to check.</li>
-        <li>frame (Integer): The sprite index to check.</li>
+        <li>frame (Integer): The frame index to check.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns whether the frame is valid.</div>
@@ -8785,7 +8785,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the index of the frame that the specified animation will loop back to when it finishes.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): The sprite index to check.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animation (Integer): The animation index of the sprite to check.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
@@ -8797,7 +8797,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the amount of frames in the specified animation.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): The sprite index to check.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animation (Integer): The animation index of the sprite to check.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
@@ -8809,7 +8809,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the frame duration of the specified sprite frame.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): The sprite index to check.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animation (Integer): The animation index of the sprite to check.</li>
         <li>frame (Integer): The frame index of the animation to check.</li>
         </ul>
@@ -8822,7 +8822,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the animation speed of the specified animation.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): The sprite index to check.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animation (Integer): The animation index of the sprite to check.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
@@ -8834,7 +8834,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the frame width of the specified sprite frame.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): The sprite index to check.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animation (Integer): The animation index of the sprite to check.</li>
         <li>frame (Integer): The frame index of the animation to check.</li>
         </ul>
@@ -8847,7 +8847,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the frame height of the specified sprite frame.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): The sprite index to check.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animation (Integer): The animation index of the sprite to check.</li>
         <li>frame (Integer): The frame index of the animation to check.</li>
         </ul>
@@ -8860,7 +8860,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the frame ID of the specified sprite frame.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): The sprite index to check.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animation (Integer): The animation index of the sprite to check.</li>
         <li>frame (Integer): The frame index of the animation to check.</li>
         </ul>
@@ -8873,7 +8873,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the X offset of the specified sprite frame.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): The sprite index to check.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animation (Integer): The animation index of the sprite to check.</li>
         <li>frame (Integer): The frame index of the animation to check.</li>
         </ul>
@@ -8886,7 +8886,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the Y offset of the specified sprite frame.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): The sprite index to check.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animation (Integer): The animation index of the sprite to check.</li>
         <li>frame (Integer): The frame index of the animation to check.</li>
         </ul>
@@ -8899,7 +8899,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the hitbox of an animation and frame of a sprite.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): The sprite index to check.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animationID (Integer): The animation index of the sprite to check.</li>
         <li>frame (Integer): The frame index of the animation to check.</li>
         <li>hitboxID (Integer): The hitbox index of the animation to check. Defaults to <code>0</code>.</li>
@@ -8911,7 +8911,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Converts a sprite's colors to the ones in the specified palette index.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): The sprite index.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>paletteIndex (Integer): The palette index.</li>
         </ul>
         </p>
@@ -8921,7 +8921,7 @@
         <div style="margin-top: 8px; font-size: 14px;">Removes a sprite's palette.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Integer): The sprite index.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         </ul>
         </p>
         <p id="Reference_functions_Stream_FromResource">
@@ -9506,12 +9506,12 @@
         </p>
         <p id="Reference_functions_TileInfo_SetSpriteInfo">
         <h2 style="margin-bottom: 8px;">TileInfo.SetSpriteInfo</h2>
-        <code>TileInfo.SetSpriteInfo(tileID, spriteIndex, animationIndex, frameIndex)</code>
+        <code>TileInfo.SetSpriteInfo(tileID, sprite, animationIndex, frameIndex)</code>
         <div style="margin-top: 8px; font-size: 14px;">Sets the sprite, animation, and frame to use for specified tile.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>tileID (Integer): ID of tile to check.</li>
-        <li>spriteIndex (Integer): Sprite index. (<code>-1</code> for default tile sprite)</li>
+        <li>sprite (Resource): A sprite resource. (<code>null</code> for default tile sprite)</li>
         <li>animationIndex (Integer): Animation index.</li>
         <li>frameIndex (Integer): Frame index. (<code>-1</code> for default tile frame)</li>
         </ul>
@@ -9652,7 +9652,7 @@
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>numVertices (Integer): The initial capacity of this vertex buffer.</li>
-        <li>unloadPolicy (Integer): Whether or not to delete the vertex buffer at the end of the current Scene, or the game end.</li>
+        <li>unloadPolicy (Integer): The <a href="#Reference_SCOPE_*">unload policy</a> of the vertex buffer.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">The index of the created vertex buffer.</div>
@@ -10646,9 +10646,9 @@
         </p>
         <p id="Reference_fields_instance_Sprite">
         <h3 style="margin-bottom: 8px;"><code>instance.Sprite</code></h2>
-        <div style="font-size: 14px;"><b>Type: </b>Integer (Resource)</div>
-        <div style="font-size: 14px;"><b>Default: </b><code>-1</code></div>
-        <div style="margin-top: 8px; font-size: 14px;">The sprite index of the entity.</div>
+        <div style="font-size: 14px;"><b>Type: </b>Resource</div>
+        <div style="font-size: 14px;"><b>Default: </b><code>null</code></div>
+        <div style="margin-top: 8px; font-size: 14px;">The sprite Resource of the entity.</div>
         </p>
         <p id="Reference_fields_instance_CurrentAnimation">
         <h3 style="margin-bottom: 8px;"><code>instance.CurrentAnimation</code></h2>
@@ -12395,7 +12395,7 @@
         </p>
         <p id="Reference_globals_LowPassFilter">
         <h3 style="margin-bottom: 8px;"><code>LowPassFilter</code></h2>
-        <div style="margin-top: 8px; font-size: 14px;">The low pass filter of the audio.</div>
+        <div style="margin-top: 8px; font-size: 14px;">The audio low pass filter value.</div>
         </p>
         <p id="Reference_globals_CurrentView">
         <h3 style="margin-bottom: 8px;"><code>CurrentView</code></h2>

--- a/guides/Documentation.htm
+++ b/guides/Documentation.htm
@@ -2062,11 +2062,11 @@
         <h3>Class methods</h3>
         <p id="Reference_functions_Animator_Create">
         <h2 style="margin-bottom: 8px;">Animator.Create</h2>
-        <code>Animator.Create(sprite, animationID, frameID, unloadPolicy)</code>
+        <code>Animator.Create([sprite, animationID, frameID, unloadPolicy])</code>
         <div style="margin-top: 8px; font-size: 14px;">Creates a new animator.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>sprite (Resource): The index of the sprite.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animationID (Integer): Which animation to use.</li>
         <li>frameID (Integer): Which frame to use.</li>
         <li>unloadPolicy (Integer): The <a href="#Reference_SCOPE_*">unload policy</a> of the animator.</li>
@@ -2090,7 +2090,7 @@
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>animator (Integer): The index of the animator.</li>
-        <li>sprite (Resource): The index of the sprite.</li>
+        <li>sprite (Resource): A sprite resource.</li>
         <li>animationID (Integer): The animator's changed animation ID.</li>
         <li>frameID (Integer): The animator's changed frame ID.</li>
         <li>forceApply (Boolean): Whether to force the animation to go back to the frame if the animation is the same as the current animation.</li>

--- a/guides/Documentation.htm
+++ b/guides/Documentation.htm
@@ -6910,7 +6910,7 @@
         <p id="Reference_functions_Resources_LoadVideo">
         <h2 style="margin-bottom: 8px;">Resources.LoadVideo</h2>
         <code>Resources.LoadVideo(filename, unloadPolicy)</code>
-        <div style="margin-top: 8px; font-size: 14px;">Loads a Video resource.</div>
+        <div style="margin-top: 8px; font-size: 14px;">Loads a Media resource.</div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
         <li>filename (String): Filename of the resource.</li>

--- a/include/Engine/Audio/AudioManager.h
+++ b/include/Engine/Audio/AudioManager.h
@@ -96,6 +96,7 @@ public:
 	static void AudioUnpauseAll();
 	static void AudioPauseAll();
 	static void AudioStopAll();
+	static void Unload(ISound* audio);
 	static bool IsOriginPlaying(void* origin, ISound* audio);
 	static void StopOriginSound(void* origin, ISound* audio);
 	static void StopAllOriginSounds(void* origin);

--- a/include/Engine/Bytecode/GarbageCollector.h
+++ b/include/Engine/Bytecode/GarbageCollector.h
@@ -12,7 +12,7 @@ private:
 	static void GrayHashMapItem(Uint32, VMValue value);
 	static void GrayHashMap(void* pointer);
 	static void BlackenObject(Obj* object);
-	static void CollectResources();
+	static void GrayResource(void* ptr);
 
 public:
 	static vector<Obj*> GrayList;

--- a/include/Engine/Bytecode/StandardLibrary.h
+++ b/include/Engine/Bytecode/StandardLibrary.h
@@ -7,6 +7,11 @@
 
 class StandardLibrary {
 public:
+	static int ExpectedTypeError(VMValue value, Uint32 expectedType, Uint32 threadID);
+	static int ExpectedObjectTypeError(VMValue value, Uint32 expectedType, Uint32 threadID);
+	static int ExpectedTypeError(int index, VMValue value, Uint32 expectedType, Uint32 threadID);
+	static int ExpectedObjectTypeError(int index, VMValue value, Uint32 expectedType, Uint32 threadID);
+	static bool ValidateResource(void* ptr, Uint8 type, Uint32 threadID);
 	static int GetInteger(VMValue* args, int index, Uint32 threadID);
 	static float GetDecimal(VMValue* args, int index, Uint32 threadID);
 	static char* GetString(VMValue* args, int index, Uint32 threadID);
@@ -14,7 +19,7 @@ public:
 	static ObjArray* GetArray(VMValue* args, int index, Uint32 threadID);
 	static ObjMap* GetMap(VMValue* args, int index, Uint32 threadID);
 	static ISprite* GetSprite(VMValue* args, int index, Uint32 threadID);
-	static ISound* GetSound(VMValue* args, int index, Uint32 threadID);
+	static ISound* GetAudio(VMValue* args, int index, Uint32 threadID);
 	static ObjInstance* GetInstance(VMValue* args, int index, Uint32 threadID);
 	static ObjFunction* GetFunction(VMValue* args, int index, Uint32 threadID);
 	static void CheckArgCount(int argCount, int expects);

--- a/include/Engine/Bytecode/StandardLibrary.h
+++ b/include/Engine/Bytecode/StandardLibrary.h
@@ -18,6 +18,7 @@ public:
 	static ObjString* GetVMString(VMValue* args, int index, Uint32 threadID);
 	static ObjArray* GetArray(VMValue* args, int index, Uint32 threadID);
 	static ObjMap* GetMap(VMValue* args, int index, Uint32 threadID);
+	static void* GetResource(VMValue* args, int index, Uint32 threadID);
 	static ISprite* GetSprite(VMValue* args, int index, Uint32 threadID);
 	static ISound* GetAudio(VMValue* args, int index, Uint32 threadID);
 	static ObjInstance* GetInstance(VMValue* args, int index, Uint32 threadID);

--- a/include/Engine/Bytecode/TypeImpl/ResourceImpl.h
+++ b/include/Engine/Bytecode/TypeImpl/ResourceImpl.h
@@ -9,6 +9,8 @@ public:
 	static ObjClass* Class;
 
 	static void Init();
+	static Obj* VM_New(void);
+	static VMValue VM_Initializer(int argCount, VMValue* args, Uint32 threadID);
 	static bool VM_PropertyGet(Obj* object, Uint32 hash, VMValue* result, Uint32 threadID);
 };
 

--- a/include/Engine/Bytecode/TypeImpl/ResourceImpl.h
+++ b/include/Engine/Bytecode/TypeImpl/ResourceImpl.h
@@ -11,7 +11,9 @@ public:
 	static void Init();
 	static Obj* VM_New(void);
 	static VMValue VM_Initializer(int argCount, VMValue* args, Uint32 threadID);
+
 	static bool VM_PropertyGet(Obj* object, Uint32 hash, VMValue* result, Uint32 threadID);
+	static VMValue VM_Unload(int argCount, VMValue* args, Uint32 threadID);
 };
 
 #endif /* ENGINE_BYTECODE_TYPEIMPL_RESOURCEIMPL_H */

--- a/include/Engine/Bytecode/TypeImpl/ResourceImpl.h
+++ b/include/Engine/Bytecode/TypeImpl/ResourceImpl.h
@@ -1,0 +1,15 @@
+#ifndef ENGINE_BYTECODE_TYPEIMPL_RESOURCEIMPL_H
+#define ENGINE_BYTECODE_TYPEIMPL_RESOURCEIMPL_H
+
+#include <Engine/Bytecode/Types.h>
+#include <Engine/Includes/Standard.h>
+
+class ResourceImpl {
+public:
+	static ObjClass* Class;
+
+	static void Init();
+	static bool VM_PropertyGet(Obj* object, Uint32 hash, VMValue* result, Uint32 threadID);
+};
+
+#endif /* ENGINE_BYTECODE_TYPEIMPL_RESOURCEIMPL_H */

--- a/include/Engine/Bytecode/TypeImpl/ResourceImpl.h
+++ b/include/Engine/Bytecode/TypeImpl/ResourceImpl.h
@@ -13,6 +13,7 @@ public:
 	static VMValue VM_Initializer(int argCount, VMValue* args, Uint32 threadID);
 
 	static bool VM_PropertyGet(Obj* object, Uint32 hash, VMValue* result, Uint32 threadID);
+	static VMValue VM_Reload(int argCount, VMValue* args, Uint32 threadID);
 	static VMValue VM_Unload(int argCount, VMValue* args, Uint32 threadID);
 };
 

--- a/include/Engine/FontFace.h
+++ b/include/Engine/FontFace.h
@@ -10,6 +10,7 @@
 class FontFace {
 public:
 	static ISprite* SpriteFromFont(Stream* stream, int pixelSize, const char* filename);
+	static ISprite* SpriteFromFont(const char* filename, int pixelSize);
 };
 
 #endif /* ENGINE_FONTFACE_H */

--- a/include/Engine/Rendering/Material.h
+++ b/include/Engine/Rendering/Material.h
@@ -3,12 +3,10 @@
 
 #include <Engine/Includes/Standard.h>
 
-#include <Engine/ResourceTypes/Image.h>
-
 class Material {
 private:
-	static Image* TryLoadForModel(std::string imagePath, const char* parentDirectory);
-	void ReleaseImage(Image* imagePtr);
+	static void* TryLoadForModel(std::string imagePath, const char* parentDirectory);
+	void ReleaseImage(void* imagePtr);
 
 public:
 	char* Name = nullptr;
@@ -23,18 +21,18 @@ public:
 	char* TextureSpecularName = nullptr;
 	char* TextureAmbientName = nullptr;
 	char* TextureEmissiveName = nullptr;
-	Image* TextureDiffuse = nullptr;
-	Image* TextureSpecular = nullptr;
-	Image* TextureAmbient = nullptr;
-	Image* TextureEmissive = nullptr;
-	void* Object = nullptr;
+	void* TextureDiffuse = nullptr;
+	void* TextureSpecular = nullptr;
+	void* TextureAmbient = nullptr;
+	void* TextureEmissive = nullptr;
+	void* VMObject = nullptr;
 
 	static Material* Create(char* name);
 	static void Remove(Material* material);
 	static std::vector<Material*> List;
 
-	static Image* LoadForModel(string imagePath, const char* parentDirectory);
-	static Image* LoadForModel(const char* imagePath, const char* parentDirectory);
+	static void* LoadForModel(string imagePath, const char* parentDirectory);
+	static void* LoadForModel(const char* imagePath, const char* parentDirectory);
 
 	Material(char* name);
 	void Dispose();

--- a/include/Engine/Rendering/Software/SoftwareRenderer.h
+++ b/include/Engine/Rendering/Software/SoftwareRenderer.h
@@ -1,6 +1,7 @@
 #ifndef ENGINE_RENDERING_SOFTWARE_SOFTWARERENDERER_H
 #define ENGINE_RENDERING_SOFTWARE_SOFTWARERENDERER_H
 
+#include <Engine/Graphics.h>
 #include <Engine/Includes/HashMap.h>
 #include <Engine/Includes/Standard.h>
 #include <Engine/Includes/StandardSDL2.h>

--- a/include/Engine/Rendering/TextureReference.h
+++ b/include/Engine/Rendering/TextureReference.h
@@ -10,8 +10,8 @@ public:
 	unsigned References;
 
 	TextureReference(Texture* ptr);
-	void AddRef();
-	bool TakeRef();
+	void TakeRef();
+	bool ReleaseRef();
 };
 
 #endif /* ENGINE_RENDERING_TEXTUREREFERENCE_H */

--- a/include/Engine/ResourceTypes/IModel.h
+++ b/include/Engine/ResourceTypes/IModel.h
@@ -1,7 +1,6 @@
 #ifndef ENGINE_RESOURCETYPES_IMODEL_H
 #define ENGINE_RESOURCETYPES_IMODEL_H
 
-#include <Engine/Graphics.h>
 #include <Engine/IO/Stream.h>
 #include <Engine/Includes/Standard.h>
 #include <Engine/Rendering/3D.h>

--- a/include/Engine/ResourceTypes/IModel.h
+++ b/include/Engine/ResourceTypes/IModel.h
@@ -22,9 +22,10 @@ public:
 	bool UseVertexAnimation;
 	Armature* BaseArmature;
 	Matrix4x4* GlobalInverseMatrix;
+	bool LoadFailed;
 
-	IModel();
 	IModel(const char* filename);
+	static bool IsFile(Stream* stream);
 	bool Load(Stream* stream, const char* filename);
 	size_t FindMaterial(const char* name);
 	size_t AddMaterial(Material* material);

--- a/include/Engine/ResourceTypes/ISound.h
+++ b/include/Engine/ResourceTypes/ISound.h
@@ -4,7 +4,14 @@
 #include <Engine/Audio/AudioPlayback.h>
 #include <Engine/Includes/Standard.h>
 #include <Engine/Includes/StandardSDL2.h>
+#include <Engine/IO/Stream.h>
 #include <Engine/ResourceTypes/SoundFormats/SoundFormat.h>
+
+enum {
+	AUDIO_FORMAT_UNKNOWN,
+	AUDIO_FORMAT_OGG,
+	AUDIO_FORMAT_WAV
+};
 
 #define AUDIO_LOOP_NONE (-2)
 #define AUDIO_LOOP_DEFAULT (-1)
@@ -21,6 +28,8 @@ public:
 
 	ISound(const char* filename);
 	ISound(const char* filename, bool streamFromFile);
+	static Uint8 DetectFormat(Stream* stream);
+	static bool IsFile(Stream* stream);
 	void Load(const char* filename, bool streamFromFile);
 	AudioPlayback* CreatePlayer();
 	void Dispose();

--- a/include/Engine/ResourceTypes/ISound.h
+++ b/include/Engine/ResourceTypes/ISound.h
@@ -1,7 +1,6 @@
 #ifndef ENGINE_RESOURCETYPES_ISOUND_H
 #define ENGINE_RESOURCETYPES_ISOUND_H
 
-#include <Engine/Application.h>
 #include <Engine/Audio/AudioPlayback.h>
 #include <Engine/Includes/Standard.h>
 #include <Engine/Includes/StandardSDL2.h>

--- a/include/Engine/ResourceTypes/ISprite.h
+++ b/include/Engine/ResourceTypes/ISprite.h
@@ -2,6 +2,7 @@
 #define ENGINE_RESOURCETYPES_ISPRITE_H
 
 #include <Engine/Includes/Standard.h>
+#include <Engine/IO/Stream.h>
 #include <Engine/Rendering/Texture.h>
 #include <Engine/Sprites/Animation.h>
 
@@ -56,6 +57,7 @@ public:
 	void RefreshGraphicsID();
 	void ConvertToRGBA();
 	void ConvertToPalette(unsigned paletteNumber);
+	static bool IsFile(Stream* stream);
 	bool LoadAnimation(const char* filename);
 	int FindAnimation(const char* animname);
 	void LinkAnimation(vector<Animation> ani);

--- a/include/Engine/ResourceTypes/Image.h
+++ b/include/Engine/ResourceTypes/Image.h
@@ -2,8 +2,16 @@
 #define ENGINE_RESOURCETYPES_IMAGE_H
 
 #include <Engine/Includes/Standard.h>
+#include <Engine/IO/Stream.h>
 #include <Engine/Rendering/GameTexture.h>
 #include <Engine/Rendering/Texture.h>
+
+enum {
+	IMAGE_FORMAT_UNKNOWN,
+	IMAGE_FORMAT_PNG,
+	IMAGE_FORMAT_GIF,
+	IMAGE_FORMAT_JPEG
+};
 
 class Image {
 private:
@@ -21,6 +29,8 @@ public:
 	void Dispose();
 	~Image();
 
+	static Uint8 DetectFormat(Stream* stream);
+	static bool IsFile(Stream* stream);
 	static Texture* LoadTextureFromResource(const char* filename);
 };
 

--- a/include/Engine/ResourceTypes/Image.h
+++ b/include/Engine/ResourceTypes/Image.h
@@ -19,13 +19,10 @@ private:
 
 public:
 	int ID = -1;
-	int References = 0;
 	char* Filename;
 	Texture* TexturePtr = NULL;
 
 	Image(const char* filename);
-	void TakeRef();
-	bool ReleaseRef();
 	void Dispose();
 	~Image();
 

--- a/include/Engine/ResourceTypes/Image.h
+++ b/include/Engine/ResourceTypes/Image.h
@@ -16,8 +16,8 @@ public:
 	Texture* TexturePtr = NULL;
 
 	Image(const char* filename);
-	void AddRef();
-	bool TakeRef();
+	void TakeRef();
+	bool ReleaseRef();
 	void Dispose();
 	~Image();
 

--- a/include/Engine/ResourceTypes/Image.h
+++ b/include/Engine/ResourceTypes/Image.h
@@ -18,7 +18,6 @@ private:
 	static Image* New(const char* filename);
 
 public:
-	int ID = -1;
 	char* Filename;
 	Texture* TexturePtr = NULL;
 

--- a/include/Engine/ResourceTypes/ImageFormats/GIF.h
+++ b/include/Engine/ResourceTypes/ImageFormats/GIF.h
@@ -26,7 +26,7 @@ private:
 public:
 	vector<Uint32*> Frames;
 
-	static GIF* Load(const char* filename);
+	static GIF* Load(Stream* stream);
 	static bool Save(GIF* gif, const char* filename);
 	bool Save(const char* filename);
 	~GIF();

--- a/include/Engine/ResourceTypes/ImageFormats/JPEG.h
+++ b/include/Engine/ResourceTypes/ImageFormats/JPEG.h
@@ -7,7 +7,7 @@
 
 class JPEG : public ImageFormat {
 public:
-	static JPEG* Load(const char* filename);
+	static JPEG* Load(Stream* stream);
 	static bool Save(JPEG* jpeg, const char* filename);
 	bool Save(const char* filename);
 	~JPEG();

--- a/include/Engine/ResourceTypes/ImageFormats/PNG.h
+++ b/include/Engine/ResourceTypes/ImageFormats/PNG.h
@@ -7,7 +7,7 @@
 
 class PNG : public ImageFormat {
 public:
-	static PNG* Load(const char* filename);
+	static PNG* Load(Stream* stream);
 	void ReadPixelDataARGB(Uint32* pixelData, int num_channels);
 	void ReadPixelBitstream(Uint8* pixelData, size_t bit_depth);
 	static bool Save(PNG* png, const char* filename);

--- a/include/Engine/ResourceTypes/ModelFormats/Importer.h
+++ b/include/Engine/ResourceTypes/ModelFormats/Importer.h
@@ -13,12 +13,14 @@ private:
 	static Skeleton* LoadBones(IModel* imodel, Mesh* mesh, struct aiMesh* amesh);
 	static SkeletalAnim*
 	LoadAnimation(IModel* imodel, ModelAnim* parentAnim, struct aiAnimation* aanim);
+	static int GetConversionFlags();
 	static bool DoConversion(const struct aiScene* scene, IModel* imodel);
 
 public:
 	static vector<int> MeshIDs;
 	static char* ParentDirectory;
 
+	static bool IsValid(Stream* stream);
 	static bool Convert(IModel* model, Stream* stream, const char* path);
 };
 

--- a/include/Engine/ResourceTypes/SoundFormats/OGG.h
+++ b/include/Engine/ResourceTypes/SoundFormats/OGG.h
@@ -3,6 +3,7 @@
 
 #include <Engine/Includes/Standard.h>
 #include <Engine/Includes/StandardSDL2.h>
+#include <Engine/IO/Stream.h>
 #include <Engine/ResourceTypes/SoundFormats/SoundFormat.h>
 
 class OGG : public SoundFormat {
@@ -17,7 +18,7 @@ private:
 	static long StaticTell(void* ptr);
 
 public:
-	static SoundFormat* Load(const char* filename);
+	static SoundFormat* Load(Stream* stream);
 	size_t SeekSample(int index);
 	int LoadSamples(size_t count);
 	int GetSamples(Uint8* buffer, size_t count, Sint32 loopIndex);

--- a/include/Engine/ResourceTypes/SoundFormats/WAV.h
+++ b/include/Engine/ResourceTypes/SoundFormats/WAV.h
@@ -3,6 +3,7 @@
 
 #include <Engine/Includes/Standard.h>
 #include <Engine/Includes/StandardSDL2.h>
+#include <Engine/IO/Stream.h>
 #include <Engine/ResourceTypes/SoundFormats/SoundFormat.h>
 
 class WAV : public SoundFormat {
@@ -11,7 +12,7 @@ private:
 	int DataStart = 0;
 
 public:
-	static SoundFormat* Load(const char* filename);
+	static SoundFormat* Load(Stream* stream);
 	int LoadSamples(size_t count);
 	void Dispose();
 };

--- a/include/Engine/Scene.h
+++ b/include/Engine/Scene.h
@@ -80,7 +80,6 @@ public:
 	static int BaseTilesetCount;
 	static bool TileCfgLoaded;
 	static vector<TileConfig*> TileCfg;
-	static vector<ResourceType*> ResourceList;
 	static vector<GameTexture*> TextureList;
 	static vector<Animator*> AnimatorList;
 	static int Frame;

--- a/include/Engine/Scene.h
+++ b/include/Engine/Scene.h
@@ -80,12 +80,7 @@ public:
 	static int BaseTilesetCount;
 	static bool TileCfgLoaded;
 	static vector<TileConfig*> TileCfg;
-	static vector<ResourceType*> SpriteList;
-	static vector<ResourceType*> ImageList;
-	static vector<ResourceType*> SoundList;
-	static vector<ResourceType*> MusicList;
-	static vector<ResourceType*> ModelList;
-	static vector<ResourceType*> MediaList;
+	static vector<ResourceType*> ResourceList;
 	static vector<GameTexture*> TextureList;
 	static vector<Animator*> AnimatorList;
 	static int Frame;
@@ -177,20 +172,6 @@ public:
 	static bool AddTileset(char* path);
 	static void LoadTileCollisions(const char* filename, size_t tilesetID);
 	static void UnloadTileCollisions();
-	static bool GetResourceListSpace(vector<ResourceType*>* list,
-		ResourceType* resource,
-		size_t& index,
-		bool& foundEmpty);
-	static bool GetResource(vector<ResourceType*>* list, ResourceType* resource, size_t& index);
-	static int LoadSpriteResource(const char* filename, int unloadPolicy);
-	static int LoadImageResource(const char* filename, int unloadPolicy);
-	static int LoadFontResource(const char* filename, int pixel_sz, int unloadPolicy);
-	static int LoadModelResource(const char* filename, int unloadPolicy);
-	static int LoadMusicResource(const char* filename, int unloadPolicy);
-	static int LoadSoundResource(const char* filename, int unloadPolicy);
-	static int LoadVideoResource(const char* filename, int unloadPolicy);
-	static ResourceType* GetSpriteResource(int index);
-	static ResourceType* GetImageResource(int index);
 	static void DisposeInScope(Uint32 scope);
 	static void Dispose();
 	static void UnloadTilesets();

--- a/include/Engine/Types/Entity.h
+++ b/include/Engine/Types/Entity.h
@@ -116,6 +116,7 @@ public:
 	void Copy(Entity* other);
 	void CopyFields(Entity* other);
 	void ApplyPhysics();
+	void SetSprite(void* sprite);
 	virtual void Initialize();
 	virtual void Create();
 	virtual void PostCreate();

--- a/include/Engine/Types/Entity.h
+++ b/include/Engine/Types/Entity.h
@@ -64,7 +64,7 @@ public:
 	float Depth = 0.0f;
 	float OldDepth = 0.0f;
 	float ZDepth = 0.0;
-	int Sprite = -1;
+	void* Sprite = nullptr;
 	int CurrentAnimation = -1;
 	int CurrentFrame = -1;
 	int CurrentFrameCount = 0;

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -756,7 +756,7 @@ void Application::Restart() {
 
 	Scene::Dispose();
 	SceneInfo::Dispose();
-	Resource::DisposeGlobal();
+	Resource::DisposeAll();
 	Graphics::DeleteSpriteSheetMap();
 
 	ScriptManager::LoadAllClasses = false;
@@ -1041,19 +1041,15 @@ void Application::PollEvents() {
 				}
 				// Show resource info (dev)
 				else if (key == KeyBindsSDL[(int)KeyBind::DevResourceInfo]) {
-					for (Uint32 i = SCOPE_SCENE; i <= SCOPE_GAME; i++) {
-						std::vector<ResourceType*>* list = Resource::GetList(i);
+					std::vector<ResourceType*>* list = Resource::GetList();
 
-						Log::Print(Log::LOG_IMPORTANT, "Resource List %d:", i);
-
-						for (size_t j = 0; j < list->size(); j++) {
-							ResourceType* resource = (*list)[j];
-							Log::Print(Log::LOG_IMPORTANT,
-								"- %d: %s (%s)",
-								j,
-								resource->Filename,
-								GetResourceTypeString(resource->Type));
-						}
+					for (size_t i = 0; i < list->size(); i++) {
+						ResourceType* resource = (*list)[i];
+						Log::Print(Log::LOG_IMPORTANT,
+							"- %d: %s (%s)",
+							i,
+							resource->Filename,
+							GetResourceTypeString(resource->Type));
 					}
 					break;
 				}
@@ -1204,7 +1200,7 @@ void Application::RunFrame(int runFrames) {
 	AudioManager::Lock();
 	Uint8 audio_buffer[0x8000]; // <-- Should be larger than AudioManager::AudioQueueMaxSize
 	int needed = 0x8000; // AudioManager::AudioQueueMaxSize;
-	vector<ResourceType*>* list = Resource::GetList(SCOPE_GAME);
+	vector<ResourceType*>* list = Resource::GetList();
 	for (size_t i = 0, i_sz = list->size(); i < i_sz; i++) {
 		if ((*list)[i]->Type != RESOURCE_MEDIA) {
 			continue;
@@ -1637,7 +1633,7 @@ void Application::Cleanup() {
 		Application::Settings->Dispose();
 	}
 
-	Resource::DisposeGlobal();
+	Resource::DisposeAll();
 
 	MemoryCache::Dispose();
 	ResourceManager::Dispose();

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -876,12 +876,13 @@ void Application::LoadKeyBinds() {
 		Application::SetKeyBind((int)KeyBind::bind, key); \
 	}
 
-	GET_KEY("fullscreen", Fullscreen, Key_F4);
+	GET_KEY("fullscreen", Fullscreen, Key_UNKNOWN);
 	GET_KEY("devRestartApp", DevRestartApp, Key_F1);
 	GET_KEY("devRestartScene", DevRestartScene, Key_F6);
 	GET_KEY("devRecompile", DevRecompile, Key_F5);
 	GET_KEY("devPerfSnapshot", DevPerfSnapshot, Key_F3);
 	GET_KEY("devLogLayerInfo", DevLayerInfo, Key_F2);
+	GET_KEY("devLogResourceInfo", DevResourceInfo, Key_F4);
 	GET_KEY("devFastForward", DevFastForward, Key_BACKSPACE);
 	GET_KEY("devToggleFrameStepper", DevFrameStepper, Key_F9);
 	GET_KEY("devStepFrame", DevStepFrame, Key_F10);
@@ -1035,6 +1036,24 @@ void Application::PollEvents() {
 							layer.DrawGroup,
 							layer.DrawBehavior,
 							layer.Flags);
+					}
+					break;
+				}
+				// Show resource info (dev)
+				else if (key == KeyBindsSDL[(int)KeyBind::DevResourceInfo]) {
+					for (Uint32 i = SCOPE_SCENE; i <= SCOPE_GAME; i++) {
+						std::vector<ResourceType*>* list = Resource::GetList(i);
+
+						Log::Print(Log::LOG_IMPORTANT, "Resource List %d:", i);
+
+						for (size_t j = 0; j < list->size(); j++) {
+							ResourceType* resource = (*list)[j];
+							Log::Print(Log::LOG_IMPORTANT,
+								"- %d: %s (%s)",
+								j,
+								resource->Filename,
+								GetResourceTypeString(resource->Type));
+						}
 					}
 					break;
 				}

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -1045,11 +1045,12 @@ void Application::PollEvents() {
 
 					for (size_t i = 0; i < list->size(); i++) {
 						ResourceType* resource = (*list)[i];
-						Log::Print(Log::LOG_IMPORTANT,
-							"- %d: %s (%s)",
+						Log::Print(Log::LOG_VERBOSE,
+							"- %d: %s (Type: %s, Scope: %s)",
 							i,
 							resource->Filename,
-							GetResourceTypeString(resource->Type));
+							GetResourceTypeString(resource->Type),
+							GetResourceScopeString(resource->UnloadPolicy));
 					}
 					break;
 				}

--- a/source/Engine/Audio/AudioManager.cpp
+++ b/source/Engine/Audio/AudioManager.cpp
@@ -558,6 +558,11 @@ void AudioManager::AudioStopAll() {
 	AudioManager::Unlock();
 }
 
+void AudioManager::Unload(ISound* audio) {
+	RemoveMusic(audio);
+	AudioRemove(audio);
+}
+
 bool AudioManager::IsOriginPlaying(void* origin, ISound* audio) {
 	bool isPlaying = false;
 	AudioManager::Lock();

--- a/source/Engine/Bytecode/ScriptEntity.cpp
+++ b/source/Engine/Bytecode/ScriptEntity.cpp
@@ -1092,6 +1092,8 @@ void ScriptEntity::Remove() {
 
 	Active = false;
 	Removed = true;
+
+	SetSprite(nullptr);
 }
 void ScriptEntity::Dispose() {
 	Entity::Dispose();
@@ -1188,11 +1190,11 @@ bool ScriptEntity::VM_Setter(Obj* object, Uint32 hash, VMValue value, Uint32 thr
 
 	if (hash == Hash_Sprite) {
 		if (IS_NULL(value)) {
-			Resource::Release((ResourceType*)self->Sprite);
-			self->Sprite = nullptr;
+			self->SetSprite(nullptr);
 			return true;
 		}
-		else if (!IS_RESOURCE(value)) {
+
+		if (!IS_RESOURCE(value)) {
 			StandardLibrary::ExpectedObjectTypeError(value, OBJ_RESOURCE, threadID);
 			return true;
 		}
@@ -1200,8 +1202,7 @@ bool ScriptEntity::VM_Setter(Obj* object, Uint32 hash, VMValue value, Uint32 thr
 		ObjResource* resourceObj = AS_RESOURCE(value);
 		void* resource = resourceObj->ResourcePtr;
 		if (StandardLibrary::ValidateResource(resource, RESOURCE_SPRITE, threadID)) {
-			Resource::TakeRef((ResourceType*)resource);
-			self->Sprite = resource;
+			self->SetSprite(resource);
 		}
 
 		return true;

--- a/source/Engine/Bytecode/ScriptManager.cpp
+++ b/source/Engine/Bytecode/ScriptManager.cpp
@@ -15,6 +15,7 @@
 #include <Engine/Filesystem/File.h>
 #include <Engine/Hashing/CombinedHash.h>
 #include <Engine/Hashing/FNV1A.h>
+#include <Engine/ResourceTypes/Resource.h>
 #include <Engine/ResourceTypes/ResourceManager.h>
 #include <Engine/TextFormats/XML/XMLParser.h>
 
@@ -635,7 +636,7 @@ void ScriptManager::FreeValue(VMValue value) {
 		case OBJ_RESOURCE: {
 			ObjResource* resource = AS_RESOURCE(value);
 
-			((ResourceType*)resource->ResourcePtr)->VMObject = nullptr;
+			Resource::ReleaseVMObject((ResourceType*)resource->ResourcePtr);
 
 			FREE_OBJ(resource, ObjResource);
 			break;

--- a/source/Engine/Bytecode/ScriptManager.cpp
+++ b/source/Engine/Bytecode/ScriptManager.cpp
@@ -8,6 +8,7 @@
 #include <Engine/Bytecode/TypeImpl/FunctionImpl.h>
 #include <Engine/Bytecode/TypeImpl/MapImpl.h>
 #include <Engine/Bytecode/TypeImpl/MaterialImpl.h>
+#include <Engine/Bytecode/TypeImpl/ResourceImpl.h>
 #include <Engine/Bytecode/TypeImpl/StringImpl.h>
 #include <Engine/Bytecode/Values.h>
 #include <Engine/Diagnostics/Log.h>
@@ -124,10 +125,11 @@ void ScriptManager::Init() {
 	ThreadCount = 1;
 
 	ArrayImpl::Init();
-	MapImpl::Init();
 	FunctionImpl::Init();
-	StringImpl::Init();
+	MapImpl::Init();
 	MaterialImpl::Init();
+	ResourceImpl::Init();
+	StringImpl::Init();
 }
 #ifdef VM_DEBUG
 Uint32 ScriptManager::GetBranchLimit() {
@@ -625,9 +627,17 @@ void ScriptManager::FreeValue(VMValue value) {
 		case OBJ_MATERIAL: {
 			ObjMaterial* material = AS_MATERIAL(value);
 
-			Material::Remove(material->MaterialPtr);
+			((Material*)material->MaterialPtr)->VMObject = nullptr;
 
 			FREE_OBJ(material, ObjMaterial);
+			break;
+		}
+		case OBJ_RESOURCE: {
+			ObjResource* resource = AS_RESOURCE(value);
+
+			((ResourceType*)resource->ResourcePtr)->VMObject = nullptr;
+
+			FREE_OBJ(resource, ObjResource);
 			break;
 		}
 		default:

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -834,7 +834,7 @@ VMValue Animator_GetHitbox(int argCount, VMValue* args, Uint32 threadID) {
 	CHECK_AT_LEAST_ARGCOUNT(1);
 	Animator* animator = GET_ARG(0, GetAnimator);
 	int hitboxID = GET_ARG_OPT(1, GetInteger, 0);
-	// Do not throw errors here because Animators are allowed to have negative sprite, animation, and frame indexes
+	// Do not throw errors here because Animators are allowed to have negative animation and frame indexes
 	if (animator && animator->Sprite != nullptr && animator->CurrentAnimation >= 0 &&
 		animator->CurrentFrame >= 0) {
 		ISprite* sprite = GetSprite((ResourceType*)animator->Sprite, threadID);

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -256,7 +256,7 @@ inline ObjStream* GetStream(VMValue* args, int index, Uint32 threadID) {
 	}
 	return value;
 }
-inline void* GetResource(Uint8 type, VMValue* args, int index, Uint32 threadID) {
+inline void* GetResource(VMValue* args, int index, Uint32 threadID) {
 	ObjResource* resourceObj = nullptr;
 
 	if (ScriptManager::Lock()) {
@@ -269,11 +269,14 @@ inline void* GetResource(Uint8 type, VMValue* args, int index, Uint32 threadID) 
 		ScriptManager::Unlock();
 	}
 
-	if (!resourceObj) {
-		return nullptr;
+	if (resourceObj) {
+		return resourceObj->ResourcePtr;
 	}
 
-	void* resource = resourceObj->ResourcePtr;
+	return nullptr;
+}
+inline void* GetResource(Uint8 type, VMValue* args, int index, Uint32 threadID) {
+	void* resource = GetResource(args, index, threadID);
 	if (ValidateResource(resource, type, threadID)) {
 		return resource;
 	}
@@ -395,7 +398,7 @@ ObjMap* StandardLibrary::GetMap(VMValue* args, int index, Uint32 threadID) {
 	return LOCAL::GetMap(args, index, threadID);
 }
 void* StandardLibrary::GetResource(VMValue* args, int index, Uint32 threadID) {
-	return LOCAL::GetResource(RESOURCE_NONE, args, index, threadID);
+	return LOCAL::GetResource(args, index, threadID);
 }
 ISprite* StandardLibrary::GetSprite(VMValue* args, int index, Uint32 threadID) {
 	return LOCAL::GetSprite(args, index, threadID);

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -11263,9 +11263,7 @@ VMValue Random_Range(int argCount, VMValue* args, Uint32 threadID) {
 
 // #region Resources
 ObjResource* LoadResource(Uint8 type, char* filename, int unloadPolicy) {
-	vector<ResourceType*>* list = Resource::GetList(unloadPolicy);
-
-	ResourceType* resource = Resource::Load(list, type, filename, unloadPolicy);
+	ResourceType* resource = Resource::Load(type, filename, unloadPolicy);
 	if (resource != nullptr) {
 		return (ObjResource*)(Resource::GetVMObject(resource));
 	}
@@ -11356,9 +11354,7 @@ VMValue Resources_LoadFont(int argCount, VMValue* args, Uint32 threadID) {
 	int pixel_sz = (int)GET_ARG(1, GetDecimal);
 	int unloadPolicy = GET_ARG(2, GetInteger);
 
-	vector<ResourceType*>* list = Resource::GetList(unloadPolicy);
-
-	ResourceType* resource = Resource::LoadFont(list, filename, pixel_sz, unloadPolicy);
+	ResourceType* resource = Resource::LoadFont(filename, pixel_sz, unloadPolicy);
 	if (resource != nullptr) {
 		return OBJECT_VAL(Resource::GetVMObject(resource));
 	}

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -11423,7 +11423,7 @@ VMValue Resources_LoadSound(int argCount, VMValue* args, Uint32 threadID) {
 }
 /***
  * Resources.LoadVideo
- * \desc Loads a Video resource.
+ * \desc Loads a Media resource.
  * \param filename (String): Filename of the resource.
  * \param unloadPolicy (Integer): The <linkto ref="SCOPE_*">unload policy</linkto> of the resource.
  * \return Returns a resource.

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -11263,7 +11263,7 @@ VMValue Random_Range(int argCount, VMValue* args, Uint32 threadID) {
 
 // #region Resources
 ObjResource* LoadResource(Uint8 type, char* filename, int unloadPolicy) {
-	vector<ResourceType*>* list = &Scene::ResourceList;
+	vector<ResourceType*>* list = Resource::GetList(unloadPolicy);
 
 	ResourceType* resource = Resource::Load(list, type, filename, unloadPolicy);
 
@@ -11344,7 +11344,7 @@ VMValue Resources_LoadFont(int argCount, VMValue* args, Uint32 threadID) {
 	int pixel_sz = (int)GET_ARG(1, GetDecimal);
 	int unloadPolicy = GET_ARG(2, GetInteger);
 
-	vector<ResourceType*>* list = &Scene::ResourceList;
+	vector<ResourceType*>* list = Resource::GetList(unloadPolicy);
 
 	ResourceType* resource = Resource::LoadFont(list, filename, pixel_sz, unloadPolicy);
 

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -84,11 +84,12 @@ namespace LOCAL {
 inline bool ValidateResource(void* ptr, Uint8 type, Uint32 threadID) {
 	ResourceType* resource = (ResourceType*)ptr;
 	if (!resource || !resource->Loaded) {
-		THROW_ERROR("Resource was not loaded.");
+		THROW_ERROR("Resource is not loaded!");
 		return false;
 	}
 
-	if (resource->Type != type) {
+	// Validate if type != RESOURCE_NONE
+	if (type != RESOURCE_NONE && resource->Type != type) {
 		THROW_ERROR("Expected resource to be of type '%s' instead of '%s'.",
 		    GetResourceTypeString(type),
 		    GetResourceTypeString(resource->Type));
@@ -392,6 +393,9 @@ ObjArray* StandardLibrary::GetArray(VMValue* args, int index, Uint32 threadID) {
 }
 ObjMap* StandardLibrary::GetMap(VMValue* args, int index, Uint32 threadID) {
 	return LOCAL::GetMap(args, index, threadID);
+}
+void* StandardLibrary::GetResource(VMValue* args, int index, Uint32 threadID) {
+	return LOCAL::GetResource(RESOURCE_NONE, args, index, threadID);
 }
 ISprite* StandardLibrary::GetSprite(VMValue* args, int index, Uint32 threadID) {
 	return LOCAL::GetSprite(args, index, threadID);
@@ -16885,7 +16889,7 @@ VMValue Video_Close(int argCount, VMValue* args, Uint32 threadID) {
 	}
 
 #ifdef USING_FFMPEG
-	MediaBag* video = resource->AsMedia;
+	MediaBag* video = ((ResourceType*)resource)->AsMedia;
 	if (video) {
 		video->Source->Close();
 		video->Player->Close();

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -11266,8 +11266,11 @@ ObjResource* LoadResource(Uint8 type, char* filename, int unloadPolicy) {
 	vector<ResourceType*>* list = Resource::GetList(unloadPolicy);
 
 	ResourceType* resource = Resource::Load(list, type, filename, unloadPolicy);
+	if (resource != nullptr) {
+		return (ObjResource*)(Resource::GetVMObject(resource));
+	}
 
-	return (ObjResource*)(Resource::GetVMObject(resource));
+	return nullptr;
 }
 /***
  * Resources.LoadSprite
@@ -11283,7 +11286,10 @@ VMValue Resources_LoadSprite(int argCount, VMValue* args, Uint32 threadID) {
 	int unloadPolicy = GET_ARG(1, GetInteger);
 
 	ObjResource* object = LoadResource(RESOURCE_SPRITE, filename, unloadPolicy);
-	return OBJECT_VAL(object);
+	if (object != nullptr) {
+		return OBJECT_VAL(object);
+	}
+	return NULL_VAL;
 }
 /***
  * Resources.LoadDynamicSprite
@@ -11311,7 +11317,10 @@ VMValue Resources_LoadDynamicSprite(int argCount, VMValue* args, Uint32 threadID
 	}
 
 	ObjResource* object = LoadResource(RESOURCE_SPRITE, filename, unloadPolicy);
-	return OBJECT_VAL(object);
+	if (object != nullptr) {
+		return OBJECT_VAL(object);
+	}
+	return NULL_VAL;
 }
 /***
  * Resources.LoadImage
@@ -11327,7 +11336,10 @@ VMValue Resources_LoadImage(int argCount, VMValue* args, Uint32 threadID) {
 	int unloadPolicy = GET_ARG(1, GetInteger);
 
 	ObjResource* object = LoadResource(RESOURCE_IMAGE, filename, unloadPolicy);
-	return OBJECT_VAL(object);
+	if (object != nullptr) {
+		return OBJECT_VAL(object);
+	}
+	return NULL_VAL;
 }
 /***
  * Resources.LoadFont
@@ -11347,8 +11359,10 @@ VMValue Resources_LoadFont(int argCount, VMValue* args, Uint32 threadID) {
 	vector<ResourceType*>* list = Resource::GetList(unloadPolicy);
 
 	ResourceType* resource = Resource::LoadFont(list, filename, pixel_sz, unloadPolicy);
-
-	return OBJECT_VAL(Resource::GetVMObject(resource));
+	if (resource != nullptr) {
+		return OBJECT_VAL(Resource::GetVMObject(resource));
+	}
+	return NULL_VAL;
 }
 /***
  * Resources.LoadModel
@@ -11364,7 +11378,10 @@ VMValue Resources_LoadModel(int argCount, VMValue* args, Uint32 threadID) {
 	int unloadPolicy = GET_ARG(1, GetInteger);
 
 	ObjResource* object = LoadResource(RESOURCE_MODEL, filename, unloadPolicy);
-	return OBJECT_VAL(object);
+	if (object != nullptr) {
+		return OBJECT_VAL(object);
+	}
+	return NULL_VAL;
 }
 /***
  * Resources.LoadMusic
@@ -11380,7 +11397,10 @@ VMValue Resources_LoadMusic(int argCount, VMValue* args, Uint32 threadID) {
 	int unloadPolicy = GET_ARG(1, GetInteger);
 
 	ObjResource* object = LoadResource(RESOURCE_AUDIO, filename, unloadPolicy);
-	return OBJECT_VAL(object);
+	if (object != nullptr) {
+		return OBJECT_VAL(object);
+	}
+	return NULL_VAL;
 }
 /***
  * Resources.LoadSound
@@ -11396,7 +11416,10 @@ VMValue Resources_LoadSound(int argCount, VMValue* args, Uint32 threadID) {
 	int unloadPolicy = GET_ARG(1, GetInteger);
 
 	ObjResource* object = LoadResource(RESOURCE_AUDIO, filename, unloadPolicy);
-	return OBJECT_VAL(object);
+	if (object != nullptr) {
+		return OBJECT_VAL(object);
+	}
+	return NULL_VAL;
 }
 /***
  * Resources.LoadVideo
@@ -11412,7 +11435,10 @@ VMValue Resources_LoadVideo(int argCount, VMValue* args, Uint32 threadID) {
 	int unloadPolicy = GET_ARG(1, GetInteger);
 
 	ObjResource* object = LoadResource(RESOURCE_MEDIA, filename, unloadPolicy);
-	return OBJECT_VAL(object);
+	if (object != nullptr) {
+		return OBJECT_VAL(object);
+	}
+	return NULL_VAL;
 }
 /***
  * Resources.FileExists

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -570,10 +570,10 @@ bool GetAnimatorSpace(vector<Animator*>* list, size_t* index, bool* foundEmpty) 
 /***
  * Animator.Create
  * \desc Creates a new animator.
- * \param sprite (Resource): The index of the sprite.
- * \param animationID (Integer): Which animation to use.
- * \param frameID (Integer): Which frame to use.
- * \param unloadPolicy (Integer): The <linkto ref="SCOPE_*">unload policy</linkto> of the animator.
+ * \paramOpt sprite (Resource): A sprite resource.
+ * \paramOpt animationID (Integer): Which animation to use.
+ * \paramOpt frameID (Integer): Which frame to use.
+ * \paramOpt unloadPolicy (Integer): The <linkto ref="SCOPE_*">unload policy</linkto> of the animator.
  * \return Returns the index of the Animator.
  * \ns Animator
  */
@@ -640,7 +640,7 @@ VMValue Animator_Remove(int argCount, VMValue* args, Uint32 threadID) {
  * Animator.SetAnimation
  * \desc Sets the current animation and frame of an animator.
  * \param animator (Integer): The index of the animator.
- * \param sprite (Resource): The index of the sprite.
+ * \param sprite (Resource): A sprite resource.
  * \param animationID (Integer): The animator's changed animation ID.
  * \param frameID (Integer): The animator's changed frame ID.
  * \param forceApply (Boolean): Whether to force the animation to go back to the frame if the animation is the same as the current animation.

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -18119,10 +18119,15 @@ void StandardLibrary::Link() {
     */
 	DEF_ENUM_CLASS(KeyBind, DevPerfSnapshot);
 	/***
-    * \enum KeyBind_Fullscreen
+    * \enum KeyBind_DevLayerInfo
     * \desc Scene layer info keybind. (dev)
     */
 	DEF_ENUM_CLASS(KeyBind, DevLayerInfo);
+	/***
+    * \enum KeyBind_DevResourceInfo
+    * \desc Resource info keybind. (dev)
+    */
+	DEF_ENUM_CLASS(KeyBind, DevResourceInfo);
 	/***
     * \enum KeyBind_DevFastForward
     * \desc Fast forward keybind. (dev)

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -10702,6 +10702,7 @@ VMValue Palette_LoadFromResource(int argCount, VMValue* args, Uint32 threadID) {
 		RSDKSceneReader::GameConfig_GetColors(filename);
 	}
 	else {
+		// TODO: This sucks.
 		ResourceStream* reader;
 		if ((reader = ResourceStream::New(filename))) {
 			MemoryStream* memoryReader;
@@ -10831,7 +10832,7 @@ VMValue Palette_LoadFromResource(int argCount, VMValue* args, Uint32 threadID) {
 					GIF* gif;
 
 					Graphics::UsePalettes = false;
-					gif = GIF::Load(filename);
+					gif = GIF::Load(memoryReader);
 					Graphics::UsePalettes = loadPalette;
 
 					if (gif) {
@@ -10863,7 +10864,7 @@ VMValue Palette_LoadFromResource(int argCount, VMValue* args, Uint32 threadID) {
 					PNG* png;
 
 					Graphics::UsePalettes = true;
-					png = PNG::Load(filename);
+					png = PNG::Load(memoryReader);
 					Graphics::UsePalettes = loadPalette;
 
 					if (png) {

--- a/source/Engine/Bytecode/TypeImpl/ResourceImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/ResourceImpl.cpp
@@ -19,6 +19,8 @@ void ResourceImpl::Init() {
 
 	Hash_Filename = Murmur::EncryptString("Filename");
 
+	ScriptManager::DefineNative(Class, "Unload", ResourceImpl::VM_Unload);
+
 	ScriptManager::ClassImplList.push_back(Class);
 
 	ScriptManager::Globals->Put(className, OBJECT_VAL(Class));
@@ -54,11 +56,6 @@ VMValue ResourceImpl::VM_Initializer(int argCount, VMValue* args, Uint32 threadI
 	return value;
 }
 
-#undef GET_ARG
-#undef GET_ARG_OPT
-
-#define THROW_ERROR(...) ScriptManager::Threads[threadID].ThrowRuntimeError(false, __VA_ARGS__)
-
 bool ResourceImpl::VM_PropertyGet(Obj* object, Uint32 hash, VMValue* result, Uint32 threadID) {
 	ObjResource* objResource = (ObjResource*)object;
 	ResourceType* resource = (ResourceType*)objResource->ResourcePtr;
@@ -78,3 +75,17 @@ bool ResourceImpl::VM_PropertyGet(Obj* object, Uint32 hash, VMValue* result, Uin
 	return false;
 }
 
+VMValue ResourceImpl::VM_Unload(int argCount, VMValue* args, Uint32 threadID) {
+	StandardLibrary::CheckArgCount(argCount, 1);
+
+	void* ptr = GET_ARG(0, GetResource);
+	if (ptr != nullptr) {
+		ResourceType* resource = (ResourceType*)ptr;
+		Resource::Unload(resource);
+	}
+
+	return NULL_VAL;
+}
+
+#undef GET_ARG
+#undef GET_ARG_OPT

--- a/source/Engine/Bytecode/TypeImpl/ResourceImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/ResourceImpl.cpp
@@ -50,8 +50,7 @@ VMValue ResourceImpl::VM_Initializer(int argCount, VMValue* args, Uint32 threadI
 	VMValue value = NULL_VAL;
 
 	if (filename != nullptr) {
-		vector<ResourceType*>* list = Resource::GetList(unloadPolicy);
-		ResourceType* resource = Resource::Load(list, RESOURCE_NONE, filename, unloadPolicy);
+		ResourceType* resource = Resource::Load(RESOURCE_NONE, filename, unloadPolicy);
 		if (resource != nullptr) {
 			value = OBJECT_VAL(Resource::GetVMObject(resource));
 		}

--- a/source/Engine/Bytecode/TypeImpl/ResourceImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/ResourceImpl.cpp
@@ -1,6 +1,7 @@
 #include <Engine/Bytecode/ScriptManager.h>
 #include <Engine/Bytecode/StandardLibrary.h>
 #include <Engine/Bytecode/TypeImpl/ResourceImpl.h>
+#include <Engine/ResourceTypes/Resource.h>
 #include <Engine/ResourceTypes/ResourceType.h>
 
 ObjClass* ResourceImpl::Class = nullptr;
@@ -8,16 +9,53 @@ ObjClass* ResourceImpl::Class = nullptr;
 Uint32 Hash_Filename = 0;
 
 void ResourceImpl::Init() {
-	const char* className = "$$ResourceImpl";
+	const char* className = "Resource";
 
 	Class = NewClass(Murmur::EncryptString(className));
 	Class->Name = CopyString(className);
+	Class->NewFn = VM_New;
+	Class->Initializer = OBJECT_VAL(NewNative(VM_Initializer));
 	Class->PropertyGet = VM_PropertyGet;
 
 	Hash_Filename = Murmur::EncryptString("Filename");
 
 	ScriptManager::ClassImplList.push_back(Class);
+
+	ScriptManager::Globals->Put(className, OBJECT_VAL(Class));
 }
+
+#define GET_ARG(argIndex, argFunction) (StandardLibrary::argFunction(args, argIndex, threadID))
+#define GET_ARG_OPT(argIndex, argFunction, argDefault) \
+	(argIndex < argCount ? GET_ARG(argIndex, argFunction) : argDefault)
+
+Obj* ResourceImpl::VM_New() {
+	// Don't worry about it.
+	return nullptr;
+}
+
+VMValue ResourceImpl::VM_Initializer(int argCount, VMValue* args, Uint32 threadID) {
+	StandardLibrary::CheckAtLeastArgCount(argCount, 2);
+	char* filename = GET_ARG(1, GetString);
+	int unloadPolicy = GET_ARG_OPT(2, GetInteger, SCOPE_GAME);
+
+	VMValue value = NULL_VAL;
+
+	if (filename != nullptr) {
+		vector<ResourceType*>* list = &Scene::ResourceList;
+		ResourceType* resource = Resource::Load(list, RESOURCE_NONE, filename, unloadPolicy);
+		if (resource != nullptr) {
+			value = OBJECT_VAL(Resource::GetVMObject(resource));
+		}
+	}
+
+	// Since we know args[] is in the thread's stack, this is okay to do.
+	args[0] = value;
+
+	return value;
+}
+
+#undef GET_ARG
+#undef GET_ARG_OPT
 
 #define THROW_ERROR(...) ScriptManager::Threads[threadID].ThrowRuntimeError(false, __VA_ARGS__)
 

--- a/source/Engine/Bytecode/TypeImpl/ResourceImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/ResourceImpl.cpp
@@ -1,0 +1,42 @@
+#include <Engine/Bytecode/ScriptManager.h>
+#include <Engine/Bytecode/StandardLibrary.h>
+#include <Engine/Bytecode/TypeImpl/ResourceImpl.h>
+#include <Engine/ResourceTypes/ResourceType.h>
+
+ObjClass* ResourceImpl::Class = nullptr;
+
+Uint32 Hash_Filename = 0;
+
+void ResourceImpl::Init() {
+	const char* className = "$$ResourceImpl";
+
+	Class = NewClass(Murmur::EncryptString(className));
+	Class->Name = CopyString(className);
+	Class->PropertyGet = VM_PropertyGet;
+
+	Hash_Filename = Murmur::EncryptString("Filename");
+
+	ScriptManager::ClassImplList.push_back(Class);
+}
+
+#define THROW_ERROR(...) ScriptManager::Threads[threadID].ThrowRuntimeError(false, __VA_ARGS__)
+
+bool ResourceImpl::VM_PropertyGet(Obj* object, Uint32 hash, VMValue* result, Uint32 threadID) {
+	ObjResource* objResource = (ObjResource*)object;
+	ResourceType* resource = (ResourceType*)objResource->ResourcePtr;
+
+	if (hash == Hash_Filename) {
+		if (ScriptManager::Lock()) {
+			ObjString* string = CopyString(resource->Filename);
+			ScriptManager::Unlock();
+			*result = OBJECT_VAL(string);
+		}
+		else {
+			*result = NULL_VAL;
+		}
+		return true;
+	}
+
+	return false;
+}
+

--- a/source/Engine/Bytecode/TypeImpl/ResourceImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/ResourceImpl.cpp
@@ -50,7 +50,7 @@ VMValue ResourceImpl::VM_Initializer(int argCount, VMValue* args, Uint32 threadI
 	VMValue value = NULL_VAL;
 
 	if (filename != nullptr) {
-		vector<ResourceType*>* list = &Scene::ResourceList;
+		vector<ResourceType*>* list = Resource::GetList(unloadPolicy);
 		ResourceType* resource = Resource::Load(list, RESOURCE_NONE, filename, unloadPolicy);
 		if (resource != nullptr) {
 			value = OBJECT_VAL(Resource::GetVMObject(resource));

--- a/source/Engine/Bytecode/Types.cpp
+++ b/source/Engine/Bytecode/Types.cpp
@@ -7,6 +7,7 @@
 #include <Engine/Bytecode/TypeImpl/FunctionImpl.h>
 #include <Engine/Bytecode/TypeImpl/MapImpl.h>
 #include <Engine/Bytecode/TypeImpl/MaterialImpl.h>
+#include <Engine/Bytecode/TypeImpl/ResourceImpl.h>
 #include <Engine/Bytecode/TypeImpl/StringImpl.h>
 #include <Engine/Diagnostics/Log.h>
 #include <Engine/Diagnostics/Memory.h>
@@ -198,12 +199,19 @@ ObjModule* NewModule() {
 	module->SourceFilename = NULL;
 	return module;
 }
-ObjMaterial* NewMaterial(Material* materialPtr) {
+ObjMaterial* NewMaterial(void* materialPtr) {
 	ObjMaterial* material = ALLOCATE_OBJ(ObjMaterial, OBJ_MATERIAL);
 	Memory::Track(material, "NewMaterial");
 	material->Object.Class = MaterialImpl::Class;
 	material->MaterialPtr = materialPtr;
 	return material;
+}
+ObjResource* NewResource(void* resourcePtr) {
+	ObjResource* resource = ALLOCATE_OBJ(ObjResource, OBJ_RESOURCE);
+	Memory::Track(resource, "NewResource");
+	resource->Object.Class = ResourceImpl::Class;
+	resource->ResourcePtr = resourcePtr;
+	return resource;
 }
 
 bool ValuesEqual(VMValue a, VMValue b) {
@@ -269,6 +277,8 @@ const char* GetObjectTypeString(Uint32 type) {
 		return "Module";
 	case OBJ_MATERIAL:
 		return "Material";
+	case OBJ_RESOURCE:
+		return "Resource";
 	}
 	return "Unknown Object Type";
 }

--- a/source/Engine/Bytecode/Types.h
+++ b/source/Engine/Bytecode/Types.h
@@ -5,8 +5,6 @@
 
 #include <Engine/IO/Stream.h>
 
-#include <Engine/Rendering/Material.h>
-
 #define FRAMES_MAX 64
 #define STACK_SIZE_MAX (FRAMES_MAX * 256)
 #define THREAD_NAME_MAX 64
@@ -172,6 +170,7 @@ typedef bool (*StructSetFn)(Obj* object, VMValue at, VMValue value, Uint32 threa
 #define IS_ENUM(value) IsObjectType(value, OBJ_ENUM)
 #define IS_MODULE(value) IsObjectType(value, OBJ_MODULE)
 #define IS_MATERIAL(value) IsObjectType(value, OBJ_MATERIAL)
+#define IS_RESOURCE(value) IsObjectType(value, OBJ_RESOURCE)
 
 #define AS_BOUND_METHOD(value) ((ObjBoundMethod*)AS_OBJECT(value))
 #define AS_CLASS(value) ((ObjClass*)AS_OBJECT(value))
@@ -188,6 +187,7 @@ typedef bool (*StructSetFn)(Obj* object, VMValue at, VMValue value, Uint32 threa
 #define AS_ENUM(value) ((ObjEnum*)AS_OBJECT(value))
 #define AS_MODULE(value) ((ObjModule*)AS_OBJECT(value))
 #define AS_MATERIAL(value) ((ObjMaterial*)AS_OBJECT(value))
+#define AS_RESOURCE(value) ((ObjResource*)AS_OBJECT(value))
 
 enum ObjType {
 	OBJ_BOUND_METHOD,
@@ -204,10 +204,11 @@ enum ObjType {
 	OBJ_NAMESPACE,
 	OBJ_ENUM,
 	OBJ_MODULE,
-	OBJ_MATERIAL
-};
+	OBJ_MATERIAL,
+	OBJ_RESOURCE,
 
-#define MAX_OBJ_TYPE (OBJ_MATERIAL + 1)
+	MAX_OBJ_TYPE
+};
 
 typedef HashMap<VMValue> Table;
 
@@ -313,7 +314,11 @@ struct ObjEnum {
 };
 struct ObjMaterial {
 	Obj Object;
-	Material* MaterialPtr;
+	void* MaterialPtr;
+};
+struct ObjResource {
+	Obj Object;
+	void* ResourcePtr;
 };
 
 ObjString* TakeString(char* chars, size_t length);
@@ -336,7 +341,8 @@ ObjStream* NewStream(Stream* streamPtr, bool writable);
 ObjNamespace* NewNamespace(Uint32 hash);
 ObjEnum* NewEnum(Uint32 hash);
 ObjModule* NewModule();
-ObjMaterial* NewMaterial(Material* material);
+ObjMaterial* NewMaterial(void* material);
+ObjResource* NewResource(void* resourcePtr);
 
 #define FREE_OBJ(obj, type) \
 	assert(GarbageCollector::GarbageSize >= sizeof(type)); \

--- a/source/Engine/Bytecode/VMThread.cpp
+++ b/source/Engine/Bytecode/VMThread.cpp
@@ -3289,6 +3289,9 @@ VMValue VMThread::Value_TypeOf() {
 		case OBJ_MATERIAL:
 			valueType = "material";
 			break;
+		case OBJ_RESOURCE:
+			valueType = "resource";
+			break;
 		}
 	}
 	}

--- a/source/Engine/Bytecode/Values.cpp
+++ b/source/Engine/Bytecode/Values.cpp
@@ -1,8 +1,8 @@
 #include <Engine/Bytecode/Values.h>
-
 #include <Engine/Diagnostics/Log.h>
-
 #include <Engine/Includes/PrintBuffer.h>
+#include <Engine/Rendering/Material.h>
+#include <Engine/ResourceTypes/ResourceType.h>
 
 // NOTE: This is for printing, not string conversion
 void Values::PrintValue(VMValue value) {
@@ -78,13 +78,16 @@ void Values::PrintObject(PrintBuffer* buffer, VMValue value, int indent, bool pr
 	case OBJ_STREAM:
 		buffer_printf(buffer, "<stream>");
 		break;
-	case OBJ_MATERIAL:
+	case OBJ_RESOURCE: {
+		ResourceType* resource = (ResourceType*)AS_RESOURCE(value)->ResourcePtr;
 		buffer_printf(buffer,
-			"<material %s>",
-			(AS_MATERIAL(value)->MaterialPtr != nullptr &&
-				AS_MATERIAL(value)->MaterialPtr->Name != nullptr)
-				? AS_MATERIAL(value)->MaterialPtr->Name
-				: "(null)");
+			"<%s \"%s\">",
+			GetResourceTypeString(resource->Type),
+			resource->Filename);
+		break;
+	}
+	case OBJ_MATERIAL:
+		buffer_printf(buffer, "<material %s>", ((Material*)AS_MATERIAL(value)->MaterialPtr)->Name);
 		break;
 	case OBJ_NAMESPACE:
 		buffer_printf(buffer,

--- a/source/Engine/FontFace.cpp
+++ b/source/Engine/FontFace.cpp
@@ -1,6 +1,7 @@
 #include <Engine/Diagnostics/Log.h>
 #include <Engine/Diagnostics/Memory.h>
 #include <Engine/FontFace.h>
+#include <Engine/IO/ResourceStream.h>
 
 #ifdef USING_FREETYPE
 #include <ft2build.h>
@@ -153,7 +154,6 @@ FT_Package* PackBoxes(FT_GlyphBox* boxes, int boxCount, int defWidth, int defHei
 
 ISprite* FontFace::SpriteFromFont(Stream* stream, int pixelSize, const char* filename) {
 #ifdef USING_FREETYPE
-
 	if (!ftInitialized) {
 		if (FT_Init_FreeType(&ftLib)) {
 			Log::Print(Log::LOG_ERROR, "FREETYPE: Could not init FreeType Library.");
@@ -304,4 +304,15 @@ ISprite* FontFace::SpriteFromFont(Stream* stream, int pixelSize, const char* fil
 
 #endif
 	return NULL;
+}
+
+ISprite* FontFace::SpriteFromFont(const char* filename, int pixelSize) {
+	ResourceStream* stream = ResourceStream::New(filename);
+	if (!stream) {
+		return nullptr;
+	}
+
+	ISprite* sprite = SpriteFromFont(stream, pixelSize, filename);
+	stream->Close();
+	return sprite;
 }

--- a/source/Engine/Graphics.cpp
+++ b/source/Engine/Graphics.cpp
@@ -416,7 +416,7 @@ void Graphics::DisposeTexture(Texture* texture) {
 TextureReference* Graphics::GetSpriteSheet(string sheetPath) {
 	if (Graphics::SpriteSheetTextureMap.count(sheetPath) != 0) {
 		TextureReference* textureRef = Graphics::SpriteSheetTextureMap.at(sheetPath);
-		textureRef->AddRef();
+		textureRef->TakeRef();
 		return textureRef;
 	}
 
@@ -433,7 +433,7 @@ TextureReference* Graphics::AddSpriteSheet(string sheetPath, Texture* texture) {
 void Graphics::DisposeSpriteSheet(string sheetPath) {
 	if (Graphics::SpriteSheetTextureMap.count(sheetPath) != 0) {
 		TextureReference* textureRef = Graphics::SpriteSheetTextureMap.at(sheetPath);
-		if (textureRef->TakeRef()) {
+		if (textureRef->ReleaseRef()) {
 			Graphics::DisposeTexture(textureRef->TexturePtr);
 			Graphics::SpriteSheetTextureMap.erase(sheetPath);
 			delete textureRef;

--- a/source/Engine/Includes/Standard.h
+++ b/source/Engine/Includes/Standard.h
@@ -52,6 +52,7 @@ enum class KeyBind {
 	DevRecompile,
 	DevPerfSnapshot,
 	DevLayerInfo,
+	DevResourceInfo,
 	DevFastForward,
 	DevFrameStepper,
 	DevStepFrame,

--- a/source/Engine/Includes/Standard.h
+++ b/source/Engine/Includes/Standard.h
@@ -73,8 +73,10 @@ enum class KeyBind {
 #define MAX_DEFORM_LINES 0x400
 #define MAX_FRAMEBUFFER_HEIGHT 4096
 
-#define SCOPE_SCENE 0
-#define SCOPE_GAME 1
+enum {
+	SCOPE_SCENE,
+	SCOPE_GAME
+};
 
 typedef uint8_t Uint8;
 typedef uint16_t Uint16;

--- a/source/Engine/Rendering/FaceInfo.cpp
+++ b/source/Engine/Rendering/FaceInfo.cpp
@@ -1,4 +1,5 @@
 #include <Engine/Rendering/FaceInfo.h>
+#include <Engine/ResourceTypes/ResourceType.h>
 
 void FaceInfo::SetMaterial(Material* material) {
 	if (!material) {
@@ -9,9 +10,9 @@ void FaceInfo::SetMaterial(Material* material) {
 	UseMaterial = true;
 	MaterialInfo.Texture = NULL;
 
-	Image* image = material->TextureDiffuse;
-	if (image && image->TexturePtr) {
-		MaterialInfo.Texture = (Texture*)image->TexturePtr;
+	ResourceType* resource = (ResourceType*)(material->TextureDiffuse);
+	if (resource && resource->Loaded && resource->AsImage->TexturePtr) {
+		MaterialInfo.Texture = (Texture*)resource->AsImage->TexturePtr;
 	}
 
 	for (unsigned i = 0; i < 4; i++) {

--- a/source/Engine/Rendering/Material.cpp
+++ b/source/Engine/Rendering/Material.cpp
@@ -39,9 +39,7 @@ void* Material::TryLoadForModel(std::string imagePath, const char* parentDirecto
 		filename = Path::Concat(std::string(parentDirectory), filename);
 	}
 
-	vector<ResourceType*>* list = Resource::GetList(SCOPE_GAME);
-
-	ResourceType* resource = Resource::Load(list, RESOURCE_IMAGE, filename.c_str(), SCOPE_GAME);
+	ResourceType* resource = Resource::Load(RESOURCE_IMAGE, filename.c_str(), SCOPE_GAME);
 	if (resource) {
 		Resource::TakeRef(resource);
 

--- a/source/Engine/Rendering/Material.cpp
+++ b/source/Engine/Rendering/Material.cpp
@@ -5,7 +5,6 @@
 #include <Engine/Filesystem/Path.h>
 #include <Engine/ResourceTypes/Resource.h>
 #include <Engine/ResourceTypes/ResourceType.h>
-#include <Engine/Scene.h>
 #include <Engine/Utilities/StringUtils.h>
 
 std::vector<Material*> Material::List;
@@ -40,7 +39,7 @@ void* Material::TryLoadForModel(std::string imagePath, const char* parentDirecto
 		filename = Path::Concat(std::string(parentDirectory), filename);
 	}
 
-	vector<ResourceType*>* list = &Scene::ResourceList;
+	vector<ResourceType*>* list = Resource::GetList(SCOPE_GAME);
 
 	ResourceType* resource = Resource::Load(list, RESOURCE_IMAGE, filename.c_str(), SCOPE_GAME);
 	if (resource) {

--- a/source/Engine/Rendering/ModelRenderer.cpp
+++ b/source/Engine/Rendering/ModelRenderer.cpp
@@ -1,3 +1,4 @@
+#include <Engine/Graphics.h>
 #include <Engine/Rendering/ModelRenderer.h>
 #include <Engine/Rendering/PolygonRenderer.h>
 #include <Engine/Utilities/ColorUtils.h>

--- a/source/Engine/Rendering/TextureReference.cpp
+++ b/source/Engine/Rendering/TextureReference.cpp
@@ -3,14 +3,14 @@
 TextureReference::TextureReference(Texture* ptr) {
 	TexturePtr = ptr;
 	References = 0;
-	AddRef();
+	TakeRef();
 }
 
-void TextureReference::AddRef() {
+void TextureReference::TakeRef() {
 	References++;
 }
 
-bool TextureReference::TakeRef() {
+bool TextureReference::ReleaseRef() {
 	if (References == 0) {
 		abort();
 	}

--- a/source/Engine/ResourceTypes/IModel.cpp
+++ b/source/Engine/ResourceTypes/IModel.cpp
@@ -2,6 +2,7 @@
 #include <Engine/Math/Vector.h>
 #include <Engine/ResourceTypes/IModel.h>
 
+#include <Engine/Application.h>
 #include <Engine/Diagnostics/Clock.h>
 #include <Engine/Diagnostics/Memory.h>
 #include <Engine/IO/MemoryStream.h>

--- a/source/Engine/ResourceTypes/IModel.cpp
+++ b/source/Engine/ResourceTypes/IModel.cpp
@@ -13,7 +13,7 @@
 #include <Engine/ResourceTypes/ModelFormats/RSDKModel.h>
 #include <Engine/Utilities/StringUtils.h>
 
-IModel::IModel() {
+IModel::IModel(const char* filename) {
 	VertexCount = 0;
 	VertexIndexCount = 0;
 	VertexPerFace = 0;
@@ -26,24 +26,37 @@ IModel::IModel() {
 	BaseArmature = nullptr;
 	GlobalInverseMatrix = nullptr;
 	UseVertexAnimation = false;
-}
-IModel::IModel(const char* filename) {
+	LoadFailed = true;
+
 	ResourceStream* resourceStream = ResourceStream::New(filename);
 	if (!resourceStream) {
 		return;
 	}
 
-	this->Load(resourceStream, filename);
+	LoadFailed = !Load(resourceStream, filename);
 
 	if (resourceStream) {
 		resourceStream->Close();
 	}
 }
-bool IModel::Load(Stream* stream, const char* filename) {
-	if (!stream) {
-		return false;
+bool IModel::IsFile(Stream* stream) {
+	if (HatchModel::IsMagic(stream)) {
+		return true;
 	}
-	if (!filename) {
+	else if (MD3Model::IsMagic(stream)) {
+		return true;
+	}
+	else if (RSDKModel::IsMagic(stream)) {
+		return true;
+	}
+	else {
+		return ModelImporter::IsValid(stream);
+	}
+
+	return false;
+}
+bool IModel::Load(Stream* stream, const char* filename) {
+	if (!stream || !filename) {
 		return false;
 	}
 

--- a/source/Engine/ResourceTypes/ISound.cpp
+++ b/source/Engine/ResourceTypes/ISound.cpp
@@ -1,4 +1,5 @@
 #include <Engine/Audio/AudioIncludes.h>
+#include <Engine/Audio/AudioManager.h>
 #include <Engine/Diagnostics/Clock.h>
 #include <Engine/Diagnostics/Log.h>
 #include <Engine/Diagnostics/Memory.h>

--- a/source/Engine/ResourceTypes/Image.cpp
+++ b/source/Engine/ResourceTypes/Image.cpp
@@ -15,16 +15,16 @@
 #include <Engine/Utilities/StringUtils.h>
 
 Image::Image(const char* filename) {
-	AddRef();
+	TakeRef();
 	Filename = StringUtils::Duplicate(filename);
 	TexturePtr = Image::LoadTextureFromResource(Filename);
 }
 
-void Image::AddRef() {
+void Image::TakeRef() {
 	References++;
 }
 
-bool Image::TakeRef() {
+bool Image::ReleaseRef() {
 	if (References == 0) {
 		abort();
 	}

--- a/source/Engine/ResourceTypes/Image.cpp
+++ b/source/Engine/ResourceTypes/Image.cpp
@@ -15,23 +15,8 @@
 #include <Engine/Utilities/StringUtils.h>
 
 Image::Image(const char* filename) {
-	TakeRef();
 	Filename = StringUtils::Duplicate(filename);
 	TexturePtr = Image::LoadTextureFromResource(Filename);
-}
-
-void Image::TakeRef() {
-	References++;
-}
-
-bool Image::ReleaseRef() {
-	if (References == 0) {
-		abort();
-	}
-
-	References--;
-
-	return References == 0;
 }
 
 void Image::Dispose() {

--- a/source/Engine/ResourceTypes/ImageFormats/ImageFormat.cpp
+++ b/source/Engine/ResourceTypes/ImageFormats/ImageFormat.cpp
@@ -1,4 +1,6 @@
 #include <Engine/Diagnostics/Memory.h>
+#include <Engine/IO/ResourceStream.h>
+#include <Engine/IO/Stream.h>
 #include <Engine/ResourceTypes/ImageFormats/ImageFormat.h>
 
 Uint32* ImageFormat::GetPalette() {

--- a/source/Engine/ResourceTypes/ImageFormats/JPEG.cpp
+++ b/source/Engine/ResourceTypes/ImageFormats/JPEG.cpp
@@ -93,13 +93,9 @@ static void jpeg_Hatch_IO_src(j_decompress_ptr cinfo, Stream* stream) {
 }
 #endif
 
-JPEG* JPEG::Load(const char* filename) {
+JPEG* JPEG::Load(Stream* stream) {
 #ifdef USING_LIBJPEG
 	JPEG* jpeg = new JPEG;
-	Stream* stream = NULL;
-	// size_t fileSize;
-	// void*  fileBuffer = NULL;
-	// SDL_Surface* temp = NULL,* tempOld = NULL;
 
 	// JPEG variables
 	Sint64 start;
@@ -111,12 +107,6 @@ JPEG* JPEG::Load(const char* filename) {
 
 	Uint32 Rmask, Gmask, Bmask, Amask;
 	bool doConvert;
-
-	stream = ResourceStream::New(filename);
-	if (!stream) {
-		Log::Print(Log::LOG_ERROR, "Could not open file '%s'!", filename);
-		goto JPEG_Load_FAIL;
-	}
 
 	start = stream->Position();
 
@@ -249,9 +239,6 @@ JPEG_Load_FAIL:
 JPEG_Load_Success:
 	if (cinfoFlag) {
 		jpeg_destroy_decompress(&cinfo);
-	}
-	if (stream) {
-		stream->Close();
 	}
 	return jpeg;
 #endif

--- a/source/Engine/ResourceTypes/ImageFormats/PNG.cpp
+++ b/source/Engine/ResourceTypes/ImageFormats/PNG.cpp
@@ -37,10 +37,9 @@ void png_read_fn(png_structp ctx, png_bytep area, png_size_t size) {
 #include <Libraries/stb_image.h>
 #endif
 
-PNG* PNG::Load(const char* filename) {
+PNG* PNG::Load(Stream* stream) {
 #ifdef USING_LIBPNG
 	PNG* png = new PNG;
-	Stream* stream = NULL;
 
 	// PNG variables
 	png_structp png_ptr = NULL;
@@ -52,12 +51,6 @@ PNG* PNG::Load(const char* filename) {
 	Uint32* pixelData = NULL;
 	png_bytep* row_pointers = NULL;
 	Uint32 row_bytes;
-
-	stream = ResourceStream::New(filename);
-	if (!stream) {
-		Log::Print(Log::LOG_ERROR, "Could not open file '%s'!", filename);
-		goto PNG_Load_FAIL;
-	}
 
 	png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
 	if (png_ptr == NULL) {
@@ -170,13 +163,9 @@ PNG_Load_Success:
 		png_destroy_read_struct(
 			&png_ptr, info_ptr ? &info_ptr : (png_infopp)NULL, (png_infopp)NULL);
 	}
-	if (stream) {
-		stream->Close();
-	}
 	return png;
 #elif defined(USING_SPNG)
 	PNG* png = new PNG;
-	Stream* stream = NULL;
 	Uint8* pixelData = NULL;
 	Uint8* buffer = NULL;
 	size_t buffer_len = 0;
@@ -191,16 +180,9 @@ PNG_Load_Success:
 	size_t image_size;
 	int ret;
 
-	stream = ResourceStream::New(filename);
-	if (!stream) {
-		Log::Print(Log::LOG_ERROR, "Could not open file '%s'!", filename);
-		goto PNG_Load_FAIL;
-	}
-
 	buffer_len = stream->Length();
 	buffer = (Uint8*)malloc(buffer_len);
 	stream->ReadBytes(buffer, buffer_len);
-	stream->Close();
 
 	ctx = spng_ctx_new(0);
 	if (ctx == NULL) {
@@ -308,23 +290,15 @@ PNG_Load_Success:
 	return png;
 #else
 	PNG* png = new PNG;
-	Stream* stream = NULL;
 	Uint32* pixelData = NULL;
 	int num_channels;
 	int width, height;
 	Uint8* buffer = NULL;
 	size_t buffer_len = 0;
 
-	stream = ResourceStream::New(filename);
-	if (!stream) {
-		Log::Print(Log::LOG_ERROR, "Could not open file '%s'!", filename);
-		goto PNG_Load_FAIL;
-	}
-
 	buffer_len = stream->Length();
 	buffer = (Uint8*)malloc(buffer_len);
 	stream->ReadBytes(buffer, buffer_len);
-	stream->Close();
 
 	pixelData = (Uint32*)stbi_load_from_memory(
 		buffer, buffer_len, &width, &height, &num_channels, STBI_rgb_alpha);

--- a/source/Engine/ResourceTypes/ModelFormats/HatchModel.cpp
+++ b/source/Engine/ResourceTypes/ModelFormats/HatchModel.cpp
@@ -4,6 +4,7 @@
 #include <Engine/Rendering/3D.h>
 #include <Engine/Rendering/Material.h>
 #include <Engine/Rendering/Mesh.h>
+#include <Engine/ResourceTypes/ResourceType.h>
 #include <Engine/ResourceTypes/ModelFormats/HatchModel.h>
 #include <Engine/Utilities/ColorUtils.h>
 
@@ -58,7 +59,7 @@ Material* HatchModel::ReadMaterial(Stream* stream, const char* parentDirectory) 
 		material->TextureDiffuse = Material::LoadForModel(diffuseTexture, parentDirectory);
 		if (material->TextureDiffuse) {
 			material->TextureDiffuseName =
-				StringUtils::Duplicate(material->TextureDiffuse->Filename);
+				StringUtils::Duplicate(((ResourceType*)material->TextureDiffuse)->Filename);
 		}
 
 		Memory::Free(diffuseTexture);
@@ -77,7 +78,7 @@ Material* HatchModel::ReadMaterial(Stream* stream, const char* parentDirectory) 
 			Material::LoadForModel(specularTexture, parentDirectory);
 		if (material->TextureSpecular) {
 			material->TextureSpecularName =
-				StringUtils::Duplicate(material->TextureSpecular->Filename);
+				StringUtils::Duplicate(((ResourceType*)material->TextureSpecular)->Filename);
 		}
 
 		Memory::Free(specularTexture);
@@ -95,7 +96,7 @@ Material* HatchModel::ReadMaterial(Stream* stream, const char* parentDirectory) 
 		material->TextureAmbient = Material::LoadForModel(ambientTexture, parentDirectory);
 		if (material->TextureAmbient) {
 			material->TextureAmbientName =
-				StringUtils::Duplicate(material->TextureAmbient->Filename);
+				StringUtils::Duplicate(((ResourceType*)material->TextureAmbient)->Filename);
 		}
 
 		Memory::Free(ambientTexture);
@@ -114,7 +115,7 @@ Material* HatchModel::ReadMaterial(Stream* stream, const char* parentDirectory) 
 			Material::LoadForModel(emissiveTexture, parentDirectory);
 		if (material->TextureEmissive) {
 			material->TextureEmissiveName =
-				StringUtils::Duplicate(material->TextureEmissive->Filename);
+				StringUtils::Duplicate(((ResourceType*)material->TextureEmissive)->Filename);
 		}
 
 		Memory::Free(emissiveTexture);

--- a/source/Engine/ResourceTypes/ModelFormats/Importer.cpp
+++ b/source/Engine/ResourceTypes/ModelFormats/Importer.cpp
@@ -507,6 +507,35 @@ bool ModelImporter::DoConversion(const struct aiScene* scene, IModel* imodel) {
 }
 #endif
 
+int ModelImporter::GetConversionFlags() {
+	return aiProcessPreset_TargetRealtime_Fast | aiProcess_ConvertToLeftHanded;
+}
+bool ModelImporter::IsValid(Stream* stream) {
+#ifdef USING_ASSIMP
+	size_t size = stream->Length();
+	void* data = Memory::Malloc(size);
+	if (data) {
+		stream->ReadBytes(data, size);
+	}
+	else {
+		return false;
+	}
+
+	Assimp::Importer importer;
+
+	int flags = GetConversionFlags();
+
+	const struct aiScene* scene = importer.ReadFileFromMemory(data, size, flags);
+	if (scene && scene->mRootNode && (scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE) == 0) {
+		Memory::Free(data);
+		return true;
+	}
+
+	Memory::Free(data);
+#endif
+
+	return false;
+}
 bool ModelImporter::Convert(IModel* model, Stream* stream, const char* path) {
 #ifdef USING_ASSIMP
 	size_t size = stream->Length();
@@ -521,8 +550,7 @@ bool ModelImporter::Convert(IModel* model, Stream* stream, const char* path) {
 
 	Assimp::Importer importer;
 
-	int flags = aiProcessPreset_TargetRealtime_Fast;
-	flags |= aiProcess_ConvertToLeftHanded;
+	int flags = GetConversionFlags();
 
 	const struct aiScene* scene =
 		importer.ReadFileFromMemory(data, size, flags, StringUtils::GetExtension(path));

--- a/source/Engine/ResourceTypes/ModelFormats/MD3Model.cpp
+++ b/source/Engine/ResourceTypes/ModelFormats/MD3Model.cpp
@@ -3,6 +3,7 @@
 #include <Engine/Rendering/3D.h>
 #include <Engine/Rendering/Material.h>
 #include <Engine/Rendering/Mesh.h>
+#include <Engine/ResourceTypes/ResourceType.h>
 #include <Engine/ResourceTypes/ModelFormats/MD3Model.h>
 
 #define MD3_MODEL_MAGIC 0x49445033 // IDP3
@@ -315,7 +316,7 @@ bool MD3Model::Convert(IModel* model, Stream* stream, const char* path) {
 				Material::LoadForModel(MaterialNames[i], parentDirectory);
 			if (material->TextureDiffuse) {
 				material->TextureDiffuseName =
-					StringUtils::Duplicate(material->TextureDiffuse->Filename);
+					StringUtils::Duplicate(((ResourceType*)material->TextureDiffuse)->Filename);
 			}
 			model->AddUniqueMaterial(material);
 		}

--- a/source/Engine/ResourceTypes/Resource.cpp
+++ b/source/Engine/ResourceTypes/Resource.cpp
@@ -41,6 +41,25 @@ void Resource::TakeRef(ResourceType* resource) {
 	}
 }
 
+bool Resource::Reload(ResourceType* resource) {
+	if (!resource) {
+		return false;
+	}
+
+	UnloadData(resource);
+
+	resource->Loaded = false;
+
+	// Try loading it.
+	void* resData = LoadData(resource->Type, resource->Filename);
+	if (resData != nullptr) {
+		resource->AsAny = resData;
+		resource->Loaded = true;
+	}
+
+	return resource->Loaded;
+}
+
 void Resource::Unload(ResourceType* resource) {
 	if (resource && resource->Loaded) {
 		UnloadData(resource);

--- a/source/Engine/ResourceTypes/Resource.cpp
+++ b/source/Engine/ResourceTypes/Resource.cpp
@@ -271,7 +271,7 @@ void* Resource::LoadData(Uint8 type, const char* filename) {
 	}
 	case RESOURCE_MODEL: {
 		IModel* resData = new (std::nothrow) IModel(filename);
-		if (!resData->LoadFailed) {
+		if (resData->LoadFailed) {
 			delete resData;
 			return nullptr;
 		}

--- a/source/Engine/ResourceTypes/Resource.cpp
+++ b/source/Engine/ResourceTypes/Resource.cpp
@@ -1,0 +1,317 @@
+#include <Engine/Diagnostics/Memory.h>
+#include <Engine/FontFace.h>
+#include <Engine/Hashing/CRC32.h>
+#include <Engine/IO/ResourceStream.h>
+#include <Engine/ResourceTypes/Resource.h>
+#include <Engine/Utilities/StringUtils.h>
+
+ResourceType* Resource::New(Uint8 type, const char* filename, Uint32 hash, int unloadPolicy) {
+	ResourceType* resource = new (std::nothrow) ResourceType();
+	resource->Type = type;
+	resource->Filename = StringUtils::Duplicate(filename);
+	resource->FilenameHash = hash;
+	resource->UnloadPolicy = unloadPolicy;
+	AddRef(resource);
+	return resource;
+}
+
+void* Resource::GetVMObject(ResourceType* resource) {
+	if (resource->VMObject == nullptr) {
+		resource->VMObject = (void*)(NewResource(resource));
+		Resource::TakeRef(resource);
+	}
+
+	return resource->VMObject;
+}
+
+void Resource::AddRef(ResourceType* resource) {
+	resource->RefCount++;
+}
+
+void Resource::DecRef(ResourceType* resource) {
+	resource->RefCount--;
+	if (resource->RefCount == 0) {
+		Delete(resource);
+	}
+}
+
+void Resource::TakeRef(ResourceType* resource) {
+	if (resource) {
+		AddRef(resource);
+	}
+}
+
+void Resource::Unload(ResourceType* resource) {
+	if (resource && resource->Loaded) {
+		UnloadData(resource);
+
+		resource->Loaded = false;
+	}
+}
+
+void Resource::Release(ResourceType* resource) {
+	if (resource) {
+		DecRef(resource);
+	}
+}
+
+void Resource::Delete(ResourceType* resource) {
+	if (resource) {
+		if (resource->Loaded) {
+			Unload(resource);
+		}
+
+		Memory::Free(resource->Filename);
+
+		delete resource;
+	}
+}
+
+int Resource::Search(vector<ResourceType*>* list, Uint8 type, const char* filename, Uint32 hash) {
+	for (size_t i = 0, listSz = list->size(); i < listSz; i++) {
+		if ((*list)[i]->Type == type
+		&& (*list)[i]->FilenameHash == hash
+		&& strcmp((*list)[i]->Filename, filename) == 0) {
+			return (int)i;
+		}
+	}
+
+	return -1;
+}
+
+ResourceType* Resource::Load(vector<ResourceType*>* list, Uint8 type, const char* filename, int unloadPolicy) {
+	switch (type) {
+	case RESOURCE_SPRITE:
+	case RESOURCE_IMAGE:
+	case RESOURCE_AUDIO:
+	case RESOURCE_MODEL:
+	case RESOURCE_MEDIA:
+		return LoadInternal(list, type, filename, unloadPolicy);
+	default:
+		break;
+	}
+
+	return nullptr;
+}
+
+ResourceType* Resource::LoadInternal(vector<ResourceType*>* list, Uint8 type, const char* filename, int unloadPolicy) {
+	// Find a resource that already exists.
+	Uint32 hash = CRC32::EncryptString(filename);
+	int result = Search(list, type, filename, hash);
+	if (result != -1) {
+		return (*list)[result];
+	}
+
+	// Try loading it.
+	void* resData = LoadData(type, filename);
+	if (resData == nullptr) {
+		return nullptr;
+	}
+
+	// Allocate a new resource.
+	ResourceType* resource = New(type, filename, hash, unloadPolicy);
+	resource->AsAny = resData;
+	resource->Loaded = true;
+
+	// Add it to the list.
+	list->push_back(resource);
+
+	return resource;
+}
+
+ResourceType* Resource::LoadFont(vector<ResourceType*>* list, const char* filename, int pixel_sz, int unloadPolicy) {
+	// Find a resource that already exists.
+	Uint32 hash = CRC32::EncryptString(filename);
+	hash = CRC32::EncryptData(&pixel_sz, sizeof(int), hash);
+
+	int result = Search(list, RESOURCE_FONT, filename, hash);
+	if (result != -1) {
+		return (*list)[result];
+	}
+
+	// Try loading it.
+	ISprite* resData = LoadFontData(filename, pixel_sz);
+	if (!resData) {
+		return nullptr;
+	}
+
+	// Allocate a new resource.
+	ResourceType* resource = New(RESOURCE_FONT, filename, hash, unloadPolicy);
+	resource->AsSprite = resData;
+	resource->Loaded = true;
+
+	// Add it to the list.
+	list->push_back(resource);
+
+	return resource;
+}
+
+void* Resource::LoadData(Uint8 type, const char* filename) {
+	switch (type) {
+	case RESOURCE_SPRITE: {
+		ISprite* resData = new (std::nothrow) ISprite(filename);
+		if (resData->LoadFailed) {
+			delete resData;
+			return nullptr;
+		}
+		return resData;
+	}
+	case RESOURCE_IMAGE: {
+		Image* resData = new (std::nothrow) Image(filename);
+		if (!resData->TexturePtr) {
+			delete resData;
+			return nullptr;
+		}
+		return resData;
+	}
+	case RESOURCE_AUDIO: {
+		ISound* resData = new (std::nothrow) ISound(filename);
+		if (resData->LoadFailed) {
+			delete resData;
+			return nullptr;
+		}
+		return resData;
+	}
+	case RESOURCE_MODEL: {
+		// TODO: Make IModel constructor consistent with the others
+		ResourceStream* stream = ResourceStream::New(filename);
+		if (!stream) {
+			return nullptr;
+		}
+
+		IModel* resData = new (std::nothrow) IModel();
+		if (!resData->Load(stream, filename)) {
+			delete resData;
+			return nullptr;
+		}
+
+		return resData;
+	}
+	case RESOURCE_MEDIA:
+		return LoadMediaBag(filename);
+	default:
+		break;
+	}
+
+	return nullptr;
+}
+
+ISprite* Resource::LoadFontData(const char* filename, int pixel_sz) {
+	return FontFace::SpriteFromFont(filename, pixel_sz);
+}
+
+MediaBag* Resource::LoadMediaBag(const char* filename) {
+#ifdef USING_FFMPEG
+	Stream* stream = ResourceStream::New(filename);
+	if (!stream) {
+		return nullptr;
+	}
+
+	MediaSource* Source = MediaSource::CreateSourceFromStream(stream);
+	if (!Source) {
+		return nullptr;
+	}
+
+	MediaPlayer* Player = MediaPlayer::Create(Source,
+		Source->GetBestStream(MediaSource::STREAMTYPE_VIDEO),
+		Source->GetBestStream(MediaSource::STREAMTYPE_AUDIO),
+		Source->GetBestStream(MediaSource::STREAMTYPE_SUBTITLE),
+		Scene::Views[0].Width,
+		Scene::Views[0].Height);
+	if (!Player) {
+		Source->Close();
+		return nullptr;
+	}
+
+	PlayerInfo playerInfo;
+	Player->GetInfo(&playerInfo);
+	Texture* VideoTexture = Graphics::CreateTexture(playerInfo.Video.Output.Format,
+		SDL_TEXTUREACCESS_STATIC,
+		playerInfo.Video.Output.Width,
+		playerInfo.Video.Output.Height);
+	if (!VideoTexture) {
+		Player->Close();
+		Source->Close();
+		return nullptr;
+	}
+
+	if (Player->GetVideoStream() > -1) {
+		Log::Print(Log::LOG_WARN, "VIDEO STREAM:");
+		Log::Print(Log::LOG_INFO,
+			"    Resolution:  %d x %d",
+			playerInfo.Video.Output.Width,
+			playerInfo.Video.Output.Height);
+	}
+	if (Player->GetAudioStream() > -1) {
+		Log::Print(Log::LOG_WARN, "AUDIO STREAM:");
+		Log::Print(
+			Log::LOG_INFO, "    Sample Rate: %d", playerInfo.Audio.Output.SampleRate);
+		Log::Print(Log::LOG_INFO,
+			"    Bit Depth:   %d-bit",
+			playerInfo.Audio.Output.Format & 0xFF);
+		Log::Print(Log::LOG_INFO, "    Channels:    %d", playerInfo.Audio.Output.Channels);
+	}
+
+	MediaBag* newMediaBag = new (std::nothrow) MediaBag;
+	newMediaBag->Source = Source;
+	newMediaBag->Player = Player;
+	newMediaBag->VideoTexture = VideoTexture;
+	return newMediaBag;
+#else
+	return nullptr;
+#endif
+}
+
+bool Resource::UnloadData(ResourceType* resource) {
+	switch (resource->Type) {
+	case RESOURCE_SPRITE:
+	case RESOURCE_FONT:
+		if (resource->AsSprite != nullptr) {
+			delete resource->AsSprite;
+			resource->AsSprite = nullptr;
+			return true;
+		}
+		break;
+	case RESOURCE_IMAGE:
+		if (resource->AsImage != nullptr) {
+			if (resource->AsImage->ReleaseRef()) {
+				delete resource->AsImage;
+			}
+			resource->AsImage = nullptr;
+			return true;
+		}
+		break;
+	case RESOURCE_AUDIO:
+		if (resource->AsAudio != nullptr) {
+			AudioManager::Unload(resource->AsAudio);
+			delete resource->AsAudio;
+			resource->AsModel = nullptr;
+			return true;
+		}
+		break;
+	case RESOURCE_MODEL:
+		if (resource->AsModel != nullptr) {
+			delete resource->AsModel;
+			resource->AsModel = nullptr;
+			return true;
+		}
+		break;
+	case RESOURCE_MEDIA:
+		if (resource->AsMedia != nullptr) {
+#ifdef USING_FFMPEG
+			AudioManager::Lock();
+			resource->AsMedia->Player->Close();
+			resource->AsMedia->Source->Close();
+			AudioManager::Unlock();
+#endif
+			delete resource->AsMedia;
+			resource->AsMedia = nullptr;
+			return true;
+		}
+		break;
+	default:
+		break;
+	}
+
+	return false;
+}

--- a/source/Engine/ResourceTypes/Resource.cpp
+++ b/source/Engine/ResourceTypes/Resource.cpp
@@ -365,9 +365,7 @@ bool Resource::UnloadData(ResourceType* resource) {
 		break;
 	case RESOURCE_IMAGE:
 		if (resource->AsImage != nullptr) {
-			if (resource->AsImage->ReleaseRef()) {
-				delete resource->AsImage;
-			}
+			delete resource->AsImage;
 			resource->AsImage = nullptr;
 			return true;
 		}

--- a/source/Engine/ResourceTypes/Resource.cpp
+++ b/source/Engine/ResourceTypes/Resource.cpp
@@ -48,6 +48,13 @@ void* Resource::GetVMObject(ResourceType* resource) {
 	return resource->VMObject;
 }
 
+void Resource::ReleaseVMObject(ResourceType* resource) {
+	if (resource->VMObject != nullptr) {
+		resource->VMObject = nullptr;
+		Resource::Release(resource);
+	}
+}
+
 void Resource::AddRef(ResourceType* resource) {
 	resource->RefCount++;
 }

--- a/source/Engine/ResourceTypes/Resource.cpp
+++ b/source/Engine/ResourceTypes/Resource.cpp
@@ -76,13 +76,10 @@ bool Resource::Reload(ResourceType* resource) {
 		return false;
 	}
 
-	UnloadData(resource);
-
-	resource->Loaded = false;
-
 	// Try loading it.
 	void* resData = LoadData(resource->Type, resource->Filename);
 	if (resData != nullptr) {
+		UnloadData(resource); // Unload only if loading succeeded
 		resource->AsAny = resData;
 		resource->Loaded = true;
 	}

--- a/source/Engine/ResourceTypes/Resource.h
+++ b/source/Engine/ResourceTypes/Resource.h
@@ -22,6 +22,7 @@ public:
 	static ResourceType* Load(vector<ResourceType*>* list, Uint8 type, const char* filename, int unloadPolicy);
 	static ResourceType* LoadFont(vector<ResourceType*>* list, const char* filename, int pixel_sz, int unloadPolicy);
 	static void TakeRef(ResourceType* resource);
+	static bool Reload(ResourceType* resource);
 	static void Unload(ResourceType* resource);
 	static void Release(ResourceType* resource);
 };

--- a/source/Engine/ResourceTypes/Resource.h
+++ b/source/Engine/ResourceTypes/Resource.h
@@ -10,20 +10,20 @@ private:
 	static void AddRef(ResourceType* resource);
 	static void DecRef(ResourceType* resource);
 	static bool UnloadData(ResourceType* resource);
-	static int Search(vector<ResourceType*>* list, Uint8 type, const char* filename, Uint32 hash);
-	static ResourceType* LoadInternal(vector<ResourceType*>* list, Uint8 type, const char* filename, int unloadPolicy);
+	static int Search(Uint8 type, const char* filename, Uint32 hash);
+	static ResourceType* LoadInternal(Uint8 type, const char* filename, int unloadPolicy);
 	static Uint8 GuessType(const char* filename);
 	static void* LoadData(Uint8 type, const char* filename);
 	static ISprite* LoadFontData(const char* filename, int pixel_sz);
 	static MediaBag* LoadMediaBag(const char* filename);
 
 public:
-	static vector<ResourceType*>* GetList(Uint32 scope);
-	static void DisposeInList(std::vector<ResourceType*>* list, Uint32 scope);
-	static void DisposeGlobal();
+	static vector<ResourceType*>* GetList();
+	static void DisposeInScope(Uint32 scope);
+	static void DisposeAll();
 	static void* GetVMObject(ResourceType* resource);
-	static ResourceType* Load(vector<ResourceType*>* list, Uint8 type, const char* filename, int unloadPolicy);
-	static ResourceType* LoadFont(vector<ResourceType*>* list, const char* filename, int pixel_sz, int unloadPolicy);
+	static ResourceType* Load(Uint8 type, const char* filename, int unloadPolicy);
+	static ResourceType* LoadFont(const char* filename, int pixel_sz, int unloadPolicy);
 	static void TakeRef(ResourceType* resource);
 	static bool Reload(ResourceType* resource);
 	static void Unload(ResourceType* resource);

--- a/source/Engine/ResourceTypes/Resource.h
+++ b/source/Engine/ResourceTypes/Resource.h
@@ -18,6 +18,9 @@ private:
 	static MediaBag* LoadMediaBag(const char* filename);
 
 public:
+	static vector<ResourceType*>* GetList(Uint32 scope);
+	static void DisposeInList(std::vector<ResourceType*>* list, Uint32 scope);
+	static void DisposeGlobal();
 	static void* GetVMObject(ResourceType* resource);
 	static ResourceType* Load(vector<ResourceType*>* list, Uint8 type, const char* filename, int unloadPolicy);
 	static ResourceType* LoadFont(vector<ResourceType*>* list, const char* filename, int pixel_sz, int unloadPolicy);

--- a/source/Engine/ResourceTypes/Resource.h
+++ b/source/Engine/ResourceTypes/Resource.h
@@ -1,0 +1,28 @@
+#ifndef ENGINE_RESOURCETYPES_RESOURCE_H
+#define ENGINE_RESOURCETYPES_RESOURCE_H
+
+#include <Engine/ResourceTypes/ResourceType.h>
+
+class Resource {
+private:
+	static ResourceType* New(Uint8 type, const char* filename, Uint32 hash, int unloadPolicy);
+	static void Delete(ResourceType* resource);
+	static void AddRef(ResourceType* resource);
+	static void DecRef(ResourceType* resource);
+	static bool UnloadData(ResourceType* resource);
+	static int Search(vector<ResourceType*>* list, Uint8 type, const char* filename, Uint32 hash);
+	static ResourceType* LoadInternal(vector<ResourceType*>* list, Uint8 type, const char* filename, int unloadPolicy);
+	static void* LoadData(Uint8 type, const char* filename);
+	static ISprite* LoadFontData(const char* filename, int pixel_sz);
+	static MediaBag* LoadMediaBag(const char* filename);
+
+public:
+	static void* GetVMObject(ResourceType* resource);
+	static ResourceType* Load(vector<ResourceType*>* list, Uint8 type, const char* filename, int unloadPolicy);
+	static ResourceType* LoadFont(vector<ResourceType*>* list, const char* filename, int pixel_sz, int unloadPolicy);
+	static void TakeRef(ResourceType* resource);
+	static void Unload(ResourceType* resource);
+	static void Release(ResourceType* resource);
+};
+
+#endif /* ENGINE_RESOURCETYPES_RESOURCE_H */

--- a/source/Engine/ResourceTypes/Resource.h
+++ b/source/Engine/ResourceTypes/Resource.h
@@ -22,6 +22,7 @@ public:
 	static void DisposeInScope(Uint32 scope);
 	static void DisposeAll();
 	static void* GetVMObject(ResourceType* resource);
+	static void ReleaseVMObject(ResourceType* resource);
 	static ResourceType* Load(Uint8 type, const char* filename, int unloadPolicy);
 	static ResourceType* LoadFont(const char* filename, int pixel_sz, int unloadPolicy);
 	static void TakeRef(ResourceType* resource);

--- a/source/Engine/ResourceTypes/Resource.h
+++ b/source/Engine/ResourceTypes/Resource.h
@@ -12,6 +12,7 @@ private:
 	static bool UnloadData(ResourceType* resource);
 	static int Search(vector<ResourceType*>* list, Uint8 type, const char* filename, Uint32 hash);
 	static ResourceType* LoadInternal(vector<ResourceType*>* list, Uint8 type, const char* filename, int unloadPolicy);
+	static Uint8 GuessType(const char* filename);
 	static void* LoadData(Uint8 type, const char* filename);
 	static ISprite* LoadFontData(const char* filename, int pixel_sz);
 	static MediaBag* LoadMediaBag(const char* filename);

--- a/source/Engine/ResourceTypes/ResourceType.h
+++ b/source/Engine/ResourceTypes/ResourceType.h
@@ -43,6 +43,19 @@ inline const char* GetResourceTypeString(Uint8 type) {
 	return "unknown";
 }
 
+inline const char* GetResourceScopeString(Uint8 scope) {
+	switch (scope) {
+	case SCOPE_GAME:
+		return "game";
+	case SCOPE_SCENE:
+		return "scene";
+	default:
+		break;
+	}
+
+	return "unknown";
+}
+
 struct MediaBag {
 	Texture* VideoTexture;
 	MediaSource* Source;

--- a/source/Engine/ResourceTypes/ResourceType.h
+++ b/source/Engine/ResourceTypes/ResourceType.h
@@ -9,6 +9,40 @@
 #include <Engine/ResourceTypes/ISprite.h>
 #include <Engine/ResourceTypes/Image.h>
 
+enum {
+	RESOURCE_NONE,
+	RESOURCE_SPRITE,
+	RESOURCE_IMAGE,
+	RESOURCE_AUDIO,
+	RESOURCE_FONT,
+	RESOURCE_SHADER,
+	RESOURCE_MODEL,
+	RESOURCE_MEDIA
+};
+
+inline const char* GetResourceTypeString(Uint8 type) {
+	switch (type) {
+	case RESOURCE_SPRITE:
+		return "sprite";
+	case RESOURCE_IMAGE:
+		return "image";
+	case RESOURCE_AUDIO:
+		return "audio";
+	case RESOURCE_FONT:
+		return "font";
+	case RESOURCE_SHADER:
+		return "shader";
+	case RESOURCE_MODEL:
+		return "model";
+	case RESOURCE_MEDIA:
+		return "media";
+	default:
+		break;
+	}
+
+	return "unknown";
+}
+
 struct MediaBag {
 	Texture* VideoTexture;
 	MediaSource* Source;
@@ -17,18 +51,23 @@ struct MediaBag {
 };
 
 struct ResourceType {
-	Uint32 FilenameHash;
+	Uint8 Type = RESOURCE_NONE;
+	char* Filename = nullptr;
+	Uint32 FilenameHash = 0;
+	bool Loaded = false;
+	int RefCount = 0;
+	void* VMObject;
+	Uint32 UnloadPolicy;
 	union {
 		ISprite* AsSprite;
 		Image* AsImage;
-		ISound* AsSound;
-		ISound* AsMusic;
+		ISound* AsAudio;
 		void* AsFont;
 		void* AsShader;
 		IModel* AsModel;
 		MediaBag* AsMedia;
+		void* AsAny;
 	};
-	Uint32 UnloadPolicy;
 };
 
 #endif /* ENGINE_RESOURCETYPES_RESOURCETYPE_H */

--- a/source/Engine/ResourceTypes/SceneFormats/RSDKSceneReader.cpp
+++ b/source/Engine/ResourceTypes/SceneFormats/RSDKSceneReader.cpp
@@ -682,12 +682,14 @@ bool RSDKSceneReader::LoadTileset(const char* parentFolder) {
 
 	char filename16x16Tiles[MAX_RESOURCE_PATH_LENGTH];
 	snprintf(filename16x16Tiles, sizeof(filename16x16Tiles), "%s16x16Tiles.gif", parentFolder);
-	{
+
+	Stream* resourceStream = ResourceStream::New(filename16x16Tiles);
+	if (resourceStream != nullptr) {
 		GIF* gif;
 		bool loadPalette = Graphics::UsePalettes;
 
 		Graphics::UsePalettes = false;
-		gif = GIF::Load(filename16x16Tiles);
+		gif = GIF::Load(resourceStream);
 		Graphics::UsePalettes = loadPalette;
 
 		if (gif) {
@@ -699,6 +701,8 @@ bool RSDKSceneReader::LoadTileset(const char* parentFolder) {
 			}
 			delete gif;
 		}
+
+		resourceStream->Close();
 	}
 
 	ISprite* tileSprite = new ISprite();

--- a/source/Engine/ResourceTypes/SoundFormats/OGG.cpp
+++ b/source/Engine/ResourceTypes/SoundFormats/OGG.cpp
@@ -64,15 +64,10 @@ long OGG::StaticTell(void* ptr) {
 	return ((class Stream*)ptr)->Position();
 }
 
-SoundFormat* OGG::Load(const char* filename) {
+SoundFormat* OGG::Load(Stream* stream) {
 	VorbisGroup* vorbis;
 
 	OGG* ogg = NULL;
-	class Stream* stream = ResourceStream::New(filename);
-	if (!stream) {
-		Log::Print(Log::LOG_ERROR, "Could not open file '%s'!", filename);
-		goto OGG_Load_FAIL;
-	}
 
 #ifdef USING_LIBOGG
 	ogg = new (std::nothrow) OGG;
@@ -83,10 +78,6 @@ SoundFormat* OGG::Load(const char* filename) {
 	ogg->StreamPtr = stream;
 
 	ov_callbacks callbacks;
-	// callbacks = OV_CALLBACKS_STREAMONLY;
-	// callbacks = OV_CALLBACKS_STREAMONLY_NOCLOSE;
-	// callbacks = OV_CALLBACKS_DEFAULT;
-	// callbacks = OV_CALLBACKS_NOCLOSE;
 
 	callbacks.read_func = OGG::StaticRead;
 	callbacks.seek_func = OGG::StaticSeek;
@@ -99,7 +90,7 @@ SoundFormat* OGG::Load(const char* filename) {
 
 	int res;
 	if ((res = ov_open_callbacks(ogg->StreamPtr, &vorbis->File, NULL, 0, callbacks)) != 0) {
-		Log::Print(Log::LOG_ERROR, "Could not read file '%s'!", filename);
+		Log::Print(Log::LOG_ERROR, "Could not read stream!");
 		switch (res) {
 		case OV_EREAD:
 			Log::Print(Log::LOG_ERROR, "A read from media returned an error.");
@@ -159,7 +150,7 @@ SoundFormat* OGG::Load(const char* filename) {
 			stb_vorbis_open_memory((Uint8*)vorbis->FileBlock, fileLength, &error, NULL);
 		if (!vorbis->VorbisSTB) {
 			Log::Print(
-				Log::LOG_ERROR, "Could not open Vorbis stream for %s!", filename);
+				Log::LOG_ERROR, "Could not open Vorbis stream!");
 
 			switch (error) {
 			case VORBIS_need_more_data:
@@ -280,9 +271,6 @@ OGG_Load_FAIL:
 	ogg = NULL;
 
 OGG_Load_SUCCESS:
-	if (stream) {
-		stream->Close();
-	}
 	return ogg;
 }
 

--- a/source/Engine/ResourceTypes/SoundFormats/WAV.cpp
+++ b/source/Engine/ResourceTypes/SoundFormats/WAV.cpp
@@ -15,15 +15,8 @@ struct WAVheader {
 	Uint32 DATASize; // Sampled data length
 };
 
-SoundFormat* WAV::Load(const char* filename) {
-	WAV* wav = NULL;
-	class Stream* stream = ResourceStream::New(filename);
-	if (!stream) {
-		Log::Print(Log::LOG_ERROR, "Could not open file '%s'!", filename);
-		goto WAV_Load_FAIL;
-	}
-
-	wav = new (std::nothrow) WAV;
+SoundFormat* WAV::Load(Stream* stream) {
+	WAV* wav = new (std::nothrow) WAV;
 	if (!wav) {
 		goto WAV_Load_FAIL;
 	}
@@ -68,7 +61,6 @@ SoundFormat* WAV::Load(const char* filename) {
 
 	wav->TotalPossibleSamples =
 		(int)(header.DATASize / (((header.BitsPerSample & 0xFF) >> 3) * header.Channels));
-	// stream->Seek(wav->DataStart);
 
 	// Common
 	wav->LoadFinish();

--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -121,7 +121,6 @@ int Scene::ActiveCategory;
 int Scene::DebugMode;
 
 // Resource managing variables
-vector<ResourceType*> Scene::ResourceList;
 vector<GameTexture*> Scene::TextureList;
 vector<Animator*> Scene::AnimatorList;
 
@@ -2548,7 +2547,7 @@ void Scene::UnloadTileCollisions() {
 // Resource Management
 void Scene::DisposeInScope(Uint32 scope) {
 	// Resources
-	Resource::DisposeInList(&Scene::ResourceList, scope);
+	Resource::DisposeInScope(scope);
 	// Textures
 	for (size_t i = 0, i_sz = Scene::TextureList.size(); i < i_sz; i++) {
 		if (!Scene::TextureList[i]) {
@@ -2598,7 +2597,6 @@ void Scene::Dispose() {
 
 	// Dispose of all resources
 	Scene::DisposeInScope(SCOPE_GAME);
-	Scene::ResourceList.clear();
 	Scene::TextureList.clear();
 	Scene::AnimatorList.clear();
 

--- a/source/Engine/Sprites/Animation.h
+++ b/source/Engine/Sprites/Animation.h
@@ -33,7 +33,7 @@ struct Animation {
 };
 struct Animator {
 	vector<AnimFrame> Frames;
-	int Sprite = -1;
+	void* Sprite = nullptr;
 	int CurrentAnimation = -1;
 	int CurrentFrame = -1;
 	int PrevAnimation = 0;

--- a/source/Engine/Types/Entity.cpp
+++ b/source/Engine/Types/Entity.cpp
@@ -6,14 +6,12 @@ void Entity::ApplyMotion() {
 	Y += YSpeed;
 }
 void Entity::Animate() {
-	ResourceType* resource = Scene::GetSpriteResource(Sprite);
-	if (!resource) {
+	if (!Sprite) {
 		return;
 	}
 
-	ISprite* sprite = resource->AsSprite;
-	if (!sprite || CurrentAnimation < 0 ||
-		(size_t)CurrentAnimation >= sprite->Animations.size()) {
+	ISprite* sprite = ((ResourceType*)Sprite)->AsSprite;
+	if (CurrentAnimation < 0 || (size_t)CurrentAnimation >= sprite->Animations.size()) {
 		return;
 	}
 
@@ -41,11 +39,9 @@ void Entity::Animate() {
 				CurrentFrame = AnimationLoopIndex;
 				OnAnimationFinish();
 
-				// Sprite may have changed after a call
-				// to OnAnimationFinish
-				ResourceType* resource = Scene::GetSpriteResource(Sprite);
-				if (resource) {
-					sprite = Scene::GetSpriteResource(Sprite)->AsSprite;
+				// Sprite may have changed after a call to OnAnimationFinish
+				if (Sprite) {
+					sprite = ((ResourceType*)Sprite)->AsSprite;
 				}
 				else {
 					sprite = nullptr;
@@ -80,13 +76,12 @@ void Entity::SetAnimation(int animation, int frame) {
 	}
 }
 void Entity::ResetAnimation(int animation, int frame) {
-	ResourceType* resource = Scene::GetSpriteResource(Sprite);
-	if (!resource) {
+	if (!Sprite) {
 		return;
 	}
 
-	ISprite* sprite = resource->AsSprite;
-	if (!sprite || animation < 0 || (size_t)animation >= sprite->Animations.size()) {
+	ISprite* sprite = ((ResourceType*)Sprite)->AsSprite;
+	if (animation < 0 || (size_t)animation >= sprite->Animations.size()) {
 		return;
 	}
 

--- a/source/Engine/Types/Entity.cpp
+++ b/source/Engine/Types/Entity.cpp
@@ -81,7 +81,7 @@ void Entity::ResetAnimation(int animation, int frame) {
 	}
 
 	ISprite* sprite = ((ResourceType*)Sprite)->AsSprite;
-	if (animation < 0 || (size_t)animation >= sprite->Animations.size()) {
+	if (!sprite || animation < 0 || (size_t)animation >= sprite->Animations.size()) {
 		return;
 	}
 

--- a/source/Engine/Types/Entity.cpp
+++ b/source/Engine/Types/Entity.cpp
@@ -1,3 +1,4 @@
+#include <Engine/ResourceTypes/Resource.h>
 #include <Engine/Types/Entity.h>
 
 void Entity::ApplyMotion() {
@@ -465,6 +466,18 @@ void Entity::CopyFields(Entity* other) {
 #undef COPY
 }
 
+void Entity::SetSprite(void* newSprite) {
+	if (Sprite != nullptr) {
+		Resource::Release((ResourceType*)Sprite);
+		Sprite = nullptr;
+	}
+
+	if (newSprite != nullptr) {
+		Resource::TakeRef((ResourceType*)newSprite);
+		Sprite = newSprite;
+	}
+}
+
 void Entity::ApplyPhysics() {}
 
 void Entity::Initialize() {}
@@ -491,4 +504,6 @@ void Entity::RenderLate() {}
 
 void Entity::Remove() {}
 
-void Entity::Dispose() {}
+void Entity::Dispose() {
+	SetSprite(nullptr);
+}


### PR DESCRIPTION
Changes:
- Turned resource indices into `Resource` instances
  - Adjusted all standard library functions that accepted a resource index to accept an instance of `Resource`
  - Adjusted `entity.Sprite` to accept an instance of `Resource`
  - Added proper type checking for resource types
- Implemented `Resource` constructor for scripts
- Removed reference counting from `Image`, since resources are now reference counted
- Deleted some duplicated code from `ISprite`
- Made all image and sound loaders detect file formats using their signatures, instead of their filename extensions
- Refactored `ImageFormat`/`SoundFormat` loaders to read from a `Stream`
- Moved all resource code out of `Scene`. Thank God.
- Added `devLogResourceInfo` key bind (default is F4)
  - This means `fullscreen` is no longer F4 by default.