### PR TITLE
Allow declaring enums locally

### DIFF
--- a/include/Engine/Bytecode/Compiler.h
+++ b/include/Engine/Bytecode/Compiler.h
@@ -169,7 +169,7 @@ public:
 	void GetModuleVariableDeclaration();
 	void GetPropertyDeclaration(Token propertyName);
 	void GetClassDeclaration();
-	void GetEnumDeclaration();
+	void GetEnumDeclaration(bool isLocal);
 	void GetImportDeclaration();
 	void GetUsingDeclaration();
 	void GetEventDeclaration();

--- a/source/Engine/Bytecode/Compiler.cpp
+++ b/source/Engine/Bytecode/Compiler.cpp
@@ -1309,8 +1309,18 @@ ExprContext Compiler::NamedVariable(Token name, Local& currentLocal, ExprContext
 		}
 	}
 	else {
+		// Look for a constant in this scope
+		for (int i = Constants.size() - 1; i >= 0; i--) {
+			Local* constLocal = &Constants[i];
+			if (IdentifiersEqual(&name, &constLocal->Name)) {
+				constLocal->Resolved = true;
+				EmitConstant(constLocal->ConstantVal);
+				return EXPRCONTEXT_VALUE;
+			}
+		}
+
+		// Resolve module local
 		arg = ResolveModuleLocal(&name, &local);
-		VMValue value;
 		if (arg != -1) {
 			if (emitValue) {
 				getOp = OP_GET_MODULE_LOCAL;
@@ -1325,15 +1335,31 @@ ExprContext Compiler::NamedVariable(Token name, Local& currentLocal, ExprContext
 				currentLocal.Index = arg;
 			}
 		}
-		else if (emitValue && StandardConstants->GetIfExists(name.ToString().c_str(), &value)) {
-			EmitConstant(value);
-			return EXPRCONTEXT_VALUE;
-		}
-		else if (emitValue) {
-			getOp = OP_GET_GLOBAL;
-		}
 		else {
-			getOp = OP_LOCATION_GLOBAL;
+			// Look for a module constant
+			for (int i = ModuleConstants.size() - 1; i >= 0; i--) {
+				Local* constLocal = &ModuleConstants[i];
+				if (IdentifiersEqual(&name, &constLocal->Name)) {
+					constLocal->Resolved = true;
+					EmitConstant(constLocal->ConstantVal);
+					return EXPRCONTEXT_VALUE;
+				}
+			}
+
+			// Must be a StandardLibrary constant or a global
+			if (emitValue) {
+				VMValue value;
+				if (StandardConstants->GetIfExists(name.ToString().c_str(), &value)) {
+					EmitConstant(value);
+					return EXPRCONTEXT_VALUE;
+				}
+				else {
+					getOp = OP_GET_GLOBAL;
+				}
+			}
+			else {
+				getOp = OP_LOCATION_GLOBAL;
+			}
 		}
 	}
 
@@ -1485,17 +1511,6 @@ int Compiler::ResolveLocal(Token* name, Local* result) {
 		}
 	}
 
