### PR TITLE
Fix `Array.Pop`, `Array.Insert`, and `Array.Erase`

### DIFF
--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -1792,6 +1792,11 @@ VMValue Array_Pop(int argCount, VMValue* args, Uint32 threadID) {
 
 	if (ScriptManager::Lock()) {
 		ObjArray* array = GET_ARG(0, GetArray);
+		if (array->Values->size() == 0) {
+			ScriptManager::Unlock();
+			THROW_ERROR("Array is empty!");
+			return NULL_VAL;
+		}
 		VMValue value = array->Values->back();
 		array->Values->pop_back();
 		ScriptManager::Unlock();
@@ -1813,6 +1818,13 @@ VMValue Array_Insert(int argCount, VMValue* args, Uint32 threadID) {
 	if (ScriptManager::Lock()) {
 		ObjArray* array = GET_ARG(0, GetArray);
 		int index = GET_ARG(1, GetInteger);
+		if (index < 0 || index > (int)array->Values->size()) { // Not a typo
+			ScriptManager::Unlock();
+			THROW_ERROR("Index %d is out of bounds of array of size %d.",
+				index,
+				(int)array->Values->size());
+			return NULL_VAL;
+		}
 		array->Values->insert(array->Values->begin() + index, args[2]);
 		ScriptManager::Unlock();
 	}
@@ -1831,6 +1843,13 @@ VMValue Array_Erase(int argCount, VMValue* args, Uint32 threadID) {
 	if (ScriptManager::Lock()) {
 		ObjArray* array = GET_ARG(0, GetArray);
 		int index = GET_ARG(1, GetInteger);
+		if (index < 0 || index >= (int)array->Values->size()) {
+			ScriptManager::Unlock();
+			THROW_ERROR("Index %d is out of bounds of array of size %d.",
+				index,
+				(int)array->Values->size());
+			return NULL_VAL;
+		}
 		array->Values->erase(array->Values->begin() + index);
 		ScriptManager::Unlock();
 	}


### PR DESCRIPTION
Fixes #80.

HSL code that tests this:

```js
var arr = [];

// "Array is empty!"
Array.Pop(arr);

Array.Push(arr, 1);
Array.Push(arr, 2);
Array.Push(arr, 3);

// "INFO: [1,2,3]"
print arr;

// "Index 10 is out of bounds of array of size 3."
Array.Insert(arr, 10, 4);

// "Index 20 is out of bounds of array of size 3."
Array.Erase(arr, 20);

// "Index -1 is out of bounds of array of size 3."
Array.Insert(arr, -1, 5);

// "Index -2 is out of bounds of array of size 3."
Array.Erase(arr, -2);

repeat (3) {
    Array.Pop(arr);
}

// "Index 0 is out of bounds of array of size 0."
Array.Erase(arr, 0);

// The following works, and is equivalent to Array.Push
Array.Insert(arr, 0, 10);
Array.Insert(arr, 1, 20);

// "INFO: [10, 20]"
print arr;

// The following does not work, though.
// "Index 3 is out of bounds of array of size 2."
Array.Insert(arr, 3, 30);
```