### PR TITLE
Autodetect image and sound formats

### DIFF
--- a/include/Engine/ResourceTypes/IModel.h
+++ b/include/Engine/ResourceTypes/IModel.h
@@ -23,9 +23,10 @@ public:
 	bool UseVertexAnimation;
 	Armature* BaseArmature;
 	Matrix4x4* GlobalInverseMatrix;
+	bool LoadFailed;
 
-	IModel();
 	IModel(const char* filename);
+	static bool IsFile(Stream* stream);
 	bool Load(Stream* stream, const char* filename);
 	size_t FindMaterial(const char* name);
 	size_t AddMaterial(Material* material);

--- a/include/Engine/ResourceTypes/ISound.h
+++ b/include/Engine/ResourceTypes/ISound.h
@@ -5,7 +5,14 @@
 #include <Engine/Audio/AudioPlayback.h>
 #include <Engine/Includes/Standard.h>
 #include <Engine/Includes/StandardSDL2.h>
+#include <Engine/IO/Stream.h>
 #include <Engine/ResourceTypes/SoundFormats/SoundFormat.h>
+
+enum {
+	AUDIO_FORMAT_UNKNOWN,
+	AUDIO_FORMAT_OGG,
+	AUDIO_FORMAT_WAV
+};
 
 #define AUDIO_LOOP_NONE (-2)
 #define AUDIO_LOOP_DEFAULT (-1)
@@ -22,6 +29,8 @@ public:
 
 	ISound(const char* filename);
 	ISound(const char* filename, bool streamFromFile);
+	static Uint8 DetectFormat(Stream* stream);
+	static bool IsFile(Stream* stream);
 	void Load(const char* filename, bool streamFromFile);
 	AudioPlayback* CreatePlayer();
 	void Dispose();

--- a/include/Engine/ResourceTypes/ISprite.h
+++ b/include/Engine/ResourceTypes/ISprite.h
@@ -2,6 +2,7 @@
 #define ENGINE_RESOURCETYPES_ISPRITE_H
 
 #include <Engine/Includes/Standard.h>
+#include <Engine/IO/Stream.h>
 #include <Engine/Rendering/Texture.h>
 #include <Engine/Sprites/Animation.h>
 
@@ -56,6 +57,7 @@ public:
 	void RefreshGraphicsID();
 	void ConvertToRGBA();
 	void ConvertToPalette(unsigned paletteNumber);
+	static bool IsFile(Stream* stream);
 	bool LoadAnimation(const char* filename);
 	int FindAnimation(const char* animname);
 	void LinkAnimation(vector<Animation> ani);

--- a/include/Engine/ResourceTypes/Image.h
+++ b/include/Engine/ResourceTypes/Image.h
@@ -2,8 +2,16 @@
 #define ENGINE_RESOURCETYPES_IMAGE_H
 
 #include <Engine/Includes/Standard.h>
+#include <Engine/IO/Stream.h>
 #include <Engine/Rendering/GameTexture.h>
 #include <Engine/Rendering/Texture.h>
+
+enum {
+	IMAGE_FORMAT_UNKNOWN,
+	IMAGE_FORMAT_PNG,
+	IMAGE_FORMAT_GIF,
+	IMAGE_FORMAT_JPEG
+};
 
 class Image {
 private:
@@ -21,6 +29,8 @@ public:
 	void Dispose();
 	~Image();
 
+	static Uint8 DetectFormat(Stream* stream);
+	static bool IsFile(Stream* stream);
 	static Texture* LoadTextureFromResource(const char* filename);
 };
 

--- a/include/Engine/ResourceTypes/ImageFormats/GIF.h
+++ b/include/Engine/ResourceTypes/ImageFormats/GIF.h
@@ -26,7 +26,7 @@ private:
 public:
 	vector<Uint32*> Frames;
 
-	static GIF* Load(const char* filename);
+	static GIF* Load(Stream* stream);
 	static bool Save(GIF* gif, const char* filename);
 	bool Save(const char* filename);
 	~GIF();

