### PR TITLE
Fix `XMLParser` adding string tokens to the node tree improperly

### DIFF
--- a/source/Engine/TextFormats/XML/XMLParser.cpp
+++ b/source/Engine/TextFormats/XML/XMLParser.cpp
@@ -477,7 +477,9 @@ void XMLParser::DoParsing() {
 			}
 
 			Token data = PeekToken();
-			data.Length = scanner.Current - data.Start;
+			if (data.Type != TOKEN_STRING) {
+				data.Length = scanner.Current - data.Start;
+			}
 			data.Type = TOKEN_CDATA;
 
 			XMLNode* node = new (std::nothrow) XMLNode;


### PR DESCRIPTION
If the node was created from a string token, the parser would reset the length of the token, adding an extra `"` character to the string.

Test `GameConfig.xml`:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<gameconfig>
    <name>"Game Title"</name>
</gameconfig>
```

The window should say `Game Title` instead of `Game Title"`.