### PR TITLE
Game changing

### DIFF
--- a/guides/Documentation.htm
+++ b/guides/Documentation.htm
@@ -238,7 +238,6 @@
                     <li><a href="#Reference_functions_Application_GetFPS">Application.GetFPS</a></li>
                     <li><a href="#Reference_functions_Application_GetKeyBind">Application.GetKeyBind</a></li>
                     <li><a href="#Reference_functions_Application_SetKeyBind">Application.SetKeyBind</a></li>
-                    <li><a href="#Reference_functions_Application_Quit">Application.Quit</a></li>
                     <li><a href="#Reference_functions_Application_GetGameTitle">Application.GetGameTitle</a></li>
                     <li><a href="#Reference_functions_Application_GetGameTitleShort">Application.GetGameTitleShort</a></li>
                     <li><a href="#Reference_functions_Application_GetGameVersion">Application.GetGameVersion</a></li>
@@ -249,6 +248,8 @@
                     <li><a href="#Reference_functions_Application_SetGameDescription">Application.SetGameDescription</a></li>
                     <li><a href="#Reference_functions_Application_SetCursorVisible">Application.SetCursorVisible</a></li>
                     <li><a href="#Reference_functions_Application_GetCursorVisible">Application.GetCursorVisible</a></li>
+                    <li><a href="#Reference_functions_Application_ChangeGame">Application.ChangeGame</a></li>
+                    <li><a href="#Reference_functions_Application_Quit">Application.Quit</a></li>
                 </ul>
             </p>
             <p id="Reference_Array">
@@ -2460,11 +2461,6 @@
         <li>keyID (Integer): The key ID.</li>
         </ul>
         </p>
-        <p id="Reference_functions_Application_Quit">
-        <h2 style="margin-bottom: 8px;">Application.Quit</h2>
-        <code>Application.Quit()</code>
-        <div style="margin-top: 8px; font-size: 14px;">Closes the application.</div>
-        </p>
         <p id="Reference_functions_Application_GetGameTitle">
         <h2 style="margin-bottom: 8px;">Application.GetGameTitle</h2>
         <code>Application.GetGameTitle()</code>
@@ -2536,6 +2532,22 @@
         <div style="margin-top: 8px; font-size: 14px;">Gets the visibility of the cursor.</div>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns whether ot not the cursor is visible.</div>
+        </p>
+        <p id="Reference_functions_Application_ChangeGame">
+        <h2 style="margin-bottom: 8px;">Application.ChangeGame</h2>
+        <code>Application.ChangeGame(path)</code>
+        <div style="margin-top: 8px; font-size: 14px;">Changes the current game, by loading a data file containing the new game. If the path ends with a path separator (<code>/</code>), an entire directory will be loaded as the game instead.<br/><br/>This is permanent for as long as the application is running, so restarting the application using <linkto ref="KeyBind_DevRestartApp">the associated developer key</linkto> will reload the current game, and not the one the application started with. Script compiling is also disabled after the game changes.<br/><br/>The change only takes effect after a frame completes.<br/><br/>Note that certain game configurations will persist between games if not set by the new GameConfig. Those are:<ul><li>Game title (including the short game title)</li><li>Game version</li><li>Game description</li><li>Game developer</li><li>Game identifier</li><li>Developer identifier</li><li>Saves directory</li><li>Preferences directory</li><li>Palette colors</li><li>Whether palette rendering is enabled</li><li>Whether software rendering was enabled with <code>useSoftwareRenderer</code></li><li>Current settings file</li><li>Window size</li><li>Audio volume</li></ul>The following <b>cannot</b> be changed between games:<ul><li>Log file path</li><li>Graphics rendering backend</li></ul></div>
+        <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
+        <ul style="margin-top: 0px; font-size: 14px;">
+        <li>path (String): The path of the resources file to load.</li>
+        </ul>
+        <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
+        <div style="font-size: 14px;">Returns <code>true</code> if the path to the resource file exists, <code>false</code> if otherwise.</div>
+        </p>
+        <p id="Reference_functions_Application_Quit">
+        <h2 style="margin-bottom: 8px;">Application.Quit</h2>
+        <code>Application.Quit()</code>
+        <div style="margin-top: 8px; font-size: 14px;">Closes the application.</div>
         </p>
         <p id="Reference_functions_Array_Create">
         <h2 style="margin-bottom: 8px;">Array.Create</h2>
@@ -10238,7 +10250,7 @@
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
         <div style="font-size: 14px;">Returns a Map value if the text can be decoded, otherwise returns <code>null</code>.</div>
         </p>
-        <p>739 out of 798 functions have descriptions. </p>
+        <p>740 out of 799 functions have descriptions. </p>
         <hr/>
         <h3>Instance methods</h3>
         <p id="Reference_methods_instance_SetAnimation">

--- a/guides/Documentation.htm
+++ b/guides/Documentation.htm
@@ -2535,14 +2535,16 @@
         </p>
         <p id="Reference_functions_Application_ChangeGame">
         <h2 style="margin-bottom: 8px;">Application.ChangeGame</h2>
-        <code>Application.ChangeGame(path)</code>
+        <code>Application.ChangeGame(path[, startingScene, cmdLineArgs])</code>
         <div style="margin-top: 8px; font-size: 14px;">Changes the current game, by loading a data file containing the new game. If the path ends with a path separator (<code>/</code>), an entire directory will be loaded as the game instead.<br/><br/>This is permanent for as long as the application is running, so restarting the application using <linkto ref="KeyBind_DevRestartApp">the associated developer key</linkto> will reload the current game, and not the one the application started with. Script compiling is also disabled after the game changes.<br/><br/>The change only takes effect after a frame completes.<br/><br/>Note that certain game configurations will persist between games if not set by the new GameConfig. Those are:<ul><li>Game title (including the short game title)</li><li>Game version</li><li>Game description</li><li>Game developer</li><li>Game identifier</li><li>Developer identifier</li><li>Saves directory</li><li>Preferences directory</li><li>Palette colors</li><li>Whether palette rendering is enabled</li><li>Whether software rendering was enabled with <code>useSoftwareRenderer</code></li><li>Current settings file</li><li>Window size</li><li>Audio volume</li></ul>The following <b>cannot</b> be changed between games:<ul><li>Log file path</li><li>Graphics rendering backend</li></ul></div>
         <div style="font-weight: bold; margin-top: 8px;">Parameters:</div>
         <ul style="margin-top: 0px; font-size: 14px;">
-        <li>path (String): The path of the resources file to load.</li>
+        <li>path (String): The path of the data file to load.</li>
+        <li>startingScene (String): The filename of the scene file to load upon changing the game. Note that restarting the game will load the starting scene defined in its GameConfig instead. Passing <code>null</code> to this argument is equivalent to not passing it at all.</li>
+        <li>cmdLineArgs (Array): An Array of Strings containing the command line arguments to pass to the new game. If any of the values are not Strings, they will be converted to a String representation. If this argument is not given, the current command line arguments will be passed to the new game.</li>
         </ul>
         <div style="font-weight: bold; margin-top: 8px;">Returns:</div>
-        <div style="font-size: 14px;">Returns <code>true</code> if the path to the resource file exists, <code>false</code> if otherwise.</div>
+        <div style="font-size: 14px;">Returns <code>true</code> if the game will change, <code>false</code> if otherwise.</div>
         </p>
         <p id="Reference_functions_Application_Quit">
         <h2 style="margin-bottom: 8px;">Application.Quit</h2>

