### PR TITLE
Support palette index and global palette index table in GLSL palette shaders

### DIFF
--- a/include/Engine/Rendering/GL/GLShader.h
+++ b/include/Engine/Rendering/GL/GLShader.h
@@ -33,6 +33,7 @@ public:
 	GLint LocTextureV;
 	GLint LocPalette;
 	GLint LocPaletteLine;
+	GLint LocPaletteIndexTable;
 	GLint LocColor;
 	GLint LocDiffuseColor;
 	GLint LocSpecularColor;

--- a/include/Engine/Rendering/GL/GLShader.h
+++ b/include/Engine/Rendering/GL/GLShader.h
@@ -32,6 +32,7 @@ public:
 	GLint LocTextureU;
 	GLint LocTextureV;
 	GLint LocPalette;
+	GLint LocPaletteLine;
 	GLint LocColor;
 	GLint LocDiffuseColor;
 	GLint LocSpecularColor;

--- a/source/Engine/Rendering/GL/GLShader.cpp
+++ b/source/Engine/Rendering/GL/GLShader.cpp
@@ -145,6 +145,7 @@ void GLShader::AttachAndLink() {
 	LocTextureV = GetUniformLocation("u_textureV");
 	LocPalette = GetUniformLocation("u_paletteTexture");
 	LocPaletteLine = GetUniformLocation("u_paletteLine");
+	LocPaletteIndexTable = GetUniformLocation("u_paletteIndexTable");
 
 	LocFogColor = GetUniformLocation("u_fogColor");
 	LocFogLinearStart = GetUniformLocation("u_fogLinearStart");

--- a/source/Engine/Rendering/GL/GLShader.cpp
+++ b/source/Engine/Rendering/GL/GLShader.cpp
@@ -144,6 +144,7 @@ void GLShader::AttachAndLink() {
 	LocTextureU = GetUniformLocation("u_textureU");
 	LocTextureV = GetUniformLocation("u_textureV");
 	LocPalette = GetUniformLocation("u_paletteTexture");
+	LocPaletteLine = GetUniformLocation("u_paletteLine");
 
 	LocFogColor = GetUniformLocation("u_fogColor");
 	LocFogLinearStart = GetUniformLocation("u_fogLinearStart");

--- a/source/Engine/Rendering/GL/GLShaderBuilder.cpp
+++ b/source/Engine/Rendering/GL/GLShaderBuilder.cpp
@@ -21,7 +21,8 @@ void GLShaderBuilder::AddUniformsToShaderText(std::string& shaderText, GLShaderU
 	if (uniforms.u_palette) {
 		shaderText += "uniform sampler2D u_paletteTexture;\n";
 		shaderText += "uniform int u_paletteLine;\n";
-		shaderText += "uniform int u_paletteIndexTable[4096];\n";
+		shaderText += "uniform int u_paletteIndexTable[" +
+			std::to_string(MAX_FRAMEBUFFER_HEIGHT) + "];\n";
 	}
 	if (uniforms.u_yuv) {
 		shaderText += "uniform sampler2D u_texture;\n";
@@ -69,7 +70,8 @@ void GLShaderBuilder::AddInputsToFragmentShaderText(std::string& shaderText,
 }
 string GLShaderBuilder::BuildFragmentShaderMainFunc(GLShaderLinkage& inputs,
 	GLShaderUniforms& uniforms) {
-	std::string shaderText = "";
+	std::string shaderText;
+	std::string paletteLookupText;
 
 	if (uniforms.u_fog_linear) {
 		shaderText +=
@@ -89,14 +91,18 @@ string GLShaderBuilder::BuildFragmentShaderMainFunc(GLShaderLinkage& inputs,
 			"}\n";
 	}
 
-	std::string paletteLookupText =
-		"float paletteLine;\n"
-		"if (u_paletteLine == -1) {\n"
-		"    int screenLine = clamp(int(gl_FragCoord.y), 0, 4095);\n"
-		"    paletteLine = float(u_paletteIndexTable[screenLine]) / 256.0;\n"
-		"} else {\n"
-		"    paletteLine = float(u_paletteLine) / 256.0;\n"
-		"}\n";
+	if (uniforms.u_palette) {
+		paletteLookupText =
+			"float paletteLine;\n"
+			"if (u_paletteLine == -1) {\n"
+			"    int screenLine = clamp(int(gl_FragCoord.y), 0, " +
+			std::to_string(MAX_FRAMEBUFFER_HEIGHT) +
+			");\n"
+			"    paletteLine = float(u_paletteIndexTable[screenLine]) / 256.0;\n"
+			"} else {\n"
+			"    paletteLine = float(u_paletteLine) / 256.0;\n"
+			"}\n";
+	}
 
 	shaderText += "void main() {\n";
 	shaderText += "vec4 finalColor;\n";

--- a/source/Engine/Rendering/GL/GLShaderBuilder.cpp
+++ b/source/Engine/Rendering/GL/GLShaderBuilder.cpp
@@ -92,8 +92,8 @@ string GLShaderBuilder::BuildFragmentShaderMainFunc(GLShaderLinkage& inputs,
 	std::string paletteLookupText =
 		"float paletteLine;\n"
 		"if (u_paletteLine == -1) {\n"
-		"    int paletteLineIdx = int(gl_FragCoord.y);\n"
-		"    paletteLine = float(u_paletteIndexTable[clamp(paletteLineIdx, 0, 4095)]) / 256.0;\n"
+		"    int screenLine = clamp(int(gl_FragCoord.y), 0, 4095);\n"
+		"    paletteLine = float(u_paletteIndexTable[screenLine]) / 256.0;\n"
 		"} else {\n"
 		"    paletteLine = float(u_paletteLine) / 256.0;\n"
 		"}\n";

--- a/source/Engine/Rendering/GL/GLShaderBuilder.cpp
+++ b/source/Engine/Rendering/GL/GLShaderBuilder.cpp
@@ -96,7 +96,7 @@ string GLShaderBuilder::BuildFragmentShaderMainFunc(GLShaderLinkage& inputs,
 			"float paletteLine;\n"
 			"if (u_paletteLine == -1) {\n"
 			"    int screenLine = clamp(int(gl_FragCoord.y), 0, " +
-			std::to_string(MAX_FRAMEBUFFER_HEIGHT) +
+			std::to_string(MAX_FRAMEBUFFER_HEIGHT - 1) +
 			");\n"
 			"    paletteLine = float(u_paletteIndexTable[screenLine]) / 256.0;\n"
 			"} else {\n"

--- a/source/Engine/Rendering/GL/GLShaderBuilder.cpp
+++ b/source/Engine/Rendering/GL/GLShaderBuilder.cpp
@@ -20,6 +20,7 @@ void GLShaderBuilder::AddUniformsToShaderText(std::string& shaderText, GLShaderU
 	}
 	if (uniforms.u_palette) {
 		shaderText += "uniform sampler2D u_paletteTexture;\n";
+		shaderText += "uniform int u_paletteLine;\n";
 	}
 	if (uniforms.u_yuv) {
 		shaderText += "uniform sampler2D u_texture;\n";
@@ -97,7 +98,7 @@ string GLShaderBuilder::BuildFragmentShaderMainFunc(GLShaderLinkage& inputs,
 			if (uniforms.u_palette) {
 				shaderText += "if (base.r == 0.0) discard;\n";
 				shaderText +=
-					"base = texture2D(u_paletteTexture, vec2(base.r, 0.0));\n";
+					"base = texture2D(u_paletteTexture, vec2(base.r, float(u_paletteLine) / 256.0));\n";
 			}
 			shaderText += "if (base.a == 0.0) discard;\n";
 			shaderText += "finalColor = base * o_color;\n";
@@ -110,7 +111,7 @@ string GLShaderBuilder::BuildFragmentShaderMainFunc(GLShaderLinkage& inputs,
 			if (uniforms.u_palette) {
 				shaderText += "if (base.r == 0.0) discard;\n";
 				shaderText +=
-					"base = texture2D(u_paletteTexture, vec2(base.r, 0.0));\n";
+					"base = texture2D(u_paletteTexture, vec2(base.r, float(u_paletteLine) / 256.0));\n";
 			}
 			else {
 				shaderText += "if (base.a == 0.0) discard;\n";


### PR DESCRIPTION
Fixes the GL renderer not using the palette index when drawing sprites.

![image](https://github.com/user-attachments/assets/f2fc884e-0b07-4956-b9d4-7b2f6c289361)
![image](https://github.com/user-attachments/assets/ae20db2e-af66-48b0-9878-bb7e20f428d1)

Also, implements the global palette index table:

![image](https://github.com/user-attachments/assets/a6658152-fcfd-4328-8db1-89b755c78601)
