### PR TITLE
Parse hex and Unicode escape sequences in HSL strings

### DIFF
--- a/include/Engine/Bytecode/Compiler.h
+++ b/include/Engine/Bytecode/Compiler.h
@@ -121,6 +121,8 @@ public:
 	ExprContext GetLiteral(ExprContext context);
 	ExprContext GetInteger(ExprContext context);
 	ExprContext GetDecimal(ExprContext context);
+	int ParseHexChars(Uint32* codepoint, char* src, char* srcEnd, int maxChars);
+	std::string ParseUnicodeString(char* src, char* srcEnd, int maxChars);
 	ObjString* MakeString(Token token);
 	ExprContext GetString(ExprContext context);
 	ExprContext GetArray(ExprContext context);

--- a/include/Engine/Utilities/StringUtils.h
+++ b/include/Engine/Utilities/StringUtils.h
@@ -35,6 +35,7 @@ public:
 	static void ReplacePathSeparatorsInPlace(char* path);
 	static int DecodeUTF8Char(const char* chr, int& numChars);
 	static std::vector<Uint32> GetCodepoints(const char* text);
+	static std::string FromCodepoint(Uint32 codepoint);
 	static std::string FromCodepoints(std::vector<Uint32> codepoints);
 };
 

--- a/source/Engine/Bytecode/Compiler.cpp
+++ b/source/Engine/Bytecode/Compiler.cpp
@@ -1690,34 +1690,116 @@ ExprContext Compiler::GetDecimal(ExprContext context) {
 
 	return EXPRCONTEXT_VALUE;
 }
