### PR TITLE
Support `for (... in ...)` as an alternative of `foreach`

### DIFF
--- a/include/Engine/Bytecode/Compiler.h
+++ b/include/Engine/Bytecode/Compiler.h
@@ -145,6 +145,7 @@ public:
 	void GetWithStatement();
 	void GetForStatement();
 	void GetForEachStatement();
+	void GetForEachBlock();
 	void GetIfStatement();
 	void GetStatement();
 	int GetFunction(int type, string className);


### PR DESCRIPTION
```js
for (number in [1, 2, 3]) {
    print(number);
}
```