### PR TITLE
Incorporate skip-capable entity animating

### DIFF
--- a/include/Engine/Types/Entity.h
+++ b/include/Engine/Types/Entity.h
@@ -123,6 +123,7 @@ public:
 	int AnimationSpeedAdd = 0;
 	int PrevAnimation = -1;
 	int AutoAnimate = true;
+	int AnimationFrameSkip = true;
 	float AnimationSpeed = 0.0;
 	float AnimationTimer = 0.0;
 	int AnimationFrameDuration = 0;
@@ -153,6 +154,7 @@ public:
 
 	static HashMap<EntitySpawnFunction>* SpawnFunctions;
 	static bool DisableAutoAnimate;
+	static bool UseAnimationFrameSkip;
 
 	static void InitAll();
 	static void UnloadAll();

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -884,6 +884,7 @@ void Application::EndGame() {
 	Entity::UnloadAll();
 
 	Entity::DisableAutoAnimate = false;
+	Entity::UseAnimationFrameSkip = true;
 }
 
 void Application::UnloadGame() {

--- a/source/Engine/Bytecode/ScriptEntity.cpp
+++ b/source/Engine/Bytecode/ScriptEntity.cpp
@@ -354,6 +354,14 @@ void ScriptEntity::LinkFields() {
     * \desc Whether <ref Entity.Animate> is automatically called for this entity.
     */
 	LINK_INT(AutoAnimate);
+	/***
+	* \field AnimationFrameSkip
+	* \type boolean
+	* \default true
+	* \ns Entity
+	* \desc Whether <ref Entity.Animate> has skip-capable animating. Entities with this on can skip animation frames if <ref Entity.AnimationSpeed> passes multiples of <ref Entity.AnimationFrameDuration>.
+	*/
+	LINK_INT(AnimationFrameSkip);
 
 	/***
     * \field OnScreen

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -9572,6 +9572,17 @@ VMValue Instance_DisableAutoAnimate(int argCount, VMValue* args, Uint32 threadID
 	return NULL_VAL;
 }
 /***
+ * Instance.UseAnimationFrameSkip
+ * \desc Lets entities skip animation frames when their associated AnimationTimer passes multiples of the AnimationFrameDuration.
+ * \param allowAnimationFrameSkip (boolean): Whether to turn on the engine automatically applying AnimationFrameSkip when entities are initialized.
+ * \ns Instance
+ */
+VMValue Instance_UseAnimationFrameSkip(int argCount, VMValue* args, Uint32 threadID) {
+	CHECK_ARGCOUNT(1);
+	Entity::UseAnimationFrameSkip = !!GET_ARG(0, GetInteger);
+	return NULL_VAL;
+}
+/***
  * Instance.SetUseRenderRegions
  * \desc Sets whether entities will use Render Regions when rendering. If false, entities will use their Update Regions instead.
  * \param useRenderRegions (boolean): Whether render regions will be used.
@@ -21063,6 +21074,7 @@ This class also houses the input action system.
 	DEF_NATIVE(Instance, GetNextInstance);
 	DEF_NATIVE(Instance, GetBySlotID);
 	DEF_NATIVE(Instance, DisableAutoAnimate);
+	DEF_NATIVE(Instance, UseAnimationFrameSkip);
 	DEF_NATIVE(Instance, SetUseRenderRegions);
 	DEF_NATIVE(Instance, Copy);
 	DEF_NATIVE(Instance, ChangeClass);

--- a/source/Engine/Types/Entity.cpp
+++ b/source/Engine/Types/Entity.cpp
@@ -5,6 +5,7 @@
 
 HashMap<EntitySpawnFunction>* Entity::SpawnFunctions = nullptr;
 bool Entity::DisableAutoAnimate = false;
+bool Entity::UseAnimationFrameSkip = true;
 
 void Entity::InitAll() {
 	SpawnFunctions = new HashMap<EntitySpawnFunction>();
@@ -62,62 +63,68 @@ void Entity::Animate() {
 		return;
 	}
 
-#ifdef USE_RSDK_ANIMATE
 	AnimationTimer += (AnimationSpeed * AnimationSpeedMult + AnimationSpeedAdd);
 
-	while (AnimationTimer > AnimationFrameDuration) {
-		CurrentFrame++;
-
-		AnimationTimer -= AnimationFrameDuration;
-		if (CurrentFrame >= CurrentFrameCount) {
-			CurrentFrame = AnimationLoopIndex;
-			OnAnimationFinish();
-		}
-
-		AnimationFrameDuration =
-			sprite->Animations[CurrentAnimation].Frames[CurrentFrame].Duration;
-	}
-#else
-	if ((float)AnimationFrameDuration - AnimationTimer > 0.0f) {
-		AnimationTimer += (AnimationSpeed * AnimationSpeedMult + AnimationSpeedAdd);
-		if ((float)AnimationFrameDuration - AnimationTimer <= 0.0f) {
+	if (AnimationFrameSkip) {
+		// Skip-capable animation behavior
+		// (supports skipping animation frames if AnimationTimer passes multiples of AnimationFrameDuration)
+		while (AnimationTimer > AnimationFrameDuration) {
 			CurrentFrame++;
+			AnimationTimer -= AnimationFrameDuration;
+
 			if (CurrentFrame >= CurrentFrameCount) {
 				CurrentFrame = AnimationLoopIndex;
 				OnAnimationFinish();
 
-				// Sprite may have changed after a call
-				// to OnAnimationFinish
+				// Sprite may have changed after a call to OnAnimationFinish
 				ResourceType* resource = Scene::GetSpriteResource(Sprite);
 				if (resource) {
-					sprite = Scene::GetSpriteResource(Sprite)->AsSprite;
+					sprite = resource->AsSprite;
 				}
 				else {
 					sprite = nullptr;
+					break;
 				}
 			}
 
-			// Do a basic range check, for strange loop
-			// points (or just in case CurrentAnimation
-			// happens to be invalid, which is very
-			// possible)
-			if (sprite && CurrentFrame < CurrentFrameCount && CurrentAnimation >= 0 &&
-				CurrentAnimation < sprite->Animations.size()) {
-				AnimationFrameDuration = sprite->Animations[CurrentAnimation]
-								 .Frames[CurrentFrame]
-								 .Duration;
+			// Update duration for the new frame
+			// Check range for strange loop points or if CurrentAnimation is now invalid
+			if (sprite && CurrentFrame < CurrentFrameCount && CurrentAnimation >= 0
+				&& CurrentAnimation < sprite->Animations.size()) {
+				AnimationFrameDuration = sprite->Animations[CurrentAnimation].Frames[CurrentFrame].Duration;
 			}
 			else {
-				AnimationFrameDuration = 1.0f;
+				AnimationFrameDuration = 1;
 			}
-
-			AnimationTimer = 0.0f;
 		}
 	}
 	else {
-		AnimationTimer = 0.0f;
+		// Strict animation behavior
+		// (never skips animation frames, and resets AnimationTimer to 0.0 upon any changed frame)
+		if ((float)AnimationFrameDuration - AnimationTimer <= 0.0f) {
+			CurrentFrame++;
+			AnimationTimer = 0.0f; // Wipe leftover time
+
+			if (CurrentFrame >= CurrentFrameCount) {
+				CurrentFrame = AnimationLoopIndex;
+				OnAnimationFinish();
+
+				// Sprite may have changed after a call to OnAnimationFinish
+				ResourceType* resource = Scene::GetSpriteResource(Sprite);
+                sprite = resource ? resource->AsSprite : nullptr;
+			}
+
+			// Update duration for the new frame
+			// Check range for strange loop points or if CurrentAnimation is now invalid
+			if (sprite && CurrentFrame < CurrentFrameCount && CurrentAnimation >= 0
+				&& CurrentAnimation < sprite->Animations.size()) {
+				AnimationFrameDuration = sprite->Animations[CurrentAnimation].Frames[CurrentFrame].Duration;
+			}
+			else {
+				AnimationFrameDuration = 1;
+			}
+		}
 	}
-#endif
 }
 void Entity::SetAnimation(int animation, int frame) {
 	if (CurrentAnimation != animation) {
@@ -579,6 +586,7 @@ void Entity::CopyFields(Entity* other) {
 	COPY(AnimationSpeedAdd);
 	COPY(PrevAnimation);
 	COPY(AutoAnimate);
+	COPY(AnimationFrameSkip);
 	COPY(AnimationSpeed);
 	COPY(AnimationTimer);
 	COPY(AnimationFrameDuration);
@@ -655,6 +663,7 @@ void Entity::Initialize() {
 	AnimationSpeedMult = 1.0;
 	AnimationSpeedAdd = 0;
 	AutoAnimate = Entity::DisableAutoAnimate ? false : true;
+	AnimationFrameSkip = Entity::UseAnimationFrameSkip;
 	AnimationSpeed = 0;
 	AnimationTimer = 0.0;
 	AnimationFrameDuration = 0;


### PR DESCRIPTION
- Adds new field 'AnimationFrameSkip' to entities, default true
- Adds 'UseAnimationFrameSkip' to the Entity class, default true
- Adds 'Instance.UseAnimationFrameSkip(bool)` to set whether AnimationFrameSkip is default true to entities