### PR TITLE
Always perform graying of `ObjEntity` fields in `BlackenObject`

### DIFF
--- a/source/Engine/Bytecode/GarbageCollector.cpp
+++ b/source/Engine/Bytecode/GarbageCollector.cpp
@@ -223,6 +223,7 @@ void GarbageCollector::BlackenObject(Obj* object) {
 	}
 	case OBJ_ENTITY: {
 		ObjEntity* entity = (ObjEntity*)object;
+		GrayHashMap(entity->InstanceObj.Fields);
 		if (entity->EntityPtr) {
 			((ScriptEntity*)entity->EntityPtr)->MarkForGarbageCollection();
 		}

--- a/source/Engine/Bytecode/ScriptEntity.cpp
+++ b/source/Engine/Bytecode/ScriptEntity.cpp
@@ -939,9 +939,7 @@ void ScriptEntity::CopyVMFields(ScriptEntity* other) {
 	other->AddEntityClassMethods();
 }
 
-void ScriptEntity::MarkForGarbageCollection() {
-	GarbageCollector::GrayHashMap(Instance->InstanceObj.Fields);
-}
+void ScriptEntity::MarkForGarbageCollection() {}
 
 // Events called from C++
 void ScriptEntity::Initialize() {

--- a/source/Engine/Types/Camera.cpp
+++ b/source/Engine/Types/Camera.cpp
@@ -95,8 +95,6 @@ void Camera::Initialize() {
 
 #ifdef SCRIPTABLE_ENTITY
 void Camera::MarkForGarbageCollection() {
-	ScriptEntity::MarkForGarbageCollection();
-
 	if (TargetEntity) {
 		GarbageCollector::GrayObject(((ScriptEntity*)TargetEntity)->Instance);
 	}


### PR DESCRIPTION
Fixes a bug where if the entity of an `ObjEntity` was despawned, the fields of the `ObjEntity` would no longer be garbage collected.

Regression caused by #145