### PR TITLE
Store alpha channel data when reading the palette of an image

### DIFF
--- a/source/Engine/ResourceTypes/ImageFormats/GIF.cpp
+++ b/source/Engine/ResourceTypes/ImageFormats/GIF.cpp
@@ -278,9 +278,11 @@ GIF* GIF::Load(Stream* stream) {
 		Uint8 green = stream->ReadByte();
 		// Load 'blue'
 		Uint8 blue = stream->ReadByte();
+		// Set alpha
+		Uint8 alpha = p == transparentColorIndex ? 0 : 0xFF;
 
 		// Store color
-		gif->Colors[p] = ColorUtils::Make(red, green, blue, 0xFF, Graphics::PreferredPixelFormat);
+		gif->Colors[p] = ColorUtils::Make(red, green, blue, alpha, Graphics::PreferredPixelFormat);
 	}
 
 #ifdef DO_GIF_PERF

--- a/source/Engine/ResourceTypes/ImageFormats/PNG.cpp
+++ b/source/Engine/ResourceTypes/ImageFormats/PNG.cpp
@@ -50,6 +50,11 @@ PNG* PNG::Load(Stream* stream) {
 	Uint32 width, height;
 	int bit_depth, color_type, palette_size;
 	bool usePalette = false;
+	bool hasTransparency = false;
+	bool hasTransValues = false;
+	png_bytep trans;
+	int num_trans;
+	png_color_16p trans_values;
 	png_colorp palette;
 	Uint8* pixelData = NULL;
 	png_bytep* row_pointers = NULL;
@@ -93,7 +98,15 @@ PNG* PNG::Load(Stream* stream) {
 		}
 	}
 
-	if (!usePalette && png_get_valid(png_ptr, info_ptr, PNG_INFO_tRNS)) {
+	if (png_get_valid(png_ptr, info_ptr, PNG_INFO_tRNS)) {
+		hasTransparency = true;
+
+		if (png_get_tRNS(png_ptr, info_ptr, &trans, &num_trans, &trans_values) == PNG_INFO_tRNS) {
+			hasTransValues = true;
+		}
+	}
+
+	if (!usePalette && hasTransparency) {
 		png_set_tRNS_to_alpha(png_ptr);
 	}
 	else if (color_type != PNG_COLOR_TYPE_RGB_ALPHA &&
@@ -139,7 +152,12 @@ PNG* PNG::Load(Stream* stream) {
 		png->Paletted = true;
 
 		for (size_t i = 0; i < png->NumPaletteColors; i++, palette++) {
-			png->Colors[i] = ColorUtils::Make(palette->red, palette->green, palette->blue, 0xFF, Graphics::PreferredPixelFormat);
+			Uint8 alpha = 0xFF;
+			if (hasTransValues && i < (size_t)num_trans) {
+				alpha = trans[i];
+			}
+
+			png->Colors[i] = ColorUtils::Make(palette->red, palette->green, palette->blue, alpha, Graphics::PreferredPixelFormat);
 		}
 	}
 	else {


### PR DESCRIPTION
Fixes `Sprite.MakeNonPalettized` no longer correctly applying transparency