--- a/include/Engine/Application.h
+++ b/include/Engine/Application.h
@@ -37,6 +37,8 @@ private:
 	static bool
 	ValidateAndSetIdentifier(const char* name, const char* id, char* dest, size_t destSize);
 	static void CreateWindow();
+	static void EndGame();
+	static void UnloadGame();
 	static void Restart();
 	static void LoadVideoSettings();
 	static void LoadAudioSettings();
@@ -97,6 +99,8 @@ public:
 	static void GetPerformanceSnapshot();
 	static void SetWindowTitle(const char* title);
 	static void UpdateWindowTitle();
+	static bool SetNextGame(const char* path);
+	static bool ChangeGame(const char* path);
 	static void SetMasterVolume(int volume);
 	static void SetMusicVolume(int volume);
 	static void SetSoundVolume(int volume);

--- a/include/Engine/Application.h
+++ b/include/Engine/Application.h
@@ -53,7 +53,9 @@ private:
 	static void LoadGameConfig();
 	static void DisposeGameConfig();
 	static string ParseGameVersion(XMLNode* versionNode);
+	static void InitGameInfo();
 	static void LoadGameInfo();
+	static void DisposeSettings();
 	static int HandleAppEvents(void* data, SDL_Event* event);
 
 public:
@@ -119,7 +121,7 @@ public:
 	static void ReadSettings();
 	static void ReloadSettings();
 	static void ReloadSettings(const char* filename);
-	static void InitSettings(const char* filename);
+	static void InitSettings();
 	static void SaveSettings();
 	static void SaveSettings(const char* filename);
 	static void SetSettingsFilename(const char* filename);

--- a/include/Engine/Application.h
+++ b/include/Engine/Application.h
@@ -59,7 +59,7 @@ private:
 	static int HandleAppEvents(void* data, SDL_Event* event);
 
 public:
-	static vector<char*> CmdLineArgs;
+	static vector<std::string> CmdLineArgs;
 	static INI* Settings;
 	static char SettingsFile[MAX_PATH_LENGTH];
 	static XMLNode* GameConfig;
@@ -102,7 +102,9 @@ public:
 	static void GetPerformanceSnapshot();
 	static void SetWindowTitle(const char* title);
 	static void UpdateWindowTitle();
-	static bool SetNextGame(const char* path);
+	static bool SetNextGame(const char* path,
+		const char* startingScene,
+		std::vector<std::string>* cmdLineArgs);
 	static bool ChangeGame(const char* path);
 	static void SetMasterVolume(int volume);
 	static void SetMusicVolume(int volume);

--- a/include/Engine/Application.h
+++ b/include/Engine/Application.h
@@ -91,6 +91,7 @@ public:
 	static bool AllowCmdLineSceneLoad;
 
 	static void Init(int argc, char* args[]);
+	static void InitScripting();
 	static void SetTargetFrameRate(int targetFPS);
 	static bool IsPC();
 	static bool IsMobile();
@@ -115,6 +116,7 @@ public:
 	static void SetKeyBind(int bind, int key);
 	static void Run(int argc, char* args[]);
 	static void Cleanup();
+	static void TerminateScripting();
 	static void LoadSceneInfo();
 	static void InitPlayerControls();
 	static bool LoadSettings(const char* filename);

--- a/include/Engine/Bytecode/GarbageCollector.h
+++ b/include/Engine/Bytecode/GarbageCollector.h
@@ -26,6 +26,7 @@ public:
 
 	static void Init();
 	static void Collect();
+	static void Dispose();
 };
 
 #endif /* ENGINE_BYTECODE_GARBAGECOLLECTOR_H */

--- a/include/Engine/Bytecode/SourceFileMap.h
+++ b/include/Engine/Bytecode/SourceFileMap.h
@@ -11,6 +11,7 @@ private:
 
 public:
 	static bool Initialized;
+	static bool AllowCompilation;
 	static HashMap<Uint32>* Checksums;
 	static HashMap<vector<Uint32>*>* ClassMap;
 	static Uint32 DirectoryChecksum;

--- a/include/Engine/Bytecode/Value.h
+++ b/include/Engine/Bytecode/Value.h
@@ -11,6 +11,7 @@ public:
 	static const char* GetObjectTypeName(VMValue value);
 	static const char* GetObjectTypeName(Uint32 type);
 
+	static std::string ToString(VMValue v);
 	static VMValue CastAsString(VMValue v);
 	static VMValue CastAsInteger(VMValue v);
 	static VMValue CastAsDecimal(VMValue v);

--- a/include/Engine/Filesystem/Path.h
+++ b/include/Engine/Filesystem/Path.h
@@ -124,12 +124,15 @@ public:
 	static bool HasRelativeComponents(const char* path);
 	static std::string Normalize(std::string path);
 	static std::string Normalize(const char* path);
+	static std::string GetLocationFromRealPath(const char* filename, PathLocation location);
+	static bool IsAbsolute(const char* filename);
 	static bool IsValidDefaultLocation(const char* filename);
 	static bool
 	FromLocation(std::string path, PathLocation location, std::string& result, bool makeDirs);
 	static bool
 	FromURL(const char* filename, std::string& result, PathLocation& location, bool makeDirs);
 	static bool FromURL(const char* filename, std::string& result);
+	static void FromURL(const char* filename, char* buf, size_t bufSize);
 	static std::string StripURL(const char* filename);
 };
 

--- a/include/Engine/IO/StandardIOStream.h
+++ b/include/Engine/IO/StandardIOStream.h
@@ -9,12 +9,13 @@ private:
 	std::string Filename;
 	Uint32 CurrentAccess;
 
+	FILE* FilePtr;
+	size_t Filesize;
+
 	static FILE* OpenFile(const char* filename, Uint32 access);
 	bool Reopen(Uint32 newAccess);
 
 public:
-	FILE* f;
-	size_t size;
 	enum { READ_ACCESS, WRITE_ACCESS, APPEND_ACCESS };
 
 	static StandardIOStream* New(const char* filename, Uint32 access);

