### PR TITLE
Persist the settings file only if it doesn't exist

### DIFF
--- a/include/Engine/Filesystem/VFS/MemoryCache.h
+++ b/include/Engine/Filesystem/VFS/MemoryCache.h
@@ -12,6 +12,7 @@ public:
 	static bool Using;
 
 	static Stream* OpenStream(const char* filename, Uint32 access);
+	static bool Exists(const char* filename);
 	static bool Init();
 	static void Dispose();
 };

--- a/include/Engine/IO/FileStream.h
+++ b/include/Engine/IO/FileStream.h
@@ -30,6 +30,7 @@ public:
 
 	static FileStream* New(const char* filename, Uint32 access);
 	static FileStream* New(const char* filename, Uint32 access, bool allowURLs);
+	static bool Exists(const char* filename, bool allowURLs);
 	bool IsReadable();
 	bool IsWritable();
 	bool MakeReadable(bool readable);

--- a/include/Engine/TextFormats/INI/INI.h
+++ b/include/Engine/TextFormats/INI/INI.h
@@ -16,6 +16,7 @@ public:
 	bool Reload();
 	bool Save(const char* filename);
 	bool Save();
+	bool IsPersisted();
 	void SetFilename(const char* filename);
 	bool Read(Stream* stream);
 	bool Write(Stream* stream);

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -241,7 +241,9 @@ void Application::Init(int argc, char* args[]) {
 		MemoryCache::Init();
 	}
 
-	Application::SaveSettings();
+	if (Application::Settings && !Application::Settings->IsPersisted()) {
+		Application::Settings->Save();
+	}
 
 	AudioManager::Init();
 

--- a/source/Engine/Filesystem/VFS/MemoryCache.cpp
+++ b/source/Engine/Filesystem/VFS/MemoryCache.cpp
@@ -51,6 +51,14 @@ Stream* MemoryCache::OpenStream(const char* filename, Uint32 access) {
 	return stream;
 }
 
+bool MemoryCache::Exists(const char* filename) {
+	if (CacheVFS) {
+		return CacheVFS->FileExists(filename);
+	}
+
+	return false;
+}
+
 void MemoryCache::Dispose() {
 	if (CacheVFS) {
 		delete CacheVFS;

--- a/source/Engine/IO/FileStream.cpp
+++ b/source/Engine/IO/FileStream.cpp
@@ -173,6 +173,28 @@ bool FileStream::Reopen(Uint32 newAccess) {
 	return true;
 }
 
+bool FileStream::Exists(const char* filename, bool allowURLs) {
+	std::string resolvedPath = "";
+
+	PathLocation location = PathLocation::DEFAULT;
+
+	if (!Path::FromURL(filename, resolvedPath, location, false)) {
+		return false;
+	}
+
+	if (!allowURLs && location != PathLocation::DEFAULT) {
+		return false;
+	}
+
+	if (location == PathLocation::CACHE) {
+		resolvedPath = Path::StripURL(filename);
+
+		return MemoryCache::Exists(resolvedPath.c_str());
+	}
+
+	return File::Exists(resolvedPath.c_str());
+}
+
 bool FileStream::IsReadable() {
 	return CurrentAccess == FileStream::READ_ACCESS;
 }

--- a/source/Engine/TextFormats/INI/INI.cpp
+++ b/source/Engine/TextFormats/INI/INI.cpp
@@ -67,6 +67,9 @@ bool INI::Save(const char* filename) {
 bool INI::Save() {
 	return Save(Filename);
 }
+bool INI::IsPersisted() {
+	return FileStream::Exists(Filename, true);
+}
 void INI::SetFilename(const char* filename) {
 	Memory::Free(Filename);
 	Filename = StringUtils::Duplicate(filename);


### PR DESCRIPTION
The engine was always saving the settings file when the application started, which isn't necessary. This PR changes it so that it only saves the settings if it doesn't exist already.