### PR TITLE
Optimize `FileSystemVFS::IsEmpty()`

### DIFF
--- a/include/Engine/Filesystem/Directory.h
+++ b/include/Engine/Filesystem/Directory.h
@@ -19,6 +19,7 @@ public:
 		bool allDirs);
 	static std::vector<std::filesystem::path>
 	GetDirectories(const char* path, const char* searchPattern, bool allDirs);
+	static bool IsEmpty(const char* path);
 };
 
 #endif /* ENGINE_FILESYSTEM_DIRECTORY_H */

--- a/source/Engine/Filesystem/Directory.cpp
+++ b/source/Engine/Filesystem/Directory.cpp
@@ -67,15 +67,14 @@ void Directory::GetFiles(std::vector<std::filesystem::path>* files,
 	const char* path,
 	const char* searchPattern,
 	bool allDirs) {
+	char fullpath[MAX_PATH_LENGTH];
+
 #if WIN32
 	char winPath[MAX_PATH_LENGTH];
 	snprintf(winPath, MAX_PATH_LENGTH, "%s%s*", path, path[strlen(path) - 1] == '/' ? "" : "/");
 
 	WIN32_FIND_DATA data;
 	HANDLE hFind = FindFirstFile(winPath, &data);
-
-	int i;
-	char fullpath[MAX_PATH_LENGTH];
 	if (hFind != INVALID_HANDLE_VALUE) {
 		do {
 			if (data.cFileName[0] == '.' && data.cFileName[1] == 0) {
@@ -114,10 +113,8 @@ void Directory::GetFiles(std::vector<std::filesystem::path>* files,
 		FindClose(hFind);
 	}
 #else
-	char fullpath[MAX_PATH_LENGTH];
 	DIR* dir = opendir(path);
 	if (dir) {
-		size_t i;
 		struct dirent* d;
 
 		while ((d = readdir(dir)) != NULL) {
@@ -260,4 +257,16 @@ Directory::GetDirectories(const char* path, const char* searchPattern, bool allD
 	std::vector<std::filesystem::path> files;
 	Directory::GetDirectories(&files, path, searchPattern, allDirs);
 	return files;
+}
+
+bool Directory::IsEmpty(const char* path) {
+	std::filesystem::path pathFs = std::filesystem::u8path(path);
+	std::filesystem::file_status status = std::filesystem::status(pathFs);
+
+	if (std::filesystem::is_directory(status)) {
+		std::error_code err;
+		return std::filesystem::is_empty(pathFs, err);
+	}
+
+	return false;
 }

--- a/source/Engine/Filesystem/VFS/FileSystemVFS.cpp
+++ b/source/Engine/Filesystem/VFS/FileSystemVFS.cpp
@@ -33,10 +33,7 @@ bool FileSystemVFS::GetPath(const char* filename, char* path, size_t pathSize) {
 }
 
 bool FileSystemVFS::IsEmpty() {
-	std::vector<std::filesystem::path> results;
-	Directory::GetFiles(&results, ParentPath.c_str(), "*", true);
-
-	return results.size() == 0;
+	return Directory::IsEmpty(ParentPath.c_str());
 }
 
 bool FileSystemVFS::HasFile(const char* filename) {


### PR DESCRIPTION
`IsEmpty()` was getting a list of all files in the path and checking if it was empty, which made startup times slow if you were using a Resources folder that had a lot of files. This PR makes it use `std::filesystem::is_empty` instead.