### PR TITLE
Reimplement palette index table for GL renderer

### DIFF
--- a/include/Engine/Graphics.h
+++ b/include/Engine/Graphics.h
@@ -22,6 +22,8 @@ class IModel;
 #include <Engine/Scene/View.h>
 #include <Engine/Utilities/ColorUtils.h>
 
+#define PALETTE_INDEX_TEXTURE_SIZE 64
+
 class Graphics {
 private:
 	static void InitCapabilities();
@@ -73,7 +75,10 @@ public:
 	static Uint32 PaletteColors[MAX_PALETTE_COUNT][0x100];
 	static Uint8 PaletteIndexLines[MAX_FRAMEBUFFER_HEIGHT];
 	static bool PaletteUpdated;
+	static bool PaletteIndexLinesUpdated;
 	static Texture* PaletteTexture;
+	static Texture* PaletteIndexTexture;
+	static Uint32* PaletteIndexTextureData;
 	static Texture* CurrentRenderTarget;
 	static Sint32 CurrentScene3D;
 	static Sint32 CurrentVertexBuffer;
@@ -137,6 +142,7 @@ public:
 	static void SoftwareStart();
 	static void SoftwareEnd();
 	static void UpdateGlobalPalette();
+	static void UpdatePaletteIndexTable();
 	static void UnloadSceneData();
 	static void SetRenderTarget(Texture* texture);
 	static bool CreateFramebufferTexture();

--- a/include/Engine/Rendering/GL/GLRenderer.h
+++ b/include/Engine/Rendering/GL/GLRenderer.h
@@ -77,6 +77,7 @@ public:
 	static void SetCurrentProgram(int program);
 	static void SetFilter(int filter);
 	static void UpdateGlobalPalette(Texture* texture);
+	static void UpdatePaletteIndexTable(Texture* texture);
 	static void Clear();
 	static void Present();
 	static void SetBlendColor(float r, float g, float b, float a);

--- a/include/Engine/Rendering/GL/GLShader.h
+++ b/include/Engine/Rendering/GL/GLShader.h
@@ -12,6 +12,7 @@ typedef std::unordered_map<std::string, GLint> GLVariableMap;
 
 #define UNIFORM_TEXTURE "u_texture"
 #define UNIFORM_PALETTETEXTURE "u_paletteTexture"
+#define UNIFORM_PALETTEINDEXTEXTURE "u_paletteIndexTexture"
 #ifdef GL_HAVE_YUV
 #define UNIFORM_TEXTUREU "u_textureU"
 #define UNIFORM_TEXTUREV "u_textureV"
@@ -99,8 +100,8 @@ public:
 	GLint LocTextureV;
 #endif
 	GLint LocPaletteTexture;
+	GLint LocPaletteIndexTexture;
 	GLint LocPaletteID;
-	GLint LocPaletteIndexTable;
 	GLint LocNumTexturePaletteIndices;
 	GLint LocColor;
 	GLint LocDiffuseColor;

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -11293,6 +11293,7 @@ VMValue Palette_SetPaletteIndexLines(int argCount, VMValue* args, Uint32 threadI
 	for (Sint32 i = lineStart; i < lineEnd; i++) {
 		Graphics::PaletteIndexLines[i] = (Uint8)palIndex;
 	}
+	Graphics::PaletteIndexLinesUpdated = true;
 	return NULL_VAL;
 }
 #undef CHECK_COLOR_INDEX

--- a/source/Engine/Rendering/GraphicsFunctions.h
+++ b/source/Engine/Rendering/GraphicsFunctions.h
@@ -35,6 +35,7 @@ struct GraphicsFunctions {
 	void (*SetFilterTable)(Uint32* table, size_t size);
 
 	void (*UpdateGlobalPalette)(Texture* texture);
+	void (*UpdatePaletteIndexTable)(Texture* texture);
 
 	void (*UpdateViewport)();
 	void (*UpdateClipRect)();

--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -1293,6 +1293,11 @@ void Scene::Render() {
 		Graphics::PaletteUpdated = false;
 	}
 
+	if (Graphics::PaletteIndexLinesUpdated) {
+		Graphics::UpdatePaletteIndexTable();
+		Graphics::PaletteIndexLinesUpdated = false;
+	}
+
 	int win_w, win_h, ren_w, ren_h;
 	SDL_GetWindowSize(Application::Window, &win_w, &win_h);
 	SDL_GL_GetDrawableSize(Application::Window, &ren_w, &ren_h);


### PR DESCRIPTION
Now uses a texture to store the palette index table data.

[Example project](https://github.com/HatchGameEngine/example-projects/tree/palette-index-lines)