-	for (int i = Constants.size() - 1; i >= 0; i--) {
-		Local* local = &Constants[i];
-		if (IdentifiersEqual(name, &local->Name)) {
-			local->Resolved = true;
-			if (result) {
-				*result = *local;
-			}
-			return i;
-		}
-	}
-
 	return -1;
 }
 void Compiler::MarkLocalAsSet(Local& local) {
@@ -1532,17 +1547,6 @@ int Compiler::ResolveModuleLocal(Token* name, Local* result) {
 			if (local.Depth == -1) {
 				Error("Cannot read local variable in its own initializer.");
 			}
-			local.Resolved = true;
-			if (result) {
-				*result = local;
-			}
-			return i;
-		}
-	}
-
-	for (int i = Compiler::ModuleConstants.size() - 1; i >= 0; i--) {
-		Local& local = Compiler::ModuleConstants[i];
-		if (IdentifiersEqual(name, &local.Name)) {
 			local.Resolved = true;
 			if (result) {
 				*result = local;
@@ -3166,7 +3170,11 @@ void Compiler::GetModuleVariableDeclaration() {
 		Error("Cannot use local declaration outside of top-level code.");
 	}
 
-	if (parser.Current.Type == TOKEN_VAR || parser.Current.Type == TOKEN_CONST) {
+	if (parser.Current.Type == TOKEN_ENUM) {
+		AdvanceToken();
+		GetEnumDeclaration(true);
+	}
+	else if (parser.Current.Type == TOKEN_VAR || parser.Current.Type == TOKEN_CONST) {
 		bool constant = parser.Current.Type == TOKEN_CONST;
 		vector<Local>* vec = constant ? &ModuleConstants : &ModuleLocals;
 		AdvanceToken();
@@ -3218,7 +3226,7 @@ void Compiler::GetModuleVariableDeclaration() {
 		ConsumeToken(TOKEN_SEMICOLON, "Expected \";\" after variable declaration.");
 	}
 	else {
-		ErrorAtCurrent("Expected \"var\" or \"const\" after \"local\" declaration.");
+		ErrorAtCurrent("Expected \"var\", \"const\", or \"enum\" after \"local\" declaration.");
 	}
 }
 void Compiler::GetPropertyDeclaration(Token propertyName) {
@@ -3294,25 +3302,32 @@ void Compiler::GetClassDeclaration() {
 
 	ConsumeToken(TOKEN_RIGHT_BRACE, "Expect '}' after class body.");
 }
-void Compiler::GetEnumDeclaration() {
+void Compiler::GetEnumDeclaration(bool isLocal) {
 	Token enumName;
 	bool isNamed = false;
 
 	if (MatchToken(TOKEN_IDENTIFIER)) {
 		enumName = parser.Previous;
 		DeclareVariable(&enumName, false);
+		MarkInitialized();
 
 		EmitByte(OP_NEW_ENUM);
 		EmitStringHash(enumName);
 
-		DefineVariableToken(enumName, true);
+		if (isLocal) {
+			int index = DeclareModuleVariable(&enumName, false);
+			Compiler::DefineModuleVariable(index);
+		}
+		else {
+			DefineVariableToken(enumName, true);
+		}
 
 		isNamed = true;
 	}
 
-	ConsumeToken(TOKEN_LEFT_BRACE, "Expect '{' before enum body.");
+	ConsumeToken(TOKEN_LEFT_BRACE, "Expect '{' before enumeration body.");
 
-	while (!CheckToken(TOKEN_RIGHT_BRACE) && !CheckToken(TOKEN_EOF)) {
+	while (true) {
 		bool didStart = false;
 
 		VMValue current = INTEGER_VAL(0);
@@ -3321,12 +3336,21 @@ void Compiler::GetEnumDeclaration() {
 				break;
 			}
 
-			int variable = ParseVariable("Expected constant name.", true);
+			int variable;
+			if (isNamed) {
+				ConsumeIdentifier("Expected constant name.");
+			}
+			else if (isLocal) {
+				variable = ParseModuleVariable("Expected constant name.", true);
+			}
+			else {
+				variable = ParseVariable("Expected constant name.", true);
+			}
 
 			Token token = parser.Previous;
 
-			// Push the enum class to the stack
-			if (isNamed) {
+			// Push the enumeration to the stack if it's global
+			if (isNamed && ScopeDepth == 0) {
 				Local local;
 				NamedVariable(enumName, local, EXPRCONTEXT_VALUE);
 			}
@@ -3340,7 +3364,7 @@ void Compiler::GetEnumDeclaration() {
 						CodePointer() ||
 					!CurrentChunk()->GetConstant(pre, &current, &constantIndex)) {
 					ErrorAt(&token,
-						"Manual enum value must be constant.",
+						"Manual enumeration value must be constant.",
 						true);
 				}
 				EmitCopy(1);
@@ -3349,7 +3373,7 @@ void Compiler::GetEnumDeclaration() {
 			else {
 				if (didStart) {
 					if (IS_NOT_NUMBER(current)) {
-						Warning("Current enum base is a non-number, this enum value will be null!");
+						Warning("Current enumeration base is a non-number; this value will be null!");
 						current = NULL_VAL;
 					}
 					else if (IS_DECIMAL(current)) {
@@ -3374,19 +3398,30 @@ void Compiler::GetEnumDeclaration() {
 			if (isNamed) {
 				EmitByte(OP_ADD_ENUM);
 				EmitStringHash(token);
+
+				// Pop the enumeration from the stack if it's global
+				if (ScopeDepth == 0) {
+					EmitByte(OP_POP);
+				}
+			}
+			else if (isLocal) {
+				ModuleConstants[variable].ConstantVal = current;
+			}
+			else if (ScopeDepth > 0) {
+				Constants[variable].ConstantVal = current;
 			}
 			else {
 				DefineVariableToken(token, true);
-				if (variable == -1) {
-					// treat it as a module constant
-					ModuleConstants.push_back(
-						{token, VARTYPE_MODULE_LOCAL, constantIndex, 0, false, false, true, current});
-				}
+
+				// treat it as a module constant
+				ModuleConstants.push_back(
+					{token, VARTYPE_MODULE_LOCAL, constantIndex, 0, false, false, true, current});
 			}
 		} while (MatchToken(TOKEN_COMMA));
-	}
 
-	ConsumeToken(TOKEN_RIGHT_BRACE, "Expect '}' after enum body.");
+		ConsumeToken(TOKEN_RIGHT_BRACE, "Expect '}' after enumeration body.");
+		break;
+	}
 }
 void Compiler::GetImportDeclaration() {
 	bool importModules = MatchToken(TOKEN_FROM);
@@ -3454,7 +3489,7 @@ void Compiler::GetDeclaration() {
 		GetClassDeclaration();
 	}
 	else if (MatchToken(TOKEN_ENUM)) {
-		GetEnumDeclaration();
+		GetEnumDeclaration(false);
 	}
 	else if (MatchToken(TOKEN_IMPORT)) {
 		GetImportDeclaration();

--- a/source/Engine/Bytecode/VMThread.cpp
+++ b/source/Engine/Bytecode/VMThread.cpp
@@ -1055,7 +1055,6 @@ int VMThread::RunInstruction() {
 		// Otherwise, if it's a class,
 		else if (IS_CLASS(object)) {
 			ObjClass* klass = AS_CLASS(object);
-
 			if (ScriptManager::Lock()) {
 				if (HasProperty(klass, hash)) {
 					Pop();
@@ -1065,11 +1064,11 @@ int VMThread::RunInstruction() {
 				}
 			}
 		}
-		// Otherwise, if it's an enum,
+		// Otherwise, if it's an enumeration,
 		else if (IS_ENUM(object)) {
-			ObjEnum* enumObj = AS_ENUM(object);
+			ObjEnum* enumeration = AS_ENUM(object);
 			if (ScriptManager::Lock()) {
-				if (enumObj->Fields->Exists(hash)) {
+				if (enumeration->Fields->Exists(hash)) {
 					Pop();
 					Push(INTEGER_VAL(true));
 					ScriptManager::Unlock();
@@ -1903,8 +1902,8 @@ int VMThread::RunInstruction() {
 
 	VM_CASE(OP_NEW_ENUM) {
 		Uint32 hash = ReadUInt32(frame);
-		ObjEnum* enumObj = NewEnum(hash);
-		Push(OBJECT_VAL(enumObj));
+		ObjEnum* enumeration = NewEnum(hash);
+		Push(OBJECT_VAL(enumeration));
 		VM_BREAK;
 	}
 	VM_CASE(OP_ENUM_NEXT) {
@@ -1921,24 +1920,23 @@ int VMThread::RunInstruction() {
 		VM_BREAK;
 	}
 	VM_CASE(OP_ADD_ENUM) {
-		ObjEnum* enumeration = nullptr;
+		ObjEnum* enumeration;
 		VMValue object = Peek(1);
 		Uint32 hash = ReadUInt32(frame);
 
 		if (IS_ENUM(object)) {
 			enumeration = AS_ENUM(object);
 		}
-		else if (ThrowRuntimeError(false,
-				 "Unexpected value type; value was of type %s.",
-				 GetValueTypeString(object)) == ERROR_RES_CONTINUE) {
+		else {
+			ThrowRuntimeError(false,
+				 "Expected an enumeration, but value was of type %s.",
+				 GetValueTypeString(object));
 			goto FAIL_OP_ADD_ENUM;
 		}
 
 		if (ScriptManager::Lock()) {
 			VMValue value = Pop();
 			enumeration->Fields->Put(hash, value);
-			Pop();
-			Push(value);
 			ScriptManager::Unlock();
 			VM_BREAK;
 		}
@@ -2624,12 +2622,12 @@ VMValue VMThread::GetProperty(VMValue object, Uint32 hash) {
 			return NULL_VAL;
 		}
 	}
-	// Otherwise, if it's an enum,
+	// Otherwise, if it's an enumeration,
 	else if (IS_ENUM(object)) {
-		ObjEnum* enumObj = AS_ENUM(object);
+		ObjEnum* enumeration = AS_ENUM(object);
 
 		if (ScriptManager::Lock()) {
-			if (enumObj->Fields->GetIfExists(hash, &result)) {
+			if (enumeration->Fields->GetIfExists(hash, &result)) {
 				result = Value::Delink(result);
 				ScriptManager::Unlock();
 				return result;

--- a/source/Engine/Bytecode/ValuePrinter.cpp
+++ b/source/Engine/Bytecode/ValuePrinter.cpp
@@ -67,6 +67,7 @@ void ValuePrinter::PrintObject(VMValue value, int indent) {
 	case OBJ_FUNCTION:
 	case OBJ_MODULE:
 	case OBJ_NAMESPACE:
+	case OBJ_ENUM:
 		if (IsJSON) {
 			buffer_printf(Buffer,
 				"\"%s %s\"",


### PR DESCRIPTION
Allows using `local enum` to declare enumerations, fixes enumerations not working properly when declared outside of top-level code, and fixes some edge cases when parsing enumerations.

Example code:

```js
enum ABCDEF {
    A,
    B,
    C,
    D = 3,
    E,
    F
}

print(ABCDEF);
print(ABCDEF.A);
print(ABCDEF.B);
print(ABCDEF.C);
print(ABCDEF.D);
print(ABCDEF.E);
print(ABCDEF.F);

local enum GHIJKL {
    G = 6,
    H,
    I,
    J = 9,
    K,
    L
}

print(GHIJKL);
print(GHIJKL.G);
print(GHIJKL.H);
print(GHIJKL.I);
print(GHIJKL.J);
print(GHIJKL.K);
print(GHIJKL.L);

if (GHIJKL.L == 11) {
    enum MNOPQR {
        M = 12,
        N,
        O,
        P = 15,
        Q,
        R
    }

    print(MNOPQR);
    print(MNOPQR.M);
    print(MNOPQR.N);
    print(MNOPQR.O);
    print(MNOPQR.P);
    print(MNOPQR.Q);
    print(MNOPQR.R);

    enum {
        S = 18,
        T,
        U,
        V = 21,
        W,
        X
    }

    print("Unnamed enum:");
    print(S);
    print(T);
    print(U);
    print(V);
    print(W);
    print(X);

    enum UnusedEnum { // Compiler warning here
        Y,
        Z
    }
}

enum {
    Unnamed1 = 24,
    Unnamed2,
    Unnamed3,
    Unnamed4 = 27,
    Unnamed5,
    Unnamed6
}

print("Global unnamed enum:");
print(Unnamed1);
print(Unnamed2);
print(Unnamed3);
print(Unnamed4);
print(Unnamed5);
print(Unnamed6);

local enum {
    Unnamed7 = 30,
    Unnamed8,
    Unnamed9,
    Unnamed10 = 33,
    Unnamed11,
    Unnamed12
}

print("Local unnamed enum:");
print(Unnamed7);
print(Unnamed8);
print(Unnamed9);
print(Unnamed10);
print(Unnamed11);
print(Unnamed12);
```

Should print the following:
```
     INFO: <enum ABCDEF>
     INFO: 0
     INFO: 1
     INFO: 2
     INFO: 3
     INFO: 4
     INFO: 5
     INFO: <enum GHIJKL>
     INFO: 6
     INFO: 7
     INFO: 8
     INFO: 9
     INFO: 10
     INFO: 11
     INFO: <enum MNOPQR>
     INFO: 12
     INFO: 13
     INFO: 14
     INFO: 15
     INFO: 16
     INFO: 17
     INFO: Unnamed enum:
     INFO: 18
     INFO: 19
     INFO: 20
     INFO: 21
     INFO: 22
     INFO: 23
     INFO: Global unnamed enum:
     INFO: 24
     INFO: 25
     INFO: 26
     INFO: 27
     INFO: 28
     INFO: 29
     INFO: Local unnamed enum:
     INFO: 30
     INFO: 31
     INFO: 32
     INFO: 33
     INFO: 34
     INFO: 35
```