### PR TITLE
Fix crash when no data file is found

### DIFF
--- a/source/Engine/Audio/AudioManager.cpp
+++ b/source/Engine/Audio/AudioManager.cpp
@@ -856,7 +856,9 @@ void AudioManager::AudioCallback(void* data, Uint8* stream, int len) {
 }
 
 void AudioManager::Dispose() {
-	AudioManager::ClearSounds();
+	if (SoundArray) {
+		AudioManager::ClearSounds();
+	}
 
 	Memory::Free(SoundArray);
 	Memory::Free(AudioQueue);


### PR DESCRIPTION
`Error::ShowFatal()` attempts an `Application::Cleanup()` before exiting, but the AudioManager hasn't been initialized yet. Check for SoundArray being non-NULL before trying to clear sound data.