--- a/include/Engine/ResourceTypes/ResourceManager.h
+++ b/include/Engine/ResourceTypes/ResourceManager.h
@@ -8,7 +8,6 @@
 class ResourceManager {
 public:
 	static bool UsingDataFolder;
-	static bool UsingModPack;
 
 	static bool Init(const char* dataFilePath);
 	static bool Mount(const char* name,

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -999,7 +999,7 @@ void Application::LoadDevSettings() {
 	Application::Settings->GetBool("dev", "loadAllClasses", &ScriptManager::LoadAllClasses);
 
 	if (!Running) {
-		Application::Settings->GetBool("dev", "writeToFile", &Log::WriteToFile);
+		Application::Settings->GetBool("dev", "writeLogFile", &Log::WriteToFile);
 		Application::Settings->GetBool("dev", "trackMemory", &Memory::IsTracking);
 	}
 

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -228,6 +228,22 @@ void Application::Init(int argc, char* args[]) {
 
 	Running = true;
 }
+void Application::InitScripting() {
+	GarbageCollector::Init();
+
+	Compiler::Init();
+
+	ScriptManager::Init();
+	ScriptManager::ResetStack();
+	ScriptManager::LinkStandardLibrary();
+	ScriptManager::LinkExtensions();
+
+	Compiler::GetStandardConstants();
+
+	if (SourceFileMap::CheckForUpdate()) {
+		ScriptManager::ForceGarbageCollection();
+	}
+}
 void Application::LogEngineVersion() {
 #ifdef GIT_COMMIT_HASH
 	Log::Print(Log::LOG_INFO,
@@ -754,9 +770,7 @@ void Application::EndGame() {
 	Scene::Dispose();
 	SceneInfo::Dispose();
 	Graphics::DeleteSpriteSheetMap();
-
-	ScriptManager::LoadAllClasses = false;
-	ScriptEntity::DisableAutoAnimate = false;
+	Application::TerminateScripting();
 }
 
 void Application::UnloadGame() {
@@ -765,7 +779,6 @@ void Application::UnloadGame() {
 	MemoryCache::Dispose();
 	ResourceManager::Dispose();
 
-	InputManager::ControllerStopRumble();
 	InputManager::ClearPlayers();
 	InputManager::ClearInputs();
 }
@@ -1540,6 +1553,8 @@ void Application::DelayFrame() {
 	}
 }
 void Application::StartGame(const char* startingScene) {
+	Application::InitScripting();
+
 	Scene::Init();
 	Scene::Prepare();
 
@@ -1673,6 +1688,8 @@ void Application::Run(int argc, char* args[]) {
 }
 
 void Application::Cleanup() {
+	Application::TerminateScripting();
+
 	if (DEBUG_fontSprite) {
 		DEBUG_fontSprite->Dispose();
 		delete DEBUG_fontSprite;
@@ -1707,6 +1724,15 @@ void Application::Cleanup() {
 #ifdef MSYS
 	FreeConsole();
 #endif
+}
+void Application::TerminateScripting() {
+	ScriptManager::Dispose();
+	SourceFileMap::Dispose();
+	Compiler::Dispose();
+	GarbageCollector::Dispose();
+
+	ScriptManager::LoadAllClasses = false;
+	ScriptEntity::DisableAutoAnimate = false;
 }
 
 static char* ParseGameConfigText(XMLNode* parent, const char* option) {

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -195,6 +195,7 @@ void Application::Init(int argc, char* args[]) {
 		ResourceManager::Init(NULL);
 
 	Application::LoadGameConfig();
+	Application::InitGameInfo();
 	Application::LoadGameInfo();
 	Application::ReloadSettings();
 
@@ -711,9 +712,6 @@ void Application::UpdateWindowTitle() {
 		if (ResourceManager::UsingDataFolder) {
 			ADD_TEXT("using Resources folder");
 		}
-		if (ResourceManager::UsingModPack) {
-			ADD_TEXT("using Modpack");
-		}
 	}
 
 	if (UpdatesPerFrame != 1) {
@@ -759,8 +757,6 @@ void Application::EndGame() {
 
 	ScriptManager::LoadAllClasses = false;
 	ScriptEntity::DisableAutoAnimate = false;
-
-	Graphics::Reset();
 }
 
 void Application::UnloadGame() {
@@ -768,13 +764,19 @@ void Application::UnloadGame() {
 
 	MemoryCache::Dispose();
 	ResourceManager::Dispose();
-	InputManager::Dispose();
+
+	InputManager::ControllerStopRumble();
+	InputManager::ClearPlayers();
+	InputManager::ClearInputs();
 }
 
 void Application::Restart() {
 	Application::EndGame();
 
+	Graphics::Reset();
+
 	Application::LoadGameConfig();
+	Application::InitGameInfo();
 	Application::LoadGameInfo();
 	Application::ReloadSettings();
 	Application::LoadSceneInfo();
@@ -784,29 +786,41 @@ void Application::Restart() {
 }
 
 bool Application::ChangeGame(const char* path) {
-	Application::UnloadGame();
+	char lastSettingsPath[MAX_PATH_LENGTH];
+	char currentSettingsPath[MAX_PATH_LENGTH];
+	Path::FromURL(SettingsFile, lastSettingsPath, sizeof lastSettingsPath);
 
-	ResourceManager::Dispose();
+	Application::UnloadGame();
 
 	if (!ResourceManager::Init(path)) {
 		return false;
+	}
+
+	Application::LoadGameConfig();
+	Application::LoadGameInfo();
+
+	// Reload settings file if the path to it changed.
+	Path::FromURL(SettingsFile, currentSettingsPath, sizeof currentSettingsPath);
+	if (strcmp(currentSettingsPath, lastSettingsPath) != 0) {
+		Application::DisposeSettings();
+
+		if (!Application::LoadSettings(Application::SettingsFile)) {
+			// Couldn't load new settings file, so use a default one.
+			Application::InitSettings();
+		}
 	}
 
 	if (UseMemoryFileCache) {
 		MemoryCache::Init();
 	}
 
-	InputManager::Init();
-
-	Application::LoadGameConfig();
-	Application::LoadGameInfo();
-	Application::ReloadSettings();
-
 	Application::LoadSceneInfo();
 	Application::InitPlayerControls();
 	Application::DisposeGameConfig();
 
 	FirstFrame = true;
+
+	SourceFileMap::AllowCompilation = false;
 
 	Application::StartGame(StartingScene);
 	Application::UpdateWindowTitle();
@@ -815,9 +829,25 @@ bool Application::ChangeGame(const char* path) {
 }
 
 bool Application::SetNextGame(const char* path) {
-	std::string resolved = "";
+	bool exists = false;
 
-	if (Path::FromURL(path, resolved) && File::Exists(resolved.c_str())) {
+	std::string resolved = "";
+	PathLocation location;
+
+	if (Path::FromURL(path, resolved, location, false)) {
+		if (location != PathLocation::GAME && location != PathLocation::USER) {
+			return false;
+		}
+
+		if (path[strlen(path) - 1] == '/') {
+			exists = Directory::Exists(resolved.c_str());
+		}
+		else {
+			exists = File::Exists(resolved.c_str());
+		}
+	}
+
+	if (exists) {
 		StringUtils::Copy(NextGame, resolved.c_str(), sizeof NextGame);
 
 		return true;
@@ -1649,9 +1679,7 @@ void Application::Cleanup() {
 		DEBUG_fontSprite = NULL;
 	}
 
-	if (Application::Settings) {
-		Application::Settings->Dispose();
-	}
+	Application::DisposeSettings();
 
 	MemoryCache::Dispose();
 	ResourceManager::Dispose();
@@ -1724,7 +1752,10 @@ static bool ParseGameConfigBool(XMLNode* node, const char* option, bool& val) {
 
 void Application::LoadGameConfig() {
 	StartingScene[0] = '\0';
-	LogFilename[0] = '\0';
+
+	if (!Running) {
+		LogFilename[0] = '\0';
+	}
 
 	Application::GameConfig = nullptr;
 
@@ -1752,8 +1783,12 @@ void Application::LoadGameConfig() {
 		ParseGameConfigBool(node, "loadAllClasses", ScriptManager::LoadAllClasses);
 		ParseGameConfigBool(node, "useSoftwareRenderer", Graphics::UseSoftwareRenderer);
 		ParseGameConfigBool(node, "enablePaletteUsage", Graphics::UsePalettes);
-		ParseGameConfigBool(node, "writeLogFile", Log::WriteToFile);
-		ParseGameConfigText(node, "logFilename", LogFilename, sizeof LogFilename);
+		ParseGameConfigText(node, "settingsFile", SettingsFile, sizeof SettingsFile);
+
+		if (!Running) {
+			ParseGameConfigBool(node, "writeLogFile", Log::WriteToFile);
+			ParseGameConfigText(node, "logFilename", LogFilename, sizeof LogFilename);
+		}
 	}
 
 	// Read display defaults
@@ -1852,7 +1887,7 @@ string Application::ParseGameVersion(XMLNode* versionNode) {
 	return versionText;
 }
 
-void Application::LoadGameInfo() {
+void Application::InitGameInfo() {
 	StringUtils::Copy(GameTitle, DEFAULT_GAME_TITLE, sizeof(GameTitle));
 	StringUtils::Copy(GameTitleShort, DEFAULT_GAME_SHORT_TITLE, sizeof(GameTitleShort));
 	StringUtils::Copy(GameVersion, DEFAULT_GAME_VERSION, sizeof(GameVersion));
@@ -1860,7 +1895,9 @@ void Application::LoadGameInfo() {
 
 	StringUtils::Copy(GameIdentifier, DEFAULT_GAME_IDENTIFIER, sizeof(GameIdentifier));
 	StringUtils::Copy(SavesDir, DEFAULT_SAVES_DIR, sizeof(SavesDir));
+}
 
+void Application::LoadGameInfo() {
 	bool shouldSetGameId = false;
 	bool shouldSetGameDevId = false;
 
@@ -2065,11 +2102,11 @@ bool Application::LoadSettings(const char* filename) {
 		return false;
 	}
 
-	StringUtils::Copy(Application::SettingsFile, filename, sizeof(Application::SettingsFile));
-
-	if (Application::Settings) {
-		Application::Settings->Dispose();
+	if (filename != Application::SettingsFile) {
+		StringUtils::Copy(Application::SettingsFile, filename, sizeof(Application::SettingsFile));
 	}
+
+	Application::DisposeSettings();
 	Application::Settings = ini;
 
 	return true;
@@ -2085,7 +2122,11 @@ void Application::ReadSettings() {
 void Application::ReloadSettings() {
 	// First time load
 	if (Application::Settings == nullptr) {
-		Application::InitSettings(DEFAULT_SETTINGS_FILENAME);
+		if (Application::SettingsFile[0] == '\0') {
+			StringUtils::Copy(Application::SettingsFile, DEFAULT_SETTINGS_FILENAME, sizeof(Application::SettingsFile));
+		}
+
+		Application::InitSettings();
 	}
 
 	if (Application::Settings->Reload()) {
@@ -2099,10 +2140,8 @@ void Application::ReloadSettings(const char* filename) {
 	}
 }
 
-void Application::InitSettings(const char* filename) {
+void Application::InitSettings() {
 	// Create settings with default values.
-	StringUtils::Copy(Application::SettingsFile, filename, sizeof(Application::SettingsFile));
-
 	Application::Settings = INI::New(Application::SettingsFile);
 
 	Application::Settings->SetBool("display", "fullscreen", false);
@@ -2123,6 +2162,13 @@ void Application::SetSettingsFilename(const char* filename) {
 	StringUtils::Copy(Application::SettingsFile, filename, sizeof(Application::SettingsFile));
 	if (Application::Settings) {
 		Application::Settings->SetFilename(filename);
+	}
+}
+
+void Application::DisposeSettings() {
+	if (Application::Settings) {
+		Application::Settings->Dispose();
+		Application::Settings = nullptr;
 	}
 }
 

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -998,17 +998,17 @@ void Application::LoadDevSettings() {
 	Application::Settings->GetBool("dev", "convertModels", &Application::DevConvertModels);
 	Application::Settings->GetBool("dev", "useMemoryFileCache", &UseMemoryFileCache);
 	Application::Settings->GetBool("dev", "loadAllClasses", &ScriptManager::LoadAllClasses);
+	Application::Settings->GetBool("dev", "trackMemory", &Memory::IsTracking);
 
 	int logLevel = 0;
 #ifdef DEBUG
 	logLevel = -1;
 #endif
-#ifdef ANDROID
-	logLevel = -1;
-#endif
-	Application::Settings->GetInteger("dev", "logLevel", &logLevel);
-	Application::Settings->GetBool("dev", "trackMemory", &Memory::IsTracking);
-	Log::SetLogLevel(logLevel);
+
+	bool hasLogLevelSetting = Application::Settings->GetInteger("dev", "logLevel", &logLevel);
+	if (!Running || hasLogLevelSetting) {
+		Log::SetLogLevel(logLevel);
+	}
 
 	Application::Settings->GetBool("dev", "autoPerfSnapshots", &AutomaticPerformanceSnapshots);
 	int apsFrameTimeThreshold = 20, apsMinInterval = 5;

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -9,6 +9,7 @@
 #include <Engine/Diagnostics/Log.h>
 #include <Engine/Diagnostics/Memory.h>
 #include <Engine/Diagnostics/MemoryPools.h>
+#include <Engine/Filesystem/File.h>
 #include <Engine/Filesystem/Directory.h>
 #include <Engine/Filesystem/VFS/MemoryCache.h>
 #include <Engine/ResourceTypes/ResourceManager.h>
@@ -106,7 +107,8 @@ bool Application::DevConvertModels = false;
 
 bool Application::AllowCmdLineSceneLoad = false;
 
-char StartingScene[256];
+char StartingScene[MAX_RESOURCE_PATH_LENGTH];
+char NextGame[MAX_PATH_LENGTH];
 char LogFilename[MAX_PATH_LENGTH];
 
 bool UseMemoryFileCache = false;
@@ -739,7 +741,7 @@ void Application::UpdateWindowTitle() {
 	SDL_SetWindowTitle(Application::Window, titleText.c_str());
 }
 
-void Application::Restart() {
+void Application::EndGame() {
 	if (DEBUG_fontSprite) {
 		DEBUG_fontSprite->Dispose();
 		delete DEBUG_fontSprite;
@@ -759,6 +761,18 @@ void Application::Restart() {
 	ScriptEntity::DisableAutoAnimate = false;
 
 	Graphics::Reset();
+}
+
+void Application::UnloadGame() {
+	Application::EndGame();
+
+	MemoryCache::Dispose();
+	ResourceManager::Dispose();
+	InputManager::Dispose();
+}
+
+void Application::Restart() {
+	Application::EndGame();
 
 	Application::LoadGameConfig();
 	Application::LoadGameInfo();
@@ -767,6 +781,49 @@ void Application::Restart() {
 	Application::DisposeGameConfig();
 
 	FirstFrame = true;
+}
+
+bool Application::ChangeGame(const char* path) {
+	Application::UnloadGame();
+
+	ResourceManager::Dispose();
+
+	if (!ResourceManager::Init(path)) {
+		return false;
+	}
+
+	if (UseMemoryFileCache) {
+		MemoryCache::Init();
+	}
+
+	InputManager::Init();
+
+	Application::LoadGameConfig();
+	Application::LoadGameInfo();
+	Application::ReloadSettings();
+
+	Application::LoadSceneInfo();
+	Application::InitPlayerControls();
+	Application::DisposeGameConfig();
+
+	FirstFrame = true;
+
+	Application::StartGame(StartingScene);
+	Application::UpdateWindowTitle();
+
+	return true;
+}
+
+bool Application::SetNextGame(const char* path) {
+	std::string resolved = "";
+
+	if (Path::FromURL(path, resolved) && File::Exists(resolved.c_str())) {
+		StringUtils::Copy(NextGame, resolved.c_str(), sizeof NextGame);
+
+		return true;
+	}
+
+	return false;
 }
 
 void Application::LoadVideoSettings() {
@@ -1568,6 +1625,14 @@ void Application::Run(int argc, char* args[]) {
 		if (TakeSnapshot) {
 			TakeSnapshot = false;
 			Application::GetPerformanceSnapshot();
+		}
+
+		if (NextGame[0] != '\0') {
+			char gamePath[MAX_PATH_LENGTH];
+			StringUtils::Copy(gamePath, NextGame, sizeof gamePath);
+			NextGame[0] = '\0';
+
+			ChangeGame(gamePath);
 		}
 	}
 

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -9,8 +9,8 @@
 #include <Engine/Diagnostics/Log.h>
 #include <Engine/Diagnostics/Memory.h>
 #include <Engine/Diagnostics/MemoryPools.h>
-#include <Engine/Filesystem/File.h>
 #include <Engine/Filesystem/Directory.h>
+#include <Engine/Filesystem/File.h>
 #include <Engine/Filesystem/VFS/MemoryCache.h>
 #include <Engine/ResourceTypes/ResourceManager.h>
 #include <Engine/Scene/SceneInfo.h>
@@ -62,7 +62,7 @@ Platforms Application::Platform = Platforms::iOS;
 Platforms Application::Platform = Platforms::Unknown;
 #endif
 
-vector<char*> Application::CmdLineArgs;
+vector<std::string> Application::CmdLineArgs;
 
 INI* Application::Settings = NULL;
 char Application::SettingsFile[MAX_PATH_LENGTH];
@@ -109,6 +109,8 @@ bool Application::AllowCmdLineSceneLoad = false;
 
 char StartingScene[MAX_RESOURCE_PATH_LENGTH];
 char NextGame[MAX_PATH_LENGTH];
+char NextGameStartingScene[MAX_RESOURCE_PATH_LENGTH];
+std::vector<std::string>* NextGameCmdLineArgs;
 char LogFilename[MAX_PATH_LENGTH];
 
 bool UseMemoryFileCache = false;
@@ -178,7 +180,7 @@ void Application::Init(int argc, char* args[]) {
 	Application::SetTargetFrameRate(DEFAULT_TARGET_FRAMERATE);
 
 	for (int i = 1; i < argc; i++) {
-		Application::CmdLineArgs.push_back(StringUtils::Duplicate(args[i]));
+		Application::CmdLineArgs.push_back(std::string(args[i]));
 	}
 
 	// Initialize a few needed subsystems
@@ -799,13 +801,28 @@ void Application::Restart() {
 }
 
 bool Application::ChangeGame(const char* path) {
+	char startingScene[MAX_PATH_LENGTH];
 	char lastSettingsPath[MAX_PATH_LENGTH];
 	char currentSettingsPath[MAX_PATH_LENGTH];
+
 	Path::FromURL(SettingsFile, lastSettingsPath, sizeof lastSettingsPath);
+
+	if (NextGameStartingScene[0] != '\0') {
+		StringUtils::Copy(startingScene, NextGameStartingScene, sizeof startingScene);
+		NextGameStartingScene[0] = '\0';
+	}
+	else {
+		startingScene[0] = '\0';
+	}
 
 	Application::UnloadGame();
 
 	if (!ResourceManager::Init(path)) {
+		if (NextGameCmdLineArgs) {
+			delete NextGameCmdLineArgs;
+			NextGameCmdLineArgs = nullptr;
+		}
+
 		return false;
 	}
 
@@ -835,23 +852,36 @@ bool Application::ChangeGame(const char* path) {
 
 	SourceFileMap::AllowCompilation = false;
 
-	Application::StartGame(StartingScene);
+	if (startingScene[0] == '\0') {
+		StringUtils::Copy(startingScene, StartingScene, sizeof startingScene);
+	}
+
+	if (NextGameCmdLineArgs) {
+		Application::CmdLineArgs.clear();
+		for (size_t i = 0, iSz = NextGameCmdLineArgs->size(); i < iSz; i++) {
+			Application::CmdLineArgs.push_back((*NextGameCmdLineArgs)[i]);
+		}
+
+		delete NextGameCmdLineArgs;
+		NextGameCmdLineArgs = nullptr;
+	}
+
+	Application::StartGame(startingScene);
 	Application::UpdateWindowTitle();
 
 	return true;
 }
 
-bool Application::SetNextGame(const char* path) {
+bool Application::SetNextGame(const char* path,
+	const char* startingScene,
+	std::vector<std::string>* cmdLineArgs) {
 	bool exists = false;
 
 	std::string resolved = "";
 	PathLocation location;
 
-	if (Path::FromURL(path, resolved, location, false)) {
-		if (location != PathLocation::GAME && location != PathLocation::USER) {
-			return false;
-		}
-
+	if (Path::FromURL(path, resolved, location, false) &&
+		(location == PathLocation::GAME || location == PathLocation::USER)) {
 		if (path[strlen(path) - 1] == '/') {
 			exists = Directory::Exists(resolved.c_str());
 		}
@@ -863,8 +893,17 @@ bool Application::SetNextGame(const char* path) {
 	if (exists) {
 		StringUtils::Copy(NextGame, resolved.c_str(), sizeof NextGame);
 
+		if (startingScene != nullptr) {
+			StringUtils::Copy(
+				NextGameStartingScene, startingScene, sizeof NextGameStartingScene);
+		}
+
+		NextGameCmdLineArgs = cmdLineArgs;
+
 		return true;
 	}
+
+	Log::Print(Log::LOG_ERROR, "Path \"%s\" is not valid!", path);
 
 	return false;
 }
@@ -1708,10 +1747,12 @@ void Application::Cleanup() {
 
 	Graphics::Dispose();
 
-	for (size_t i = 0; i < Application::CmdLineArgs.size(); i++) {
-		Memory::Free(Application::CmdLineArgs[i]);
-	}
 	Application::CmdLineArgs.clear();
+
+	if (NextGameCmdLineArgs) {
+		delete NextGameCmdLineArgs;
+		NextGameCmdLineArgs = nullptr;
+	}
 
 	Memory::PrintLeak();
 	Memory::ClearTrackedMemory();
@@ -2132,7 +2173,8 @@ bool Application::LoadSettings(const char* filename) {
 	}
 
 	if (filename != Application::SettingsFile) {
-		StringUtils::Copy(Application::SettingsFile, filename, sizeof(Application::SettingsFile));
+		StringUtils::Copy(
+			Application::SettingsFile, filename, sizeof(Application::SettingsFile));
 	}
 
 	Application::DisposeSettings();
@@ -2152,7 +2194,9 @@ void Application::ReloadSettings() {
 	// First time load
 	if (Application::Settings == nullptr) {
 		if (Application::SettingsFile[0] == '\0') {
-			StringUtils::Copy(Application::SettingsFile, DEFAULT_SETTINGS_FILENAME, sizeof(Application::SettingsFile));
+			StringUtils::Copy(Application::SettingsFile,
+				DEFAULT_SETTINGS_FILENAME,
+				sizeof(Application::SettingsFile));
 		}
 
 		Application::InitSettings();

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -991,14 +991,17 @@ void Application::LoadKeyBinds() {
 void Application::LoadDevSettings() {
 #ifdef DEVELOPER_MODE
 	Application::Settings->GetBool("dev", "devMenu", &DevMenu);
-	Application::Settings->GetBool("dev", "writeToFile", &Log::WriteToFile);
 	Application::Settings->GetBool("dev", "viewPerformance", &ShowFPS);
 	Application::Settings->GetBool("dev", "donothing", &DoNothing);
 	Application::Settings->GetInteger("dev", "fastforward", &UpdatesPerFastForward);
 	Application::Settings->GetBool("dev", "convertModels", &Application::DevConvertModels);
 	Application::Settings->GetBool("dev", "useMemoryFileCache", &UseMemoryFileCache);
 	Application::Settings->GetBool("dev", "loadAllClasses", &ScriptManager::LoadAllClasses);
-	Application::Settings->GetBool("dev", "trackMemory", &Memory::IsTracking);
+
+	if (!Running) {
+		Application::Settings->GetBool("dev", "writeToFile", &Log::WriteToFile);
+		Application::Settings->GetBool("dev", "trackMemory", &Memory::IsTracking);
+	}
 
 	int logLevel = 0;
 #ifdef DEBUG

--- a/source/Engine/Bytecode/Compiler.cpp
+++ b/source/Engine/Bytecode/Compiler.cpp
@@ -4388,7 +4388,7 @@ void Compiler::Initialize(Compiler* enclosing, int scope, int type) {
 		Function->Name = CopyString(parser.Previous.Start, parser.Previous.Length);
 		break;
 	case TYPE_TOP_LEVEL:
-		Function->Name = CopyString("main", 4);
+		Function->Name = CopyString("main");
 		break;
 	}
 

--- a/source/Engine/Bytecode/Compiler.cpp
+++ b/source/Engine/Bytecode/Compiler.cpp
@@ -4518,5 +4518,8 @@ void Compiler::Dispose() {
 		delete StandardConstants;
 		StandardConstants = NULL;
 	}
-	Memory::Free(Rules);
+	if (Rules) {
+		Memory::Free(Rules);
+		Rules = NULL;
+	}
 }

--- a/source/Engine/Bytecode/GarbageCollector.cpp
+++ b/source/Engine/Bytecode/GarbageCollector.cpp
@@ -287,3 +287,7 @@ void GarbageCollector::BlackenObject(Obj* object) {
 		break;
 	}
 }
+
+void GarbageCollector::Dispose() {
+	Init();
+}

--- a/source/Engine/Bytecode/ScriptManager.cpp
+++ b/source/Engine/Bytecode/ScriptManager.cpp
@@ -212,7 +212,10 @@ void ScriptManager::Dispose() {
 		Tokens = NULL;
 	}
 
-	SDL_DestroyMutex(GlobalLock);
+	if (GlobalLock) {
+		SDL_DestroyMutex(GlobalLock);
+		GlobalLock = NULL;
+	}
 }
 void ScriptManager::RemoveNonGlobalableValue(Uint32 hash, VMValue value) {
 	if (IS_OBJECT(value)) {
@@ -777,10 +780,8 @@ bool ScriptManager::LoadObjectClass(const char* objectName, bool addNativeFuncti
 
 			if (fn == 0) {
 				Log::Print(Log::LOG_VERBOSE,
-					"Loading class %s%s%s, %d filename(s)...",
-					Log::WriteToFile ? "" : FG_YELLOW,
+					"Loading class %s, %d filename(s)...",
 					objectName,
-					Log::WriteToFile ? "" : FG_RESET,
 					(int)filenameHashList->size());
 			}
 

--- a/source/Engine/Bytecode/SourceFileMap.cpp
+++ b/source/Engine/Bytecode/SourceFileMap.cpp
@@ -15,6 +15,7 @@
 #define OBJECTS_HCM_NAME OBJECTS_DIR_NAME "Objects.hcm"
 
 bool SourceFileMap::Initialized = false;
+bool SourceFileMap::AllowCompilation = false;
 HashMap<Uint32>* SourceFileMap::Checksums = NULL;
 HashMap<vector<Uint32>*>* SourceFileMap::ClassMap = NULL;
 Uint32 SourceFileMap::DirectoryChecksum = 0;
@@ -69,6 +70,8 @@ void SourceFileMap::CheckInit() {
 	}
 
 #ifndef NO_SCRIPT_COMPILING
+	SourceFileMap::AllowCompilation = true;
+
 	if (File::ProtectedExists(SOURCEFILEMAP_NAME, true)) {
 		char* bytes;
 		size_t len = File::ReadAllBytes(SOURCEFILEMAP_NAME, &bytes, true);
@@ -85,6 +88,10 @@ bool SourceFileMap::CheckForUpdate() {
 	SourceFileMap::CheckInit();
 
 #ifndef NO_SCRIPT_COMPILING
+	if (!SourceFileMap::AllowCompilation) {
+		return false;
+	}
+
 	VFSProvider* mainVfs = ResourceManager::GetMainResource();
 	if (!mainVfs || !mainVfs->IsWritable()) {
 		return false;

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -1251,8 +1251,8 @@ VMValue Application_GetCommandLineArguments(int argCount, VMValue* args, Uint32 
 	if (ScriptManager::Lock()) {
 		ObjArray* array = NewArray();
 		for (size_t i = 0; i < Application::CmdLineArgs.size(); i++) {
-			array->Values->push_back(
-				OBJECT_VAL(CopyString(Application::CmdLineArgs[i])));
+			ObjString* argString = CopyString(Application::CmdLineArgs[i]);
+			array->Values->push_back(OBJECT_VAL(argString));
 		}
 		ScriptManager::Unlock();
 		return OBJECT_VAL(array);
@@ -1524,17 +1524,39 @@ The following <b>cannot</b> be changed between games:<ul>\
 <li>Log file path</li>\
 <li>Graphics rendering backend</li>\
 </ul>
- * \param path (String): The path of the resources file to load.
- * \return Returns <code>true</code> if the path to the resource file exists, <code>false</code> if otherwise.
+ * \param path (String): The path of the data file to load.
+ * \paramOpt startingScene (String): The filename of the scene file to load upon changing the game. Note that restarting the game will load the starting scene defined in its GameConfig instead. Passing <code>null</code> to this argument is equivalent to not passing it at all.
+ * \paramOpt cmdLineArgs (Array): An Array of Strings containing the command line arguments to pass to the new game. If any of the values are not Strings, they will be converted to a String representation. If this argument is not given, the current command line arguments will be passed to the new game.
+ * \return Returns <code>true</code> if the game will change, <code>false</code> if otherwise.
  * \ns Application
  */
 VMValue Application_ChangeGame(int argCount, VMValue* args, Uint32 threadID) {
-	CHECK_ARGCOUNT(1);
+	CHECK_AT_LEAST_ARGCOUNT(1);
 	char* path = GET_ARG(0, GetString);
+	char* startingScene = nullptr;
+	ObjArray* cmdLineArgsArray = GET_ARG_OPT(2, GetArray, nullptr);
+	std::vector<std::string>* cmdLineArgs = nullptr;
 
-	bool exists = Application::SetNextGame(path);
+	if (argCount >= 2 && !IS_NULL(args[1])) {
+		startingScene = GET_ARG(1, GetString);
+	}
 
-	return INTEGER_VAL(exists);
+	if (cmdLineArgsArray) {
+		cmdLineArgs = new std::vector<std::string>();
+
+		for (size_t i = 0; i < cmdLineArgsArray->Values->size(); i++) {
+			std::string arg = Value::ToString((*cmdLineArgsArray->Values)[i]);
+			cmdLineArgs->push_back(arg);
+		}
+	}
+
+	bool exists = Application::SetNextGame(path, startingScene, cmdLineArgs);
+	if (!exists) {
+		delete cmdLineArgs;
+		return INTEGER_VAL(false);
+	}
+
+	return INTEGER_VAL(true);
 }
 /***
  * Application.Quit
@@ -2720,7 +2742,7 @@ VMValue Directory_GetFiles(int argCount, VMValue* args, Uint32 threadID) {
 	if (ScriptManager::Lock()) {
 		array = NewArray();
 		for (size_t i = 0; i < fileList.size(); i++) {
-			ObjString* part = CopyString(fileList[i]);
+			ObjString* part = CopyString(fileList[i].u8string());
 			array->Values->push_back(OBJECT_VAL(part));
 		}
 		ScriptManager::Unlock();
@@ -2750,7 +2772,7 @@ VMValue Directory_GetDirectories(int argCount, VMValue* args, Uint32 threadID) {
 	if (ScriptManager::Lock()) {
 		array = NewArray();
 		for (size_t i = 0; i < fileList.size(); i++) {
-			ObjString* part = CopyString(fileList[i]);
+			ObjString* part = CopyString(fileList[i].u8string());
 			array->Values->push_back(OBJECT_VAL(part));
 		}
 		ScriptManager::Unlock();
@@ -7301,7 +7323,7 @@ VMValue Input_GetActionList(int argCount, VMValue* args, Uint32 threadID) {
 	for (size_t i = 0; i < count; i++) {
 		InputAction& action = InputManager::Actions[i];
 
-		ObjString* actionName = CopyString(action.Name.c_str());
+		ObjString* actionName = CopyString(action.Name);
 
 		array->Values->push_back(OBJECT_VAL(actionName));
 	}

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -1501,7 +1501,30 @@ VMValue Application_GetCursorVisible(int argCount, VMValue* args, Uint32 threadI
 }
 /***
  * Application.ChangeGame
- * \desc Changes the current game.
+ * \desc Changes the current game, by loading a data file containing the new game. If the path ends with a path separator (<code>/</code>), an entire directory will be loaded as the game instead.<br/><br/>\
+This is permanent for as long as the application is running, so restarting the application using <linkto ref="KeyBind_DevRestartApp">the associated developer key</linkto> will reload the current game, and not the one the application started with. Script compiling is also disabled after the game changes.<br/><br/>\
+The change only takes effect after a frame completes.<br/><br/>\
+Note that certain game configurations will persist between games if not set by the new GameConfig. Those are:<ul>\
+<li>Game title (including the short game title)</li>\
+<li>Game version</li>\
+<li>Game description</li>\
+<li>Game developer</li>\
+<li>Game identifier</li>\
+<li>Developer identifier</li>\
+<li>Saves directory</li>\
+<li>Preferences directory</li>\
+<li>Palette colors</li>\
+<li>Whether palette rendering is enabled</li>\
+<li>Whether software rendering was enabled with <code>useSoftwareRenderer</code></li>\
+<li>Current settings file</li>\
+<li>Window size</li>\
+<li>Audio volume</li>\
+</ul>\
+The following <b>cannot</b> be changed between games:<ul>\
+<li>Log file path</li>\
+<li>Graphics rendering backend</li>\
+</ul>
+ * \param path (String): The path of the resources file to load.
  * \return Returns <code>true</code> if the path to the resource file exists, <code>false</code> if otherwise.
  * \ns Application
  */

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -1390,16 +1390,6 @@ VMValue Application_SetKeyBind(int argCount, VMValue* args, Uint32 threadID) {
 	return NULL_VAL;
 }
 /***
- * Application.Quit
- * \desc Closes the application.
- * \ns Application
- */
-VMValue Application_Quit(int argCount, VMValue* args, Uint32 threadID) {
-	CHECK_ARGCOUNT(0);
-	Application::Running = false;
-	return NULL_VAL;
-}
-/***
  * Application.GetGameTitle
  * \desc Gets the game title of the application.
  * \ns Application
@@ -1508,6 +1498,30 @@ VMValue Application_GetCursorVisible(int argCount, VMValue* args, Uint32 threadI
 		return INTEGER_VAL(1);
 	}
 	return INTEGER_VAL(0);
+}
+/***
+ * Application.ChangeGame
+ * \desc Changes the current game.
+ * \return Returns <code>true</code> if the path to the resource file exists, <code>false</code> if otherwise.
+ * \ns Application
+ */
+VMValue Application_ChangeGame(int argCount, VMValue* args, Uint32 threadID) {
+	CHECK_ARGCOUNT(1);
+	char* path = GET_ARG(0, GetString);
+
+	bool exists = Application::SetNextGame(path);
+
+	return INTEGER_VAL(exists);
+}
+/***
+ * Application.Quit
+ * \desc Closes the application.
+ * \ns Application
+ */
+VMValue Application_Quit(int argCount, VMValue* args, Uint32 threadID) {
+	CHECK_ARGCOUNT(0);
+	Application::Running = false;
+	return NULL_VAL;
 }
 // #endregion
 
@@ -18073,6 +18087,7 @@ void StandardLibrary::Link() {
 	DEF_NATIVE(Application, SetGameDescription);
 	DEF_NATIVE(Application, SetCursorVisible);
 	DEF_NATIVE(Application, GetCursorVisible);
+	DEF_NATIVE(Application, ChangeGame);
 	DEF_NATIVE(Application, Quit);
 	/***
     * \enum KeyBind_Fullscreen

--- a/source/Engine/Bytecode/Types.cpp
+++ b/source/Engine/Bytecode/Types.cpp
@@ -67,10 +67,8 @@ ObjString* CopyString(ObjString* string) {
 
 	return AllocateString(heapChars, string->Length, string->Hash);
 }
-ObjString* CopyString(std::filesystem::path path) {
-	std::string asStr = path.u8string();
-	const char* cStr = asStr.c_str();
-	return CopyString(cStr);
+ObjString* CopyString(std::string string) {
+	return CopyString(string.c_str());
 }
 ObjString* AllocString(size_t length) {
 	char* heapChars = ALLOCATE(char, length + 1);

--- a/source/Engine/Bytecode/Types.h
+++ b/source/Engine/Bytecode/Types.h
@@ -321,7 +321,7 @@ ObjString* TakeString(char* chars);
 ObjString* CopyString(const char* chars, size_t length);
 ObjString* CopyString(const char* chars);
 ObjString* CopyString(ObjString* string);
-ObjString* CopyString(std::filesystem::path path);
+ObjString* CopyString(std::string string);
 ObjString* AllocString(size_t length);
 ObjFunction* NewFunction();
 ObjNative* NewNative(NativeFn function);

--- a/source/Engine/Bytecode/Value.cpp
+++ b/source/Engine/Bytecode/Value.cpp
@@ -76,6 +76,21 @@ const char* Value::GetPrintableObjectName(VMValue value) {
 	}
 }
 
+std::string Value::ToString(VMValue v) {
+	if (IS_STRING(v)) {
+		return std::string(AS_CSTRING(v));
+	}
+
+	char* buffer = (char*)malloc(512);
+	PrintBuffer buffer_info;
+	buffer_info.Buffer = &buffer;
+	buffer_info.WriteIndex = 0;
+	buffer_info.BufferSize = 512;
+	ValuePrinter::Print(&buffer_info, v, false);
+	std::string result(buffer, buffer_info.WriteIndex);
+	free(buffer);
+	return result;
+}
 VMValue Value::CastAsString(VMValue v) {
 	if (IS_STRING(v)) {
 		return v;

--- a/source/Engine/Filesystem/Directory.cpp
+++ b/source/Engine/Filesystem/Directory.cpp
@@ -27,10 +27,9 @@ bool Directory::Exists(const char* path) {
 		return true;
 	}
 #else
-	DIR* dir = opendir(path);
-	if (dir) {
-		closedir(dir);
-		return true;
+	struct stat pathStat;
+	if (stat(path, &pathStat) == 0) {
+		return S_ISDIR(pathStat.st_mode);
 	}
 #endif
 	return false;

--- a/source/Engine/Filesystem/Path.cpp
+++ b/source/Engine/Filesystem/Path.cpp
@@ -463,6 +463,29 @@ std::string Path::GetForLocation(PathLocation location) {
 	return finalPath;
 }
 
+std::string Path::GetLocationFromRealPath(const char* filename, PathLocation location) {
+	std::string pathForLocation = GetForLocation(location);
+	if (pathForLocation == "") {
+		return "";
+	}
+
+	std::filesystem::path locFs = std::filesystem::u8path(pathForLocation);
+	std::filesystem::path pathFs = std::filesystem::u8path(std::string(filename));
+
+	locFs = locFs.lexically_normal();
+	pathFs = pathFs.lexically_normal();
+
+	if (locFs == pathFs) {
+		return "";
+	}
+
+	if (!StringUtils::StartsWith(pathFs.c_str(), locFs.c_str())) {
+		return "";
+	}
+
+	return pathFs.u8string().substr(locFs.u8string().size());
+}
+
 std::string Path::StripLocationFromURL(const char* filename, PathLocation& location) {
 	std::string startingString = "";
 
@@ -476,6 +499,14 @@ std::string Path::StripLocationFromURL(const char* filename, PathLocation& locat
 			location = pair.second;
 			break;
 		}
+		else {
+			std::string fromRealPath = GetLocationFromRealPath(filename, pair.second);
+
+			if (fromRealPath != "") {
+				location = pair.second;
+				return fromRealPath;
+			}
+		}
 	}
 
 	if (location == PathLocation::DEFAULT) {
@@ -487,13 +518,21 @@ std::string Path::StripLocationFromURL(const char* filename, PathLocation& locat
 	return std::string(pathAfterURL);
 }
 
+bool Path::IsAbsolute(const char* filename) {
+	if (filename[0] == '/' || StringUtils::StartsWith(&filename[1], ":\\") ||
+		StringUtils::StartsWith(&filename[1], ":/")) {
+		return true;
+	}
+
+	return false;
+}
+
 bool Path::IsValidDefaultLocation(const char* filename) {
 	if (!IsInCurrentDir(filename)) {
 		return false;
 	}
 
-	if (filename[0] == '/' || StringUtils::StartsWith(&filename[1], ":\\") ||
-		StringUtils::StartsWith(&filename[1], ":/")) {
+	if (Path::IsAbsolute(filename)) {
 		return false;
 	}
 
@@ -594,6 +633,20 @@ bool Path::FromURL(const char* filename, std::string& result) {
 	std::string detectedPath = StripLocationFromURL(filename, location);
 
 	return FromLocation(detectedPath, location, result, false);
+}
+
+void Path::FromURL(const char* filename, char* buf, size_t bufSize) {
+	if (buf == nullptr) {
+		return;
+	}
+
+	std::string resolved = "";
+	if (Path::FromURL(filename, resolved)) {
+		StringUtils::Copy(buf, resolved.c_str(), bufSize);
+	}
+	else {
+		buf[0] = '\0';
+	}
 }
 
 std::string Path::StripURL(const char* filename) {

--- a/source/Engine/InputManager.cpp
+++ b/source/Engine/InputManager.cpp
@@ -299,7 +299,9 @@ void InputManager::InitControllers() {
 		}
 	}
 
-	Log::Print(Log::LOG_VERBOSE, "Opening controllers... (%d count)", numControllers);
+	if (numControllers != 0) {
+		Log::Print(Log::LOG_VERBOSE, "Opening controllers... (%d count)", numControllers);
+	}
 
 	InputManager::Controllers.resize(0);
 	InputManager::NumControllers = 0;

--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -3140,6 +3140,7 @@ void Scene::Dispose() {
 	ScriptManager::Dispose();
 	SourceFileMap::Dispose();
 	Compiler::Dispose();
+	GarbageCollector::Dispose();
 }
 
 void Scene::UnloadTilesets() {

--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -1,11 +1,8 @@
 #include <Engine/Scene.h>
 
 #include <Engine/Audio/AudioManager.h>
-#include <Engine/Bytecode/Compiler.h>
-#include <Engine/Bytecode/GarbageCollector.h>
 #include <Engine/Bytecode/ScriptEntity.h>
 #include <Engine/Bytecode/ScriptManager.h>
-#include <Engine/Bytecode/SourceFileMap.h>
 #include <Engine/Diagnostics/Clock.h>
 #include <Engine/Diagnostics/Log.h>
 #include <Engine/Diagnostics/Memory.h>
@@ -633,22 +630,6 @@ void Scene::Init() {
 	Scene::CurrentScene[0] = '\0';
 
 	Scene::ReservedSlotIDs = 0;
-
-	GarbageCollector::Init();
-
-	Compiler::Init();
-
-	ScriptManager::Init();
-	ScriptManager::ResetStack();
-	ScriptManager::LinkStandardLibrary();
-	ScriptManager::LinkExtensions();
-
-	Compiler::GetStandardConstants();
-
-	if (SourceFileMap::CheckForUpdate()) {
-		// Force garbage collect
-		ScriptManager::ForceGarbageCollection();
-	}
 
 	Application::Settings->GetBool("dev", "notiles", &DEV_NoTiles);
 	Application::Settings->GetBool("dev", "noobjectrender", &DEV_NoObjectRender);
@@ -3136,11 +3117,6 @@ void Scene::Dispose() {
 		delete Scene::Properties;
 	}
 	Scene::Properties = NULL;
-
-	ScriptManager::Dispose();
-	SourceFileMap::Dispose();
-	Compiler::Dispose();
-	GarbageCollector::Dispose();
 }
 
 void Scene::UnloadTilesets() {


### PR DESCRIPTION
Implements `Application.ChangeGame`.

This function changes the current game, by loading a data file containing the new game. If the path ends with a path separator (`/`), an entire directory will be loaded as the game instead. Only `game://` and `user://` URLs are supported (or an absolute path that resolves to those locations).

This is permanent for as long as the application is running, so restarting the application using the associated developer key will reload the current game, and not the one the application started with. Script compiling is also disabled after the game changes.

The change only takes effect after a frame completes.

Note that certain game configurations will persist between games if not set by the new GameConfig:
- Game-identifying configurations
  - Game title (including the short game title)
  - Game version
  - Game description
  - Game developer
  - Game identifier
  - Developer identifier
- Paths:
  - Saves directory
  - Preferences directory
- Engine configurations:
  - Window size
  - Audio volume
  - Settings filename
    - If this is changed, the current settings are discarded (not saved) and the new settings file is loaded. If the file does not exist, however, default settings will be loaded.

Some of the game's current state also persists between games:
- Command line arguments (unless `cmdLineArgs` is passed to this function)
- Palette colors
- Whether palette rendering is enabled
- Whether software rendering was enabled with `useSoftwareRenderer`

The following **does not** persist between games:
- Any loaded resources
- Any persistent entities
- Scripting state

The following **cannot** be changed between games:
- Log file name
- Graphics rendering backend
- The following developer settings:
  - `writeLogFile`
  - `trackMemory`