+int Compiler::ParseHexChars(Uint32* codepoint, char* src, char* srcEnd, int maxChars) {
+	int count = 0;
+
+	do {
+		int chr = *src++;
+		if (!IsHexDigit(chr)) {
+			break;
+		}
+
+		*codepoint <<= 4;
+
+		if (chr <= '9') {
+			*codepoint |= chr - '0';
+		}
+		else {
+			*codepoint |= (tolower(chr) - 'a') + 10;
+		}
+
+		count++;
+		if (count == maxChars) {
+			break;
+		}
+	}
+	while (src < srcEnd);
+
+	return count;
+}
+std::string Compiler::ParseUnicodeString(char* src, char* srcEnd, int maxChars) {
+	Uint32 codepoint = 0;
+
+	int count = Compiler::ParseHexChars(&codepoint, src, srcEnd, maxChars);
+	if (count != maxChars) {
+		Error("Invalid Unicode escape sequence.");
+	}
+
+	std::string result;
+	try {
+		result = StringUtils::FromCodepoint(codepoint);
+	} catch (const std::runtime_error& error) {
+		Error(error.what());
+	}
+
+	return result;
+}
 ObjString* Compiler::MakeString(Token token) {
 	ObjString* string = CopyString(token.Start + 1, token.Length - 2);
 
 	// Escape the string
 	char* dst = string->Chars;
+	char* srcEnd = token.Start + token.Length - 1;
 	string->Length = 0;
 
-	for (char* src = token.Start + 1; src < token.Start + token.Length - 1; src++) {
+	for (char* src = token.Start + 1; src < srcEnd; src++) {
 		if (*src == '\\') {
 			src++;
 			switch (*src) {
 			case 'n':
 				*dst++ = '\n';
+				string->Length++;
 				break;
 			case '"':
 				*dst++ = '"';
+				string->Length++;
 				break;
 			case '\'':
 				*dst++ = '\'';
+				string->Length++;
 				break;
 			case '\\':
 				*dst++ = '\\';
+				string->Length++;
 				break;
-			default:
-				Error("Unknown escape character");
+			case 'x': {
+				Uint32 digits = 0;
+
+				int count = Compiler::ParseHexChars(&digits, src + 1, srcEnd, 2);
+				if (count != 2) {
+					Error("Invalid escape sequence.");
+				}
+
+				*dst++ = digits & 0xFF;
+				src += 2;
+
+				string->Length++;
 				break;
 			}
-			string->Length++;
+			case 'u': {
+				std::string result = ParseUnicodeString(src + 1, srcEnd, 4);
+
+				memcpy(dst, result.c_str(), result.size());
+				dst += result.size();
+				src += 4;
+
+				string->Length += result.size();
+				break;
+			}
+			case 'U': {
+				std::string result = ParseUnicodeString(src + 1, srcEnd, 8);
+
+				memcpy(dst, result.c_str(), result.size());
+				dst += result.size();
+				src += 8;
+
+				string->Length += result.size();
+				break;
+			}
+			default:
+				Error("Unknown escape character.");
+				break;
+			}
 		}
 		else {
 			*dst++ = *src;

--- a/source/Engine/Utilities/StringUtils.cpp
+++ b/source/Engine/Utilities/StringUtils.cpp
@@ -470,38 +470,47 @@ std::vector<Uint32> StringUtils::GetCodepoints(const char* text) {
 	return codepoints;
 }
 
+// Converts an UCS codepoint to an UTF-8 string
+// Throws an exception if it encounters an invalid codepoint.
+std::string StringUtils::FromCodepoint(Uint32 codepoint) {
+	std::string result;
+	result.reserve(4);
+
+	if (codepoint <= 0x7F) {
+		result += (char)codepoint;
+	}
+	else if (codepoint <= 0x7FF) {
+		result += (char)(0xC0 | (codepoint >> 6));
+		result += (char)(0x80 | (codepoint & 0x3F));
+	}
+	else if (codepoint <= 0xFFFF) {
+		result += (char)(0xE0 | (codepoint >> 12));
+		result += (char)(0x80 | ((codepoint >> 6) & 0x3F));
+		result += (char)(0x80 | (codepoint & 0x3F));
+	}
+	else if (codepoint <= 0x10FFFF) {
+		result += (char)(0xF0 | (codepoint >> 18));
+		result += (char)(0x80 | ((codepoint >> 12) & 0x3F));
+		result += (char)(0x80 | ((codepoint >> 6) & 0x3F));
+		result += (char)(0x80 | (codepoint & 0x3F));
+	}
+	else {
+		throw std::runtime_error("Invalid UCS codepoint encountered!");
+	}
+
+	return result;
+}
+
 // Returns UTF-8 text from UCS codepoints
 // Throws an exception if it encounters an invalid codepoint.
 std::string StringUtils::FromCodepoints(std::vector<Uint32> codepoints) {
 	size_t numCodepoints = codepoints.size();
 
 	std::string result;
-	result.reserve(numCodepoints);
+	result.reserve(numCodepoints * 2);
 
 	for (size_t i = 0; i < numCodepoints; i++) {
-		Uint32 codepoint = codepoints[i];
-
-		if (codepoint <= 0x7F) {
-			result += (char)codepoint;
-		}
-		else if (codepoint <= 0x7FF) {
-			result += (char)(0xC0 | (codepoint >> 6));
-			result += (char)(0x80 | (codepoint & 0x3F));
-		}
-		else if (codepoint <= 0xFFFF) {
-			result += (char)(0xE0 | (codepoint >> 12));
-			result += (char)(0x80 | ((codepoint >> 6) & 0x3F));
-			result += (char)(0x80 | (codepoint & 0x3F));
-		}
-		else if (codepoint <= 0x10FFFF) {
-			result += (char)(0xF0 | (codepoint >> 18));
-			result += (char)(0x80 | ((codepoint >> 12) & 0x3F));
-			result += (char)(0x80 | ((codepoint >> 6) & 0x3F));
-			result += (char)(0x80 | (codepoint & 0x3F));
-		}
-		else {
-			throw std::runtime_error("Invalid UCS codepoint encountered!");
-		}
+		result += StringUtils::FromCodepoint(codepoints[i]);
 	}
 
 	return result;


### PR DESCRIPTION
Example:
```js
print("\x41\x42\x43DEF");
print("\U0001F414\u2757");
```

Should print the following:
```
     INFO: ABCDEF
     INFO: 🐔❗
```