### PR TITLE
Implement native 'remove' method for Map

### DIFF
--- a/include/Engine/Bytecode/TypeImpl/MapImpl.h
+++ b/include/Engine/Bytecode/TypeImpl/MapImpl.h
@@ -14,6 +14,7 @@ public:
 	static void Dispose(Obj* object);
 
 	static VMValue VM_GetKeys(int argCount, VMValue* args, Uint32 threadID);
+	static VMValue VM_RemoveKey(int argCount, VMValue* args, Uint32 threadID);
 	static VMValue VM_Iterate(int argCount, VMValue* args, Uint32 threadID);
 	static VMValue VM_IteratorValue(int argCount, VMValue* args, Uint32 threadID);
 };

--- a/source/Engine/Bytecode/TypeImpl/MapImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/MapImpl.cpp
@@ -9,6 +9,7 @@ void MapImpl::Init() {
 	Class = NewClass(CLASS_MAP);
 
 	ScriptManager::DefineNative(Class, "keys", MapImpl::VM_GetKeys);
+	ScriptManager::DefineNative(Class, "remove", MapImpl::VM_RemoveKey);
 	ScriptManager::DefineNative(Class, "iterate", MapImpl::VM_Iterate);
 	ScriptManager::DefineNative(Class, "iteratorValue", MapImpl::VM_IteratorValue);
 
@@ -54,6 +55,18 @@ VMValue MapImpl::VM_GetKeys(int argCount, VMValue* args, Uint32 threadID) {
 	});
 
 	return OBJECT_VAL(array);
+}
+
+VMValue MapImpl::VM_RemoveKey(int argCount, VMValue* args, Uint32 threadID) {
+	StandardLibrary::CheckArgCount(argCount, 2);
+
+	ObjMap* map = GET_ARG(0, GetMap);
+	const char* key = GET_ARG(1, GetString);
+
+	map->Keys->Remove(key);
+	map->Values->Remove(key);
+
+	return NULL_VAL;
 }
 
 VMValue MapImpl::VM_Iterate(int argCount, VMValue* args, Uint32 threadID) {


### PR DESCRIPTION
What it says on the tin. Does nothing if the Map already didn't have that key.

Example:

```js
var map = {
	"a": 1,
	"b": 2,
	"c": 3
};

print(map.keys());
print(map["c"]);

map.remove("c");

print(map.keys());
print(map["c"]);
```

```
     INFO: ["a","b","c"]
     INFO: 3
     INFO: ["a","b"]
     INFO: null
```