### PR TITLE
Application: Clear graphics at the start of the frame

### DIFF
--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -1541,6 +1541,10 @@ void Application::RunFrame(int runFrames) {
 
 	FrameTimeStart = Clock::GetTicks();
 
+	Metrics.Clear.Begin();
+	Graphics::Clear();
+	Metrics.Clear.End();
+
 	// Event loop
 	Metrics.Event.Begin();
 	Application::PollEvents();
@@ -1627,10 +1631,6 @@ void Application::RunFrame(int runFrames) {
 #endif
 
 	// Rendering
-	Metrics.Clear.Begin();
-	Graphics::Clear();
-	Metrics.Clear.End();
-
 	Metrics.Render.Begin();
 	Scene::Render();
 	Metrics.Render.End();


### PR DESCRIPTION
When using the GL renderer, clearing the frame after GL state changes from the game sometimes add an implicit synchronization which makes glClear hang for a couple milliseconds.
Move it at the start of the frame so that the GL driver optimizes it better.