--- a/include/Engine/ResourceTypes/ImageFormats/JPEG.h
+++ b/include/Engine/ResourceTypes/ImageFormats/JPEG.h
@@ -7,7 +7,7 @@
 
 class JPEG : public ImageFormat {
 public:
-	static JPEG* Load(const char* filename);
+	static JPEG* Load(Stream* stream);
 	static bool Save(JPEG* jpeg, const char* filename);
 	bool Save(const char* filename);
 	~JPEG();

--- a/include/Engine/ResourceTypes/ImageFormats/PNG.h
+++ b/include/Engine/ResourceTypes/ImageFormats/PNG.h
@@ -7,7 +7,7 @@
 
 class PNG : public ImageFormat {
 public:
-	static PNG* Load(const char* filename);
+	static PNG* Load(Stream* stream);
 	void ReadPixelDataARGB(Uint32* pixelData, int num_channels);
 	void ReadPixelBitstream(Uint8* pixelData, size_t bit_depth);
 	static bool Save(PNG* png, const char* filename);

--- a/include/Engine/ResourceTypes/ModelFormats/Importer.h
+++ b/include/Engine/ResourceTypes/ModelFormats/Importer.h
@@ -13,12 +13,16 @@ private:
 	static Skeleton* LoadBones(IModel* imodel, Mesh* mesh, struct aiMesh* amesh);
 	static SkeletalAnim*
 	LoadAnimation(IModel* imodel, ModelAnim* parentAnim, struct aiAnimation* aanim);
+#ifdef USING_ASSIMP
+	static int GetConversionFlags();
+#endif
 	static bool DoConversion(const struct aiScene* scene, IModel* imodel);
 
 public:
 	static vector<int> MeshIDs;
 	static char* ParentDirectory;
 
+	static bool IsValid(Stream* stream);
 	static bool Convert(IModel* model, Stream* stream, const char* path);
 };
 

--- a/include/Engine/ResourceTypes/SoundFormats/OGG.h
+++ b/include/Engine/ResourceTypes/SoundFormats/OGG.h
@@ -3,6 +3,7 @@
 
 #include <Engine/Includes/Standard.h>
 #include <Engine/Includes/StandardSDL2.h>
+#include <Engine/IO/Stream.h>
 #include <Engine/ResourceTypes/SoundFormats/SoundFormat.h>
 
 class OGG : public SoundFormat {
@@ -17,7 +18,7 @@ private:
 	static long StaticTell(void* ptr);
 
 public:
-	static SoundFormat* Load(const char* filename);
+	static SoundFormat* Load(Stream* stream);
 	size_t SeekSample(int index);
 	int LoadSamples(size_t count);
 	int GetSamples(Uint8* buffer, size_t count, Sint32 loopIndex);

--- a/include/Engine/ResourceTypes/SoundFormats/WAV.h
+++ b/include/Engine/ResourceTypes/SoundFormats/WAV.h
@@ -3,6 +3,7 @@
 
 #include <Engine/Includes/Standard.h>
 #include <Engine/Includes/StandardSDL2.h>
+#include <Engine/IO/Stream.h>
 #include <Engine/ResourceTypes/SoundFormats/SoundFormat.h>
 
 class WAV : public SoundFormat {
@@ -11,7 +12,7 @@ private:
 	int DataStart = 0;
 
 public:
-	static SoundFormat* Load(const char* filename);
+	static SoundFormat* Load(Stream* stream);
 	int LoadSamples(size_t count);
 	void Dispose();
 };

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -10994,7 +10994,7 @@ VMValue Palette_LoadFromResource(int argCount, VMValue* args, Uint32 threadID) {
 					GIF* gif;
 
 					Graphics::UsePalettes = false;
-					gif = GIF::Load(filename);
+					gif = GIF::Load(memoryReader);
 					Graphics::UsePalettes = loadPalette;
 
 					if (gif) {
@@ -11026,7 +11026,7 @@ VMValue Palette_LoadFromResource(int argCount, VMValue* args, Uint32 threadID) {
 					PNG* png;
 
 					Graphics::UsePalettes = true;
-					png = PNG::Load(filename);
+					png = PNG::Load(memoryReader);
 					Graphics::UsePalettes = loadPalette;
 
 					if (png) {

--- a/source/Engine/ResourceTypes/IModel.cpp
+++ b/source/Engine/ResourceTypes/IModel.cpp
@@ -12,7 +12,7 @@
 #include <Engine/ResourceTypes/ModelFormats/RSDKModel.h>
 #include <Engine/Utilities/StringUtils.h>
 
-IModel::IModel() {
+IModel::IModel(const char* filename) {
 	VertexCount = 0;
 	VertexIndexCount = 0;
 	VertexPerFace = 0;
@@ -25,24 +25,36 @@ IModel::IModel() {
 	BaseArmature = nullptr;
 	GlobalInverseMatrix = nullptr;
 	UseVertexAnimation = false;
-}
-IModel::IModel(const char* filename) {
+
+	LoadFailed = true;
+
 	ResourceStream* resourceStream = ResourceStream::New(filename);
 	if (!resourceStream) {
 		return;
 	}
 
-	this->Load(resourceStream, filename);
+	LoadFailed = !Load(resourceStream, filename);
 
-	if (resourceStream) {
-		resourceStream->Close();
+	resourceStream->Close();
+}
+bool IModel::IsFile(Stream* stream) {
+	if (HatchModel::IsMagic(stream)) {
+		return true;
 	}
+	else if (MD3Model::IsMagic(stream)) {
+		return true;
+	}
+	else if (RSDKModel::IsMagic(stream)) {
+		return true;
+	}
+	else {
+		return ModelImporter::IsValid(stream);
+	}
+
+	return false;
 }
 bool IModel::Load(Stream* stream, const char* filename) {
-	if (!stream) {
-		return false;
-	}
-	if (!filename) {
+	if (!stream || !filename) {
 		return false;
 	}
 

--- a/source/Engine/ResourceTypes/ISound.cpp
+++ b/source/Engine/ResourceTypes/ISound.cpp
@@ -2,6 +2,7 @@
 #include <Engine/Diagnostics/Clock.h>
 #include <Engine/Diagnostics/Log.h>
 #include <Engine/Diagnostics/Memory.h>
+#include <Engine/IO/ResourceStream.h>
 #include <Engine/ResourceTypes/ISound.h>
 #include <Engine/Utilities/StringUtils.h>
 // Import sound formats
@@ -15,6 +16,25 @@ ISound::ISound(const char* filename, bool streamFromFile) {
 	ISound::Load(filename, streamFromFile);
 }
 
+Uint8 ISound::DetectFormat(Stream* stream) {
+	Uint8 magic[12] = {0};
+	stream->ReadBytes(magic, sizeof magic);
+
+	// OGG
+	if (memcmp(magic, "\x4F\x67\x67\x53", 4) == 0) {
+		return AUDIO_FORMAT_OGG;
+	}
+	// WAV
+	else if (memcmp(magic, "RIFF", 4) == 0 && memcmp(magic + 8, "WAVE", 4) == 0) {
+		return AUDIO_FORMAT_WAV;
+	}
+
+	return AUDIO_FORMAT_UNKNOWN;
+}
+bool ISound::IsFile(Stream* stream) {
+	return DetectFormat(stream) != AUDIO_FORMAT_UNKNOWN;
+}
+
 void ISound::Load(const char* filename, bool streamFromFile) {
 	LoadFailed = true;
 	StreamFromFile = streamFromFile;
@@ -22,11 +42,21 @@ void ISound::Load(const char* filename, bool streamFromFile) {
 
 	double ticks = Clock::GetTicks();
 
+	Uint8 format = AUDIO_FORMAT_UNKNOWN;
+	Stream* stream = ResourceStream::New(Filename);
+	if (stream) {
+		format = DetectFormat(stream);
+		stream->Seek(0);
+	}
+	else {
+		return;
+	}
+
 	// .OGG format
-	if (StringUtils::StrCaseStr(Filename, ".ogg")) {
+	if (format == AUDIO_FORMAT_OGG) {
 		ticks = Clock::GetTicks();
 
-		SoundData = OGG::Load(Filename);
+		SoundData = OGG::Load(stream);
 		if (!SoundData) {
 			return;
 		}
@@ -41,10 +71,10 @@ void ISound::Load(const char* filename, bool streamFromFile) {
 			Filename);
 	}
 	// .WAV format
-	else if (StringUtils::StrCaseStr(Filename, ".wav")) {
+	else if (format == AUDIO_FORMAT_WAV) {
 		ticks = Clock::GetTicks();
 
-		SoundData = WAV::Load(Filename);
+		SoundData = WAV::Load(stream);
 		if (!SoundData) {
 			return;
 		}
@@ -58,7 +88,8 @@ void ISound::Load(const char* filename, bool streamFromFile) {
 	}
 	// Unsupported format
 	else {
-		Log::Print(Log::LOG_ERROR, "Unsupported audio format from file \"%s\"!", Filename);
+		stream->Close();
+		Log::Print(Log::LOG_ERROR, "Unsupported audio format for file \"%s\"!", Filename);
 		return;
 	}
 

--- a/source/Engine/ResourceTypes/ISprite.cpp
+++ b/source/Engine/ResourceTypes/ISprite.cpp
@@ -4,12 +4,9 @@
 #include <Engine/Error.h>
 #include <Engine/Graphics.h>
 
-#include <Engine/ResourceTypes/ImageFormats/GIF.h>
-#include <Engine/ResourceTypes/ImageFormats/JPEG.h>
-#include <Engine/ResourceTypes/ImageFormats/PNG.h>
+#include <Engine/ResourceTypes/Image.h>
 #include <Engine/ResourceTypes/ResourceManager.h>
 
-#include <Engine/Diagnostics/Clock.h>
 #include <Engine/Diagnostics/Log.h>
 #include <Engine/Diagnostics/Memory.h>
 
@@ -17,6 +14,8 @@
 #include <Engine/IO/ResourceStream.h>
 
 #include <Engine/Utilities/StringUtils.h>
+
+#define RSDK_SPRITE_MAGIC 0x00525053
 
 ISprite::ISprite() {
 	Spritesheets.clear();
@@ -50,12 +49,7 @@ size_t ISprite::FindOrAddSpriteSheet(const char* sheetFilename) {
 }
 
 Texture* ISprite::AddSpriteSheet(const char* sheetFilename) {
-	Texture* texture = NULL;
-	Uint32* data = NULL;
-	Uint32 width = 0;
-	Uint32 height = 0;
-	Uint32* paletteColors = NULL;
-	unsigned numPaletteColors = 0;
+	Texture* texture = nullptr;
 
 	char* filename = StringUtils::NormalizePath(sheetFilename);
 
@@ -69,113 +63,7 @@ Texture* ISprite::AddSpriteSheet(const char* sheetFilename) {
 		return textureRef->TexturePtr;
 	}
 
-	float loadDelta = 0.0f;
-	if (StringUtils::StrCaseStr(filename, ".png")) {
-		Clock::Start();
-		PNG* png = PNG::Load(filename);
-		loadDelta = Clock::End();
-
-		if (png && png->Data) {
-			Log::Print(Log::LOG_VERBOSE,
-				"PNG load took %.3f ms (%s)",
-				loadDelta,
-				filename);
-			width = png->Width;
-			height = png->Height;
-
-			data = png->Data;
-			Memory::Track(data, "Texture::Data");
-
-			if (png->Paletted) {
-				paletteColors = png->GetPalette();
-				numPaletteColors = png->NumPaletteColors;
-			}
-
-			delete png;
-		}
-		else {
-			Log::Print(Log::LOG_ERROR, "PNG could not be loaded!");
-			Memory::Free(filename);
-			return NULL;
-		}
-	}
-	else if (StringUtils::StrCaseStr(filename, ".jpg") ||
-		StringUtils::StrCaseStr(filename, ".jpeg")) {
-		Clock::Start();
-		JPEG* jpeg = JPEG::Load(filename);
-		loadDelta = Clock::End();
-
-		if (jpeg && jpeg->Data) {
-			Log::Print(Log::LOG_VERBOSE,
-				"JPEG load took %.3f ms (%s)",
-				loadDelta,
-				filename);
-			width = jpeg->Width;
-			height = jpeg->Height;
-
-			data = jpeg->Data;
-			Memory::Track(data, "Texture::Data");
-
-			delete jpeg;
-		}
-		else {
-			Log::Print(Log::LOG_ERROR, "JPEG could not be loaded!");
-			Memory::Free(filename);
-			return NULL;
-		}
-	}
-	else if (StringUtils::StrCaseStr(filename, ".gif")) {
-		Clock::Start();
-		GIF* gif = GIF::Load(filename);
-		loadDelta = Clock::End();
-
-		if (gif && gif->Data) {
-			Log::Print(Log::LOG_VERBOSE,
-				"GIF load took %.3f ms (%s)",
-				loadDelta,
-				filename);
-			width = gif->Width;
-			height = gif->Height;
-
-			data = gif->Data;
-			Memory::Track(data, "Texture::Data");
-
-			if (gif->Paletted) {
-				paletteColors = gif->GetPalette();
-				numPaletteColors = gif->NumPaletteColors;
-			}
-
-			delete gif;
-		}
-		else {
-			Log::Print(Log::LOG_ERROR, "GIF could not be loaded!");
-			Memory::Free(filename);
-			return NULL;
-		}
-	}
-	else {
-		Log::Print(Log::LOG_ERROR, "Unsupported image format for sprite!");
-		Memory::Free(filename);
-		return texture;
-	}
-
-	bool forceSoftwareTextures = false;
-	Application::Settings->GetBool("display", "forceSoftwareTextures", &forceSoftwareTextures);
-	if (forceSoftwareTextures) {
-		Graphics::NoInternalTextures = true;
-	}
-
-	texture = Graphics::CreateTextureFromPixels(width, height, data, width * sizeof(Uint32));
-
-	if (texture == NULL) {
-		Error::Fatal("Couldn't create sprite sheet texture!");
-	}
-
-	Graphics::SetTexturePalette(texture, paletteColors, numPaletteColors);
-
-	Graphics::NoInternalTextures = false;
-
-	Memory::Free(data);
+	texture = Image::LoadTextureFromResource(filename);
 
 	Graphics::AddSpriteSheet(sheetPath, texture);
 	Spritesheets.push_back(texture);
@@ -281,6 +169,9 @@ void ISprite::ConvertToPalette(unsigned paletteNumber) {
 	}
 }
 
+bool ISprite::IsFile(Stream* stream) {
+	return stream->ReadUInt32() == RSDK_SPRITE_MAGIC;
+}
 bool ISprite::LoadAnimation(const char* filename) {
 	char* str;
 	int animationCount, previousAnimationCount;
@@ -300,7 +191,7 @@ bool ISprite::LoadAnimation(const char* filename) {
 	/// =======================
 
 	// Check MAGIC
-	if (reader->ReadUInt32() != 0x00525053) {
+	if (!IsFile(reader)) {
 		reader->Close();
 		return false;
 	}
@@ -485,7 +376,7 @@ bool ISprite::SaveAnimation(const char* filename) {
 	/// =======================
 
 	// Check MAGIC
-	stream->WriteUInt32(0x00525053);
+	stream->WriteUInt32(RSDK_SPRITE_MAGIC);
 
 	// Total frame count
 	Uint32 totalFrameCount = 0;

--- a/source/Engine/ResourceTypes/Image.cpp
+++ b/source/Engine/ResourceTypes/Image.cpp
@@ -50,6 +50,29 @@ Image::~Image() {
 	Dispose();
 }
 
+Uint8 Image::DetectFormat(Stream* stream) {
+	Uint8 magic[8];
+	stream->ReadBytes(magic, sizeof magic);
+
+	// PNG
+	if (memcmp(magic, "\x89\x50\x4E\x47\x0D\x0A\x1A\x0A", 8) == 0) {
+		return IMAGE_FORMAT_PNG;
+	}
+	// GIF
+	else if (memcmp(magic, "GIF87a", 6) == 0 || memcmp(magic, "GIF89a", 6) == 0) {
+		return IMAGE_FORMAT_GIF;
+	}
+	// JPEG
+	else if (memcmp(magic, "\xFF\xD8\xFF\xDB", 4) == 0 || memcmp(magic, "\xFF\xD8\xFF\xEE", 4) == 0) {
+		return IMAGE_FORMAT_JPEG;
+	}
+
+	return IMAGE_FORMAT_UNKNOWN;
+}
+bool Image::IsFile(Stream* stream) {
+	return DetectFormat(stream) != IMAGE_FORMAT_UNKNOWN;
+}
+
 Texture* Image::LoadTextureFromResource(const char* filename) {
 	Texture* texture = NULL;
 	Uint32* data = NULL;
@@ -58,29 +81,24 @@ Texture* Image::LoadTextureFromResource(const char* filename) {
 	Uint32* paletteColors = NULL;
 	unsigned numPaletteColors = 0;
 
-	const char* altered = filename;
-
-	Uint32 magic = 0x000000;
-	Stream* stream = ResourceStream::New(altered);
+	Uint8 format = IMAGE_FORMAT_UNKNOWN;
+	Stream* stream = ResourceStream::New(filename);
 	if (stream) {
-		magic = stream->ReadUInt32();
-		stream->Close();
+		format = DetectFormat(stream);
+		stream->Seek(0);
 	}
 	else {
-		// Log::Print(Log::LOG_ERROR, "Image \"%s\" does not
-		// exist!", filename);
 		return NULL;
 	}
 
-	// 0x474E5089U PNG
-	if (magic == 0x474E5089U) {
+	if (format == IMAGE_FORMAT_PNG) {
 		Clock::Start();
-		PNG* png = PNG::Load(altered);
+		PNG* png = PNG::Load(stream);
 		if (png) {
 			Log::Print(Log::LOG_VERBOSE,
 				"PNG load took %.3f ms (%s)",
 				Clock::End(),
-				altered);
+				filename);
 			width = (Uint32)png->Width;
 			height = (Uint32)png->Height;
 
@@ -95,19 +113,19 @@ Texture* Image::LoadTextureFromResource(const char* filename) {
 			delete png;
 		}
 		else {
-			Log::Print(Log::LOG_ERROR, "PNG could not be loaded!");
+			stream->Close();
+			Log::Print(Log::LOG_ERROR, "PNG \"%s\" could not be loaded!", filename);
 			return NULL;
 		}
 	}
-	// 0xE0FFD8FFU JPEG
-	else if ((magic & 0xFFFF) == 0xD8FFU) {
+	else if (format == IMAGE_FORMAT_JPEG) {
 		Clock::Start();
-		JPEG* jpeg = JPEG::Load(altered);
+		JPEG* jpeg = JPEG::Load(stream);
 		if (jpeg) {
 			Log::Print(Log::LOG_VERBOSE,
 				"JPEG load took %.3f ms (%s)",
 				Clock::End(),
-				altered);
+				filename);
 			width = (Uint32)jpeg->Width;
 			height = (Uint32)jpeg->Height;
 
@@ -117,18 +135,19 @@ Texture* Image::LoadTextureFromResource(const char* filename) {
 			delete jpeg;
 		}
 		else {
-			Log::Print(Log::LOG_ERROR, "JPEG could not be loaded!");
+			stream->Close();
+			Log::Print(Log::LOG_ERROR, "JPEG \"%s\" could not be loaded!", filename);
 			return NULL;
 		}
 	}
-	else if (StringUtils::StrCaseStr(altered, ".gif")) {
+	else if (format == IMAGE_FORMAT_GIF) {
 		Clock::Start();
-		GIF* gif = GIF::Load(altered);
+		GIF* gif = GIF::Load(stream);
 		if (gif) {
 			Log::Print(Log::LOG_VERBOSE,
 				"GIF load took %.3f ms (%s)",
 				Clock::End(),
-				altered);
+				filename);
 			width = (Uint32)gif->Width;
 			height = (Uint32)gif->Height;
 
@@ -143,14 +162,18 @@ Texture* Image::LoadTextureFromResource(const char* filename) {
 			delete gif;
 		}
 		else {
-			Log::Print(Log::LOG_ERROR, "GIF could not be loaded!");
+			stream->Close();
+			Log::Print(Log::LOG_ERROR, "GIF \"%s\" could not be loaded!", filename);
 			return NULL;
 		}
 	}
 	else {
-		Log::Print(Log::LOG_ERROR, "Unsupported image format! %s", filename);
+		stream->Close();
+		Log::Print(Log::LOG_ERROR, "Unsupported image format for file \"%s\"!", filename);
 		return NULL;
 	}
+
+	stream->Close();
 
 	bool forceSoftwareTextures = false;
 	Application::Settings->GetBool("display", "forceSoftwareTextures", &forceSoftwareTextures);
@@ -162,7 +185,7 @@ Texture* Image::LoadTextureFromResource(const char* filename) {
 		(width > Graphics::MaxTextureWidth || height > Graphics::MaxTextureHeight)) {
 		Log::Print(Log::LOG_WARN,
 			"Image file \"%s\" of size %d x %d is larger than maximum size of %d x %d!",
-			altered,
+			filename,
 			width,
 			height,
 			Graphics::MaxTextureWidth,

--- a/source/Engine/ResourceTypes/ImageFormats/GIF.cpp
+++ b/source/Engine/ResourceTypes/ImageFormats/GIF.cpp
@@ -188,23 +188,16 @@ void GIF::FreeTree(void* root, int degree) {
 		Clock::Start(); \
 	}
 
-GIF* GIF::Load(const char* filename) {
+GIF* GIF::Load(Stream* stream) {
 	bool loadPalette = Graphics::UsePalettes;
 	Entry* codeTable = (Entry*)Memory::Malloc(0x1000 * sizeof(Entry));
 
 	GIF* gif = new GIF;
-	Stream* stream = NULL;
 
 	size_t fileSize;
 	void* fileBuffer = NULL;
 
 	Clock::Start();
-
-	stream = ResourceStream::New(filename);
-	if (!stream) {
-		Log::Print(Log::LOG_ERROR, "Could not open file '%s'!", filename);
-		goto GIF_Load_FAIL;
-	}
 
 #ifdef DO_GIF_PERF
 	MARK_PERF_LABEL("stream open");
@@ -213,7 +206,6 @@ GIF* GIF::Load(const char* filename) {
 	fileSize = stream->Length();
 	fileBuffer = Memory::Malloc(fileSize);
 	stream->ReadBytes(fileBuffer, fileSize);
-	stream->Close();
 
 #ifdef DO_GIF_PERF
 	MARK_PERF_LABEL("read to buffer");
@@ -233,9 +225,8 @@ GIF* GIF::Load(const char* filename) {
 	if (memcmp(magicGIF, "GIF", 3) != 0) {
 		magicGIF[3] = 0;
 		Log::Print(Log::LOG_ERROR,
-			"Invalid GIF file! Found \"%s\", expected \"GIF\"! (%s)",
-			magicGIF,
-			filename);
+			"Invalid GIF file! Found \"%s\", expected \"GIF\"!",
+			magicGIF);
 		goto GIF_Load_FAIL;
 	}
 
@@ -244,9 +235,8 @@ GIF* GIF::Load(const char* filename) {
 	if (memcmp(magic89a, "89a", 3) != 0 && memcmp(magic89a, "87a", 3) != 0) {
 		magic89a[3] = 0;
 		Log::Print(Log::LOG_ERROR,
-			"Invalid GIF version! Found \"%s\", expected \"89a\"! (%s)",
-			magic89a,
-			filename);
+			"Invalid GIF version! Found \"%s\", expected \"89a\"!",
+			magic89a);
 		goto GIF_Load_FAIL;
 	}
 
@@ -263,7 +253,7 @@ GIF* GIF::Load(const char* filename) {
 	stream->Skip(1); // pixelAspectRatio = stream->ReadByte();
 
 	if ((logicalScreenDesc & 0x80) == 0) {
-		Log::Print(Log::LOG_ERROR, "GIF missing palette table! (%s)", filename);
+		Log::Print(Log::LOG_ERROR, "GIF missing palette table!");
 		goto GIF_Load_FAIL;
 	}
 
@@ -575,9 +565,6 @@ GIF_Load_Success:
 	MARK_PERF_LABEL("decode gif data");
 #endif
 	Clock::End();
-	if (stream) {
-		stream->Close();
-	}
 	Memory::Free(fileBuffer);
 	Memory::Free(codeTable);
 	return gif;

--- a/source/Engine/ResourceTypes/ImageFormats/ImageFormat.cpp
+++ b/source/Engine/ResourceTypes/ImageFormats/ImageFormat.cpp
@@ -1,4 +1,6 @@
 #include <Engine/Diagnostics/Memory.h>
+#include <Engine/IO/ResourceStream.h>
+#include <Engine/IO/Stream.h>
 #include <Engine/ResourceTypes/ImageFormats/ImageFormat.h>
 
 Uint32* ImageFormat::GetPalette() {

--- a/source/Engine/ResourceTypes/ImageFormats/JPEG.cpp
+++ b/source/Engine/ResourceTypes/ImageFormats/JPEG.cpp
@@ -93,13 +93,9 @@ static void jpeg_Hatch_IO_src(j_decompress_ptr cinfo, Stream* stream) {
 }
 #endif
 
-JPEG* JPEG::Load(const char* filename) {
+JPEG* JPEG::Load(Stream* stream) {
 #ifdef USING_LIBJPEG
 	JPEG* jpeg = new JPEG;
-	Stream* stream = NULL;
-	// size_t fileSize;
-	// void*  fileBuffer = NULL;
-	// SDL_Surface* temp = NULL,* tempOld = NULL;
 
 	// JPEG variables
 	Sint64 start;
@@ -111,12 +107,6 @@ JPEG* JPEG::Load(const char* filename) {
 
 	Uint32 Rmask, Gmask, Bmask, Amask;
 	bool doConvert;
-
-	stream = ResourceStream::New(filename);
-	if (!stream) {
-		Log::Print(Log::LOG_ERROR, "Could not open file '%s'!", filename);
-		goto JPEG_Load_FAIL;
-	}
 
 	start = stream->Position();
 
@@ -235,8 +225,6 @@ JPEG* JPEG::Load(const char* filename) {
 	}
 	else {
 		memcpy(jpeg->Data, pixelData, jpeg->Width * jpeg->Height * sizeof(Uint32));
-		// memcpy(jpeg->Data, pixelData, jpeg->Width *
-		// jpeg->Height * 3);
 	}
 	free(pixelData);
 
@@ -249,9 +237,6 @@ JPEG_Load_FAIL:
 JPEG_Load_Success:
 	if (cinfoFlag) {
 		jpeg_destroy_decompress(&cinfo);
-	}
-	if (stream) {
-		stream->Close();
 	}
 	return jpeg;
 #endif

--- a/source/Engine/ResourceTypes/ImageFormats/PNG.cpp
+++ b/source/Engine/ResourceTypes/ImageFormats/PNG.cpp
@@ -37,10 +37,9 @@ void png_read_fn(png_structp ctx, png_bytep area, png_size_t size) {
 #include <Libraries/stb_image.h>
 #endif
 
-PNG* PNG::Load(const char* filename) {
+PNG* PNG::Load(Stream* stream) {
 #ifdef USING_LIBPNG
 	PNG* png = new PNG;
-	Stream* stream = NULL;
 
 	// PNG variables
 	png_structp png_ptr = NULL;
@@ -52,12 +51,6 @@ PNG* PNG::Load(const char* filename) {
 	Uint32* pixelData = NULL;
 	png_bytep* row_pointers = NULL;
 	Uint32 row_bytes;
-
-	stream = ResourceStream::New(filename);
-	if (!stream) {
-		Log::Print(Log::LOG_ERROR, "Could not open file '%s'!", filename);
-		goto PNG_Load_FAIL;
-	}
 
 	png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
 	if (png_ptr == NULL) {
@@ -170,13 +163,9 @@ PNG_Load_Success:
 		png_destroy_read_struct(
 			&png_ptr, info_ptr ? &info_ptr : (png_infopp)NULL, (png_infopp)NULL);
 	}
-	if (stream) {
-		stream->Close();
-	}
 	return png;
 #elif defined(USING_SPNG)
 	PNG* png = new PNG;
-	Stream* stream = NULL;
 	Uint8* pixelData = NULL;
 	Uint8* buffer = NULL;
 	size_t buffer_len = 0;
@@ -191,16 +180,9 @@ PNG_Load_Success:
 	size_t image_size;
 	int ret;
 
-	stream = ResourceStream::New(filename);
-	if (!stream) {
-		Log::Print(Log::LOG_ERROR, "Could not open file '%s'!", filename);
-		goto PNG_Load_FAIL;
-	}
-
 	buffer_len = stream->Length();
 	buffer = (Uint8*)malloc(buffer_len);
 	stream->ReadBytes(buffer, buffer_len);
-	stream->Close();
 
 	ctx = spng_ctx_new(0);
 	if (ctx == NULL) {
@@ -308,23 +290,15 @@ PNG_Load_Success:
 	return png;
 #else
 	PNG* png = new PNG;
-	Stream* stream = NULL;
 	Uint32* pixelData = NULL;
 	int num_channels;
 	int width, height;
 	Uint8* buffer = NULL;
 	size_t buffer_len = 0;
 
-	stream = ResourceStream::New(filename);
-	if (!stream) {
-		Log::Print(Log::LOG_ERROR, "Could not open file '%s'!", filename);
-		goto PNG_Load_FAIL;
-	}
-
 	buffer_len = stream->Length();
 	buffer = (Uint8*)malloc(buffer_len);
 	stream->ReadBytes(buffer, buffer_len);
-	stream->Close();
 
 	pixelData = (Uint32*)stbi_load_from_memory(
 		buffer, buffer_len, &width, &height, &num_channels, STBI_rgb_alpha);

--- a/source/Engine/ResourceTypes/ModelFormats/Importer.cpp
+++ b/source/Engine/ResourceTypes/ModelFormats/Importer.cpp
@@ -507,6 +507,37 @@ bool ModelImporter::DoConversion(const struct aiScene* scene, IModel* imodel) {
 }
 #endif
 
+#ifdef USING_ASSIMP
+int ModelImporter::GetConversionFlags() {
+	return aiProcessPreset_TargetRealtime_Fast | aiProcess_ConvertToLeftHanded;
+}
+#endif
+bool ModelImporter::IsValid(Stream* stream) {
+#ifdef USING_ASSIMP
+	size_t size = stream->Length();
+	void* data = Memory::Malloc(size);
+	if (data) {
+		stream->ReadBytes(data, size);
+	}
+	else {
+		return false;
+	}
+
+	Assimp::Importer importer;
+
+	int flags = GetConversionFlags();
+
+	const struct aiScene* scene = importer.ReadFileFromMemory(data, size, flags);
+	if (scene && scene->mRootNode && (scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE) == 0) {
+		Memory::Free(data);
+		return true;
+	}
+
+	Memory::Free(data);
+#endif
+
+	return false;
+}
 bool ModelImporter::Convert(IModel* model, Stream* stream, const char* path) {
 #ifdef USING_ASSIMP
 	size_t size = stream->Length();
@@ -521,8 +552,7 @@ bool ModelImporter::Convert(IModel* model, Stream* stream, const char* path) {
 
 	Assimp::Importer importer;
 
-	int flags = aiProcessPreset_TargetRealtime_Fast;
-	flags |= aiProcess_ConvertToLeftHanded;
+	int flags = GetConversionFlags();
 
 	const struct aiScene* scene =
 		importer.ReadFileFromMemory(data, size, flags, StringUtils::GetExtension(path));

--- a/source/Engine/ResourceTypes/SceneFormats/RSDKSceneReader.cpp
+++ b/source/Engine/ResourceTypes/SceneFormats/RSDKSceneReader.cpp
@@ -682,12 +682,14 @@ bool RSDKSceneReader::LoadTileset(const char* parentFolder) {
 
 	char filename16x16Tiles[MAX_RESOURCE_PATH_LENGTH];
 	snprintf(filename16x16Tiles, sizeof(filename16x16Tiles), "%s16x16Tiles.gif", parentFolder);
-	{
+
+	Stream* resourceStream = ResourceStream::New(filename16x16Tiles);
+	if (resourceStream != nullptr) {
 		GIF* gif;
 		bool loadPalette = Graphics::UsePalettes;
 
 		Graphics::UsePalettes = false;
-		gif = GIF::Load(filename16x16Tiles);
+		gif = GIF::Load(resourceStream);
 		Graphics::UsePalettes = loadPalette;
 
 		if (gif) {
@@ -699,6 +701,8 @@ bool RSDKSceneReader::LoadTileset(const char* parentFolder) {
 			}
 			delete gif;
 		}
+
+		resourceStream->Close();
 	}
 
 	ISprite* tileSprite = new ISprite();

--- a/source/Engine/ResourceTypes/SoundFormats/OGG.cpp
+++ b/source/Engine/ResourceTypes/SoundFormats/OGG.cpp
@@ -64,15 +64,10 @@ long OGG::StaticTell(void* ptr) {
 	return ((class Stream*)ptr)->Position();
 }
 
-SoundFormat* OGG::Load(const char* filename) {
+SoundFormat* OGG::Load(Stream* stream) {
 	VorbisGroup* vorbis;
 
 	OGG* ogg = NULL;
-	class Stream* stream = ResourceStream::New(filename);
-	if (!stream) {
-		Log::Print(Log::LOG_ERROR, "Could not open file '%s'!", filename);
-		goto OGG_Load_FAIL;
-	}
 
 #ifdef USING_LIBOGG
 	ogg = new (std::nothrow) OGG;
@@ -83,10 +78,6 @@ SoundFormat* OGG::Load(const char* filename) {
 	ogg->StreamPtr = stream;
 
 	ov_callbacks callbacks;
-	// callbacks = OV_CALLBACKS_STREAMONLY;
-	// callbacks = OV_CALLBACKS_STREAMONLY_NOCLOSE;
-	// callbacks = OV_CALLBACKS_DEFAULT;
-	// callbacks = OV_CALLBACKS_NOCLOSE;
 
 	callbacks.read_func = OGG::StaticRead;
 	callbacks.seek_func = OGG::StaticSeek;
@@ -99,7 +90,7 @@ SoundFormat* OGG::Load(const char* filename) {
 
 	int res;
 	if ((res = ov_open_callbacks(ogg->StreamPtr, &vorbis->File, NULL, 0, callbacks)) != 0) {
-		Log::Print(Log::LOG_ERROR, "Could not read file '%s'!", filename);
+		Log::Print(Log::LOG_ERROR, "Could not read stream!");
 		switch (res) {
 		case OV_EREAD:
 			Log::Print(Log::LOG_ERROR, "A read from media returned an error.");
@@ -159,7 +150,7 @@ SoundFormat* OGG::Load(const char* filename) {
 			stb_vorbis_open_memory((Uint8*)vorbis->FileBlock, fileLength, &error, NULL);
 		if (!vorbis->VorbisSTB) {
 			Log::Print(
-				Log::LOG_ERROR, "Could not open Vorbis stream for %s!", filename);
+				Log::LOG_ERROR, "Could not open Vorbis stream!");
 
 			switch (error) {
 			case VORBIS_need_more_data:
@@ -280,9 +271,6 @@ OGG_Load_FAIL:
 	ogg = NULL;
 
 OGG_Load_SUCCESS:
-	if (stream) {
-		stream->Close();
-	}
 	return ogg;
 }
 

--- a/source/Engine/ResourceTypes/SoundFormats/WAV.cpp
+++ b/source/Engine/ResourceTypes/SoundFormats/WAV.cpp
@@ -15,15 +15,8 @@ struct WAVheader {
 	Uint32 DATASize; // Sampled data length
 };
 
-SoundFormat* WAV::Load(const char* filename) {
-	WAV* wav = NULL;
-	class Stream* stream = ResourceStream::New(filename);
-	if (!stream) {
-		Log::Print(Log::LOG_ERROR, "Could not open file '%s'!", filename);
-		goto WAV_Load_FAIL;
-	}
-
-	wav = new (std::nothrow) WAV;
+SoundFormat* WAV::Load(Stream* stream) {
+	WAV* wav = new (std::nothrow) WAV;
 	if (!wav) {
 		goto WAV_Load_FAIL;
 	}
@@ -68,7 +61,6 @@ SoundFormat* WAV::Load(const char* filename) {
 
 	wav->TotalPossibleSamples =
 		(int)(header.DATASize / (((header.BitsPerSample & 0xFF) >> 3) * header.Channels));
-	// stream->Seek(wav->DataStart);
 
 	// Common
 	wav->LoadFinish();

--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -2848,26 +2848,13 @@ int Scene::LoadModelResource(const char* filename, int unloadPolicy) {
 		return (int)index;
 	}
 
-	ResourceStream* stream = ResourceStream::New(filename);
-	if (!stream) {
-		Log::Print(Log::LOG_ERROR, "Could not read resource \"%s\"!", filename);
-		delete resource;
-		(*list)[index] = NULL;
-		return -1;
-	}
-
-	resource->AsModel = new (std::nothrow) IModel();
-
-	if (!resource->AsModel->Load(stream, filename)) {
+	resource->AsModel = new (std::nothrow) IModel(filename);
+	if (resource->AsModel->LoadFailed) {
 		delete resource->AsModel;
 		delete resource;
-		list->pop_back();
-		stream->Close();
 		(*list)[index] = NULL;
 		return -1;
 	}
-
-	stream->Close();
 
 	return (int)index;
 }


### PR DESCRIPTION
Ported from #42. Currently Hatch checks the image or sound's filename extension to decide which loader to use, which makes it possible to "lie" to the application about the real format of the file. This PR changes it so that Hatch instead reads the file's signature (its magic number) to decide how to load the file.