### PR TITLE
Fix continue jumps inside switch cases

### DIFF
--- a/source/Engine/Bytecode/Compiler.cpp
+++ b/source/Engine/Bytecode/Compiler.cpp
@@ -2338,6 +2338,12 @@ void Compiler::GetSwitchStatement() {
 		(*top)[i] += code_offset;
 	}
 
+	// Set the old continue opcode positions to the newly placed ones
+	top = ContinueJumpListStack.top();
+	for (size_t i = 0; i < top->size(); i++) {
+		(*top)[i] += code_offset;
+	}
+
 	// Pop jump list off break stack, patch all breaks to this code
 	// point
 	EndBreakJumpList();


### PR DESCRIPTION
Test code:

```js
for (var i = 0; i < 6; i++) {
    print(i);

    switch (i) {
    case 1:
        print("First");
        break;
    case 2:
        print("Second");
        break;
    case 3:
        print("Third");
        break;
    case 4:
        print("Fourth");
        continue;
    case 5:
        print("Fifth");
        break;
    default:
        continue;
    }

    print("Next");
}
```

Should print the following:
```
     INFO: 0
     INFO: 1
     INFO: First
     INFO: Next
     INFO: 2
     INFO: Second
     INFO: Next
     INFO: 3
     INFO: Third
     INFO: Next
     INFO: 4
     INFO: Fourth
     INFO: 5
     INFO: Fifth
     INFO: Next
```