### PR TITLE
`Application` and `Scene` callbacks

### DIFF
--- a/include/Engine/Bytecode/ScriptManager.h
+++ b/include/Engine/Bytecode/ScriptManager.h
@@ -83,6 +83,8 @@ public:
 	static bool CallGlobalFunction(const char* functionName);
 	static bool CallStaticClassFunction(ObjClass* klass, const char* functionName);
 	static bool CallStaticClassFunction(const char* className, const char* functionName);
+	static bool CallStaticClassFunction(ObjClass* klass, const char* functionName, std::vector<VMValue> args);
+	static bool CallStaticClassFunction(const char* className, const char* functionName, std::vector<VMValue> args);
 	static VMValue FindFunction(const char* functionName);
 	static Entity* SpawnObject(const char* objectName);
 	static Uint32 MakeFilenameHash(const char* filename);

--- a/include/Engine/Bytecode/ScriptManager.h
+++ b/include/Engine/Bytecode/ScriptManager.h
@@ -82,6 +82,7 @@ public:
 	static bool RunBytecode(VMThread* thread, BytecodeContainer bytecodeContainer, Uint32 filenameHash);
 	static bool CallGlobalFunction(const char* functionName);
 	static bool CallStaticClassFunction(ObjClass* klass, const char* functionName);
+	static bool CallStaticClassFunction(const char* className, const char* functionName);
 	static VMValue FindFunction(const char* functionName);
 	static Entity* SpawnObject(const char* objectName);
 	static Uint32 MakeFilenameHash(const char* filename);

--- a/include/Engine/Bytecode/ScriptManager.h
+++ b/include/Engine/Bytecode/ScriptManager.h
@@ -80,7 +80,8 @@ public:
 	static void LinkExtensions();
 	static ObjModule* LoadBytecode(VMThread* thread, BytecodeContainer bytecodeContainer, Uint32 filenameHash);
 	static bool RunBytecode(VMThread* thread, BytecodeContainer bytecodeContainer, Uint32 filenameHash);
-	static bool CallFunction(const char* functionName);
+	static bool CallGlobalFunction(const char* functionName);
+	static bool CallStaticClassFunction(ObjClass* klass, const char* functionName);
 	static VMValue FindFunction(const char* functionName);
 	static Entity* SpawnObject(const char* objectName);
 	static Uint32 MakeFilenameHash(const char* filename);
@@ -100,7 +101,8 @@ public:
 	static ObjModule* GetScriptModule(Uint32 filenameHash);
 	static ObjFunction* GetFunctionAtScriptLine(ObjModule* module, int lineNum);
 	static bool LoadObjectClass(const char* objectName);
-	static ObjClass* GetObjectClass(const char* className);
+	static ObjClass* GetClass(const char* className);
+	static ObjClass* GetGlobalClass(const char* className);
 	static void LoadClasses();
 #ifdef VM_DEBUG
 	static char* GetSourceCodeLine(const char* sourceFilename, int line);

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -1808,7 +1808,7 @@ void Application::StartGame(const char* startingScene) {
 		Scene::LoadScene(startingScene);
 	}
 
-	// Call Static's GameStart here
+	// Call Application's OnGameStart here
 	Scene::CallGameStart();
 
 	// Start scene

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -892,6 +892,14 @@ void Application::UpdateWindowTitle() {
 }
 
 void Application::EndGame() {
+	// Call Application.OnGameEnd
+	ScriptManager::CallStaticClassFunction("Application", "OnGameEnd");
+
+	if (!Running) {
+		// Call Application.OnQuit if no longer running
+		ScriptManager::CallStaticClassFunction("Application", "OnQuit");
+	}
+
 	Application::UnloadDefaultFont();
 	Application::DefaultFontList.clear();
 
@@ -936,9 +944,12 @@ void Application::Restart(bool keepScene) {
 	Application::InitGameInfo();
 	Application::LoadGameInfo();
 	Application::ReloadSettings();
-	keepScene
-		? Application::LoadSceneInfo(Scene::ActiveCategory, Scene::CurrentSceneInList, true)
-		: Application::LoadSceneInfo(0, 0, false);
+	if (keepScene) {
+		Application::LoadSceneInfo(Scene::ActiveCategory, Scene::CurrentSceneInList, true);
+	}
+	else {
+		Application::LoadSceneInfo(0, 0, false);
+	}
 	Application::DisposeGameConfig();
 
 	FirstFrame = true;
@@ -1871,8 +1882,7 @@ void Application::Run(int argc, char* args[]) {
 		MainLoop();
 	}
 
-	Scene::Dispose();
-
+	Application::EndGame();
 	Application::Cleanup();
 #endif
 }

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -1024,6 +1024,9 @@ bool Application::ChangeGame(const char* path) {
 	Application::StartGame(startingScene);
 	Application::UpdateWindowTitle();
 
+	// Call Application.OnGameChange
+	ScriptManager::CallStaticClassFunction("Application", "OnGameChange");
+
 	return true;
 }
 

--- a/source/Engine/Bytecode/ScriptEntity.cpp
+++ b/source/Engine/Bytecode/ScriptEntity.cpp
@@ -46,7 +46,7 @@ Entity* ScriptEntity::SpawnNamed(const char* objectName) {
 	return (Entity*)scriptEntity;
 }
 bool ScriptEntity::SpawnForClass(ScriptEntity* entity, const char* objectName) {
-	ObjClass* klass = ScriptManager::GetObjectClass(objectName);
+	ObjClass* klass = ScriptManager::GetClass(objectName);
 	if (!klass) {
 		return false;
 	}
@@ -866,7 +866,7 @@ bool ScriptEntity::ChangeClass(const char* className) {
 		return false;
 	}
 
-	ObjClass* newClass = ScriptManager::GetObjectClass(className);
+	ObjClass* newClass = ScriptManager::GetClass(className);
 	if (!newClass) {
 		return false;
 	}

--- a/source/Engine/Bytecode/ScriptManager.cpp
+++ b/source/Engine/Bytecode/ScriptManager.cpp
@@ -646,6 +646,10 @@ bool ScriptManager::CallStaticClassFunction(ObjClass* klass, const char* functio
 	Threads[0].InvokeForEntity(callable, 0);
 	return true;
 }
+bool ScriptManager::CallStaticClassFunction(const char* className, const char* functionName) {
+	ObjClass* klass = GetGlobalClass(className);
+	return CallStaticClassFunction(klass, functionName);
+}
 VMValue ScriptManager::FindFunction(const char* functionName) {
 	VMValue callable;
 

--- a/source/Engine/Bytecode/ScriptManager.cpp
+++ b/source/Engine/Bytecode/ScriptManager.cpp
@@ -634,7 +634,7 @@ bool ScriptManager::CallGlobalFunction(const char* functionName) {
 		return false;
 	}
 
-	Threads[0].InvokeForEntity(callable, 0);
+	Threads[0].RunValue(callable, 0);
 	return true;
 }
 bool ScriptManager::CallStaticClassFunction(ObjClass* klass, const char* functionName) {
@@ -643,12 +643,43 @@ bool ScriptManager::CallStaticClassFunction(ObjClass* klass, const char* functio
 		return false;
 	}
 
-	Threads[0].InvokeForEntity(callable, 0);
+	VMThread* thread = &ScriptManager::Threads[0];
+	VMValue* stackTop = thread->StackTop;
+	thread->RunValue(callable, 0);
+	thread->StackTop = stackTop;
+
 	return true;
 }
 bool ScriptManager::CallStaticClassFunction(const char* className, const char* functionName) {
-	ObjClass* klass = GetGlobalClass(className);
-	return CallStaticClassFunction(klass, functionName);
+	return CallStaticClassFunction(GetGlobalClass(className), functionName);
+}
+bool ScriptManager::CallStaticClassFunction(ObjClass* klass, const char* functionName, std::vector<VMValue> args) {
+	VMValue callable;
+	if (!klass || !klass->Methods->GetIfExists(functionName, &callable)) {
+		return false;
+	}
+
+	VMThread* thread = &ScriptManager::Threads[0];
+	VMValue* stackTop = thread->StackTop;
+
+	for (size_t i = 0; i < args.size(); i++) {
+		thread->Push(args[i]);
+	}
+
+	int numArgs = thread->StackTop - stackTop;
+	int minArity, maxArity;
+	if (thread->GetArity(callable, minArity, maxArity) && numArgs > maxArity) {
+		numArgs = maxArity;
+		thread->StackTop = stackTop + numArgs;
+	}
+
+	thread->RunValue(callable, numArgs);
+	thread->StackTop = stackTop;
+
+	return true;
+}
+bool ScriptManager::CallStaticClassFunction(const char* className, const char* functionName, std::vector<VMValue> args) {
+	return CallStaticClassFunction(GetGlobalClass(className), functionName, args);
 }
 VMValue ScriptManager::FindFunction(const char* functionName) {
 	VMValue callable;

--- a/source/Engine/Bytecode/ScriptManager.cpp
+++ b/source/Engine/Bytecode/ScriptManager.cpp
@@ -624,13 +624,22 @@ bool ScriptManager::RunBytecode(VMThread* thread, BytecodeContainer bytecodeCont
 
 	return true;
 }
-bool ScriptManager::CallFunction(const char* functionName) {
-	if (!Globals->Exists(functionName)) {
+bool ScriptManager::CallGlobalFunction(const char* functionName) {
+	VMValue callable;
+	if (!Globals->GetIfExists(functionName, &callable)) {
 		return false;
 	}
 
-	VMValue callable = Globals->Get(functionName);
 	if (!IS_CALLABLE(callable)) {
+		return false;
+	}
+
+	Threads[0].InvokeForEntity(callable, 0);
+	return true;
+}
+bool ScriptManager::CallStaticClassFunction(ObjClass* klass, const char* functionName) {
+	VMValue callable;
+	if (!klass || !klass->Methods->GetIfExists(functionName, &callable)) {
 		return false;
 	}
 
@@ -857,7 +866,7 @@ bool ScriptManager::LoadObjectClass(const char* objectName) {
 	}
 
 	if (!IsStandardLibraryClass(objectName) && !Classes->Exists(objectName)) {
-		ObjClass* klass = GetObjectClass(objectName);
+		ObjClass* klass = GetClass(objectName);
 		if (!klass) {
 			Log::Print(Log::LOG_ERROR, "Could not find class of %s!", objectName);
 			return false;
@@ -867,9 +876,22 @@ bool ScriptManager::LoadObjectClass(const char* objectName) {
 
 	return true;
 }
-ObjClass* ScriptManager::GetObjectClass(const char* className) {
+ObjClass* ScriptManager::GetClass(const char* className) {
 	VMValue value = Globals->Get(className);
 
+	if (IS_CLASS(value)) {
+		return AS_CLASS(value);
+	}
+
+	return nullptr;
+}
+ObjClass* ScriptManager::GetGlobalClass(const char* className) {
+	ObjClass* klass = GetClass(className);
+	if (klass) {
+		return klass;
+	}
+
+	VMValue value = Constants->Get(className);
 	if (IS_CLASS(value)) {
 		return AS_CLASS(value);
 	}

--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -162,13 +162,13 @@ void ObjectList_CallLoads(Uint32 key, ObjectList* list) {
 		return;
 	}
 
-	ScriptManager::CallFunction(list->LoadFunctionName.c_str());
+	ScriptManager::CallGlobalFunction(list->LoadFunctionName.c_str());
 }
 void ObjectList_CallUpdateFunction(ObjectList* list, const char* functionName) {
 	if (list->Activity == ACTIVE_ALWAYS ||
 		(list->Activity == ACTIVE_NORMAL && !Scene::Paused) ||
 		(list->Activity == ACTIVE_PAUSED && Scene::Paused)) {
-		ScriptManager::CallFunction(functionName);
+		ScriptManager::CallGlobalFunction(functionName);
 	}
 }
 void ObjectList_CallGlobalUpdates(Uint32, ObjectList* list) {
@@ -2187,7 +2187,7 @@ ObjectList* Scene::NewObjectList(const char* objectName) {
 
 	// The above must have loaded the given scripted class if there is one.
 	// If there is still no class, then it doesn't exist natively or script-side.
-	if (!ScriptManager::GetObjectClass(objectName)) {
+	if (!ScriptManager::GetClass(objectName)) {
 		return nullptr;
 	}
 #endif
@@ -2230,6 +2230,11 @@ void Scene::AddStaticClass() {
 	StaticObject = obj;
 }
 void Scene::CallGameStart() {
+	ObjClass* klass = ScriptManager::GetGlobalClass("Application");
+	if (ScriptManager::CallStaticClassFunction(klass, "OnGameStart")) {
+		return;
+	}
+
 	if (StaticObject) {
 		StaticObject->GameStart();
 	}
@@ -2250,7 +2255,7 @@ ObjectList* Scene::GetObjectList(const char* objectName, bool callListLoadFuncti
 		Scene::ObjectLists->Put(objectNameHash, objectList);
 
 		if (callListLoadFunction) {
-			ScriptManager::CallFunction(objectList->LoadFunctionName.c_str());
+			ScriptManager::CallGlobalFunction(objectList->LoadFunctionName.c_str());
 		}
 	}
 

--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -3644,6 +3644,8 @@ void Scene::Dispose() {
 		delete Scene::Properties;
 	}
 	Scene::Properties = NULL;
+
+	Scene::Loaded = false;
 }
 
 void Scene::UnloadTilesets() {

--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -1068,6 +1068,9 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 	DrawGroupList* drawGroupList;
 	int viewRenderFlag = 1 << viewIndex;
 
+	std::vector<VMValue> args;
+	args.push_back(NULL_VAL);
+
 	// Adjust projection
 	PERF_START(ProjectionSetupTime);
 	SetupViewMatrices(currentView);
@@ -1079,7 +1082,8 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 	for (int l = 0; l < Scene::PriorityPerLayer; l++) {
 		Scene::CurrentDrawGroup = l;
 
-		ScriptManager::CallStaticClassFunction("Scene", "OnRenderEarlyDrawGroupStart");
+		args[0] = INTEGER_VAL(Scene::CurrentDrawGroup);
+		ScriptManager::CallStaticClassFunction("Scene", "OnRenderEarlyDrawGroupStart", args);
 
 		if (!DEV_NoObjectRender) {
 			drawGroupList = PriorityLists[l];
@@ -1096,7 +1100,7 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 			}
 		}
 
-		ScriptManager::CallStaticClassFunction("Scene", "OnRenderEarlyDrawGroupEnd");
+		ScriptManager::CallStaticClassFunction("Scene", "OnRenderEarlyDrawGroupEnd", args);
 	}
 	PERF_END(ObjectRenderEarlyTime);
 
@@ -1111,7 +1115,8 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 	for (int l = 0; l < Scene::PriorityPerLayer; l++) {
 		Scene::CurrentDrawGroup = l;
 
-		ScriptManager::CallStaticClassFunction("Scene", "OnRenderDrawGroupStart");
+		args[0] = INTEGER_VAL(Scene::CurrentDrawGroup);
+		ScriptManager::CallStaticClassFunction("Scene", "OnRenderDrawGroupStart", args);
 
 		if (DEV_NoObjectRender) {
 			goto DEV_NoTilesCheck;
@@ -1315,7 +1320,7 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 		Graphics::TextureBlend = texBlend;
 
 	finish_tile_render:
-		ScriptManager::CallStaticClassFunction("Scene", "OnRenderDrawGroupEnd");
+		ScriptManager::CallStaticClassFunction("Scene", "OnRenderDrawGroupEnd", args);
 	}
 	if (viewPerf) {
 		viewPerf->ObjectRenderTime = objectTimeTotal;
@@ -1326,7 +1331,8 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 	for (int l = 0; l < Scene::PriorityPerLayer; l++) {
 		Scene::CurrentDrawGroup = l;
 
-		ScriptManager::CallStaticClassFunction("Scene", "OnRenderLateDrawGroupStart");
+		args[0] = INTEGER_VAL(Scene::CurrentDrawGroup);
+		ScriptManager::CallStaticClassFunction("Scene", "OnRenderLateDrawGroupStart", args);
 
 		if (!DEV_NoObjectRender) {
 			drawGroupList = PriorityLists[l];
@@ -1343,7 +1349,7 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 			}
 		}
 
-		ScriptManager::CallStaticClassFunction("Scene", "OnRenderLateDrawGroupEnd");
+		ScriptManager::CallStaticClassFunction("Scene", "OnRenderLateDrawGroupEnd", args);
 	}
 	ScriptManager::CallStaticClassFunction("Scene", "OnRenderEnd");
 	Scene::CurrentDrawGroup = -1;
@@ -1631,7 +1637,11 @@ void Scene::AfterScene() {
 
 	if (Scene::NextScene[0]) {
 		// Call Scene.OnChange
-		ScriptManager::CallStaticClassFunction("Scene", "OnChange");
+		std::vector<VMValue> args;
+		if (ScriptManager::Lock()) {
+			args.push_back(OBJECT_VAL(CopyString(Scene::NextScene)));
+		}
+		ScriptManager::CallStaticClassFunction("Scene", "OnChange", args);
 
 		ScriptManager::ForceGarbageCollection();
 
@@ -1911,12 +1921,20 @@ void Scene::Restart() {
 	FinishLoad();
 }
 void Scene::FinishLoad() {
-	// Call Scene.OnRestart or Scene.OnLoad
-	if (Scene::Loaded) {
-		ScriptManager::CallStaticClassFunction("Scene", "OnRestart");
+	// Call Scene.OnLoad or Scene.OnRestart
+	std::vector<VMValue> args;
+	if (Scene::CurrentScene[0] && ScriptManager::Lock()) {
+		args.push_back(OBJECT_VAL(CopyString(Scene::CurrentScene)));
 	}
 	else {
-		ScriptManager::CallStaticClassFunction("Scene", "OnLoad");
+		args.push_back(NULL_VAL);
+	}
+
+	if (Scene::Loaded) {
+		ScriptManager::CallStaticClassFunction("Scene", "OnRestart", args);
+	}
+	else {
+		ScriptManager::CallStaticClassFunction("Scene", "OnLoad", args);
 	}
 
 	// Run "OnSceneLoad" or "OnSceneRestart" on all objects

--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -766,7 +766,7 @@ void Scene::FrameUpdate() {
 }
 void Scene::Update() {
 	// Call Scene.OnUpdateStart
-	ScriptManager::CallStaticClassFunction("Scene", "OnUpdateStart");
+	ScriptManager::CallStaticClassFunction("Scene", "UpdateStart");
 
 	// Call global updates
 	if (Scene::ObjectLists) {
@@ -774,7 +774,7 @@ void Scene::Update() {
 	}
 
 	// Call Scene.OnUpdateEarly
-	ScriptManager::CallStaticClassFunction("Scene", "OnUpdateEarly");
+	ScriptManager::CallStaticClassFunction("Scene", "UpdateEarly");
 
 	// Early Update
 	for (Entity *ent = Scene::ObjectFirst, *next; ent; ent = next) {
@@ -783,7 +783,7 @@ void Scene::Update() {
 	}
 
 	// Call Scene.OnUpdate
-	ScriptManager::CallStaticClassFunction("Scene", "OnUpdate");
+	ScriptManager::CallStaticClassFunction("Scene", "Update");
 
 	// Update objects
 	for (Entity *ent = Scene::ObjectFirst, *next; ent; ent = next) {
@@ -796,7 +796,7 @@ void Scene::Update() {
 	}
 
 	// Call Scene.OnUpdateLate
-	ScriptManager::CallStaticClassFunction("Scene", "OnUpdateLate");
+	ScriptManager::CallStaticClassFunction("Scene", "UpdateLate");
 
 	// Late Update
 	for (Entity *ent = Scene::ObjectFirst, *next; ent; ent = next) {
@@ -805,15 +805,15 @@ void Scene::Update() {
 	}
 
 	// Call Scene.OnUpdateEnd
-	ScriptManager::CallStaticClassFunction("Scene", "OnUpdateEnd");
+	ScriptManager::CallStaticClassFunction("Scene", "UpdateFinish");
 }
 void Scene::FixedUpdate() {
 	// Call Scene.OnFixedUpdateStart
 	if (!Application::UseFixedTimestep) {
-		ScriptManager::CallStaticClassFunction("Scene", "OnFixedUpdateStart");
+		ScriptManager::CallStaticClassFunction("Scene", "FixedUpdateStart");
 	}
 	else {
-		ScriptManager::CallStaticClassFunction("Scene", "OnUpdateStart");
+		ScriptManager::CallStaticClassFunction("Scene", "UpdateStart");
 	}
 
 	// Animate tiles
@@ -828,10 +828,10 @@ void Scene::FixedUpdate() {
 
 	// Call Scene.OnFixedUpdateEarly
 	if (!Application::UseFixedTimestep) {
-		ScriptManager::CallStaticClassFunction("Scene", "OnFixedUpdateEarly");
+		ScriptManager::CallStaticClassFunction("Scene", "FixedUpdateEarly");
 	}
 	else {
-		ScriptManager::CallStaticClassFunction("Scene", "OnUpdateEarly");
+		ScriptManager::CallStaticClassFunction("Scene", "UpdateEarly");
 	}
 
 	// Early Update
@@ -842,10 +842,10 @@ void Scene::FixedUpdate() {
 
 	// Call Scene.OnFixedUpdate
 	if (!Application::UseFixedTimestep) {
-		ScriptManager::CallStaticClassFunction("Scene", "OnFixedUpdate");
+		ScriptManager::CallStaticClassFunction("Scene", "FixedUpdate");
 	}
 	else {
-		ScriptManager::CallStaticClassFunction("Scene", "OnUpdate");
+		ScriptManager::CallStaticClassFunction("Scene", "Update");
 	}
 
 	// Update objects
@@ -860,10 +860,10 @@ void Scene::FixedUpdate() {
 
 	// Call Scene.OnFixedUpdateLate
 	if (!Application::UseFixedTimestep) {
-		ScriptManager::CallStaticClassFunction("Scene", "OnFixedUpdateLate");
+		ScriptManager::CallStaticClassFunction("Scene", "FixedUpdateLate");
 	}
 	else {
-		ScriptManager::CallStaticClassFunction("Scene", "OnUpdateLate");
+		ScriptManager::CallStaticClassFunction("Scene", "UpdateLate");
 	}
 
 	// Late Update
@@ -887,10 +887,10 @@ void Scene::FixedUpdate() {
 
 	// Call Scene.OnFixedUpdateEnd
 	if (!Application::UseFixedTimestep) {
-		ScriptManager::CallStaticClassFunction("Scene", "OnFixedUpdateEnd");
+		ScriptManager::CallStaticClassFunction("Scene", "FixedUpdateFinish");
 	}
 	else {
-		ScriptManager::CallStaticClassFunction("Scene", "OnUpdateEnd");
+		ScriptManager::CallStaticClassFunction("Scene", "UpdateFinish");
 	}
 }
 void Scene::RunTileAnimations() {
@@ -1078,12 +1078,12 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 
 	// RenderEarly
 	PERF_START(ObjectRenderEarlyTime);
-	ScriptManager::CallStaticClassFunction("Scene", "OnRenderStart");
+	ScriptManager::CallStaticClassFunction("Scene", "RenderStart");
 	for (int l = 0; l < Scene::PriorityPerLayer; l++) {
 		Scene::CurrentDrawGroup = l;
 
 		args[0] = INTEGER_VAL(Scene::CurrentDrawGroup);
-		ScriptManager::CallStaticClassFunction("Scene", "OnRenderEarlyDrawGroupStart", args);
+		ScriptManager::CallStaticClassFunction("Scene", "RenderEarlyDrawGroupStart", args);
 
 		if (!DEV_NoObjectRender) {
 			drawGroupList = PriorityLists[l];
@@ -1100,7 +1100,7 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 			}
 		}
 
-		ScriptManager::CallStaticClassFunction("Scene", "OnRenderEarlyDrawGroupEnd", args);
+		ScriptManager::CallStaticClassFunction("Scene", "RenderEarlyDrawGroupFinish", args);
 	}
 	PERF_END(ObjectRenderEarlyTime);
 
@@ -1116,7 +1116,7 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 		Scene::CurrentDrawGroup = l;
 
 		args[0] = INTEGER_VAL(Scene::CurrentDrawGroup);
-		ScriptManager::CallStaticClassFunction("Scene", "OnRenderDrawGroupStart", args);
+		ScriptManager::CallStaticClassFunction("Scene", "RenderDrawGroupStart", args);
 
 		if (DEV_NoObjectRender) {
 			goto DEV_NoTilesCheck;
@@ -1320,7 +1320,7 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 		Graphics::TextureBlend = texBlend;
 
 	finish_tile_render:
-		ScriptManager::CallStaticClassFunction("Scene", "OnRenderDrawGroupEnd", args);
+		ScriptManager::CallStaticClassFunction("Scene", "RenderDrawGroupFinish", args);
 	}
 	if (viewPerf) {
 		viewPerf->ObjectRenderTime = objectTimeTotal;
@@ -1332,7 +1332,7 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 		Scene::CurrentDrawGroup = l;
 
 		args[0] = INTEGER_VAL(Scene::CurrentDrawGroup);
-		ScriptManager::CallStaticClassFunction("Scene", "OnRenderLateDrawGroupStart", args);
+		ScriptManager::CallStaticClassFunction("Scene", "RenderLateDrawGroupStart", args);
 
 		if (!DEV_NoObjectRender) {
 			drawGroupList = PriorityLists[l];
@@ -1349,9 +1349,9 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 			}
 		}
 
-		ScriptManager::CallStaticClassFunction("Scene", "OnRenderLateDrawGroupEnd", args);
+		ScriptManager::CallStaticClassFunction("Scene", "RenderLateDrawGroupFinish", args);
 	}
-	ScriptManager::CallStaticClassFunction("Scene", "OnRenderEnd");
+	ScriptManager::CallStaticClassFunction("Scene", "RenderFinish");
 	Scene::CurrentDrawGroup = -1;
 	PERF_END(ObjectRenderLateTime);
 

--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -765,7 +765,7 @@ void Scene::FrameUpdate() {
 	Scene::SortEntities();
 }
 void Scene::Update() {
-	// Call Scene.OnUpdateStart
+	// Call Scene.UpdateStart
 	ScriptManager::CallStaticClassFunction("Scene", "UpdateStart");
 
 	// Call global updates
@@ -773,7 +773,7 @@ void Scene::Update() {
 		Scene::ObjectLists->ForAllOrdered(ObjectList_CallGlobalUpdates);
 	}
 
-	// Call Scene.OnUpdateEarly
+	// Call Scene.UpdateEarly
 	ScriptManager::CallStaticClassFunction("Scene", "UpdateEarly");
 
 	// Early Update
@@ -782,7 +782,7 @@ void Scene::Update() {
 		UpdateObjectEarly(ent);
 	}
 
-	// Call Scene.OnUpdate
+	// Call Scene.Update
 	ScriptManager::CallStaticClassFunction("Scene", "Update");
 
 	// Update objects
@@ -795,7 +795,7 @@ void Scene::Update() {
 		UpdateObject(ent);
 	}
 
-	// Call Scene.OnUpdateLate
+	// Call Scene.UpdateLate
 	ScriptManager::CallStaticClassFunction("Scene", "UpdateLate");
 
 	// Late Update
@@ -804,11 +804,11 @@ void Scene::Update() {
 		UpdateObjectLate(ent);
 	}
 
-	// Call Scene.OnUpdateEnd
+	// Call Scene.UpdateFinish
 	ScriptManager::CallStaticClassFunction("Scene", "UpdateFinish");
 }
 void Scene::FixedUpdate() {
-	// Call Scene.OnFixedUpdateStart
+	// Call Scene.FixedUpdateStart
 	if (!Application::UseFixedTimestep) {
 		ScriptManager::CallStaticClassFunction("Scene", "FixedUpdateStart");
 	}
@@ -826,7 +826,7 @@ void Scene::FixedUpdate() {
 				: ObjectList_CallGlobalFixedUpdates);
 	}
 
-	// Call Scene.OnFixedUpdateEarly
+	// Call Scene.FixedUpdateEarly
 	if (!Application::UseFixedTimestep) {
 		ScriptManager::CallStaticClassFunction("Scene", "FixedUpdateEarly");
 	}
@@ -840,7 +840,7 @@ void Scene::FixedUpdate() {
 		FixedUpdateObjectEarly(ent);
 	}
 
-	// Call Scene.OnFixedUpdate
+	// Call Scene.FixedUpdate
 	if (!Application::UseFixedTimestep) {
 		ScriptManager::CallStaticClassFunction("Scene", "FixedUpdate");
 	}
@@ -858,7 +858,7 @@ void Scene::FixedUpdate() {
 		FixedUpdateObject(ent);
 	}
 
-	// Call Scene.OnFixedUpdateLate
+	// Call Scene.FixedUpdateLate
 	if (!Application::UseFixedTimestep) {
 		ScriptManager::CallStaticClassFunction("Scene", "FixedUpdateLate");
 	}
@@ -885,7 +885,7 @@ void Scene::FixedUpdate() {
 		Scene::ProcessSceneTimer();
 	}
 
-	// Call Scene.OnFixedUpdateEnd
+	// Call Scene.FixedUpdateFinish
 	if (!Application::UseFixedTimestep) {
 		ScriptManager::CallStaticClassFunction("Scene", "FixedUpdateFinish");
 	}
@@ -1078,10 +1078,12 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 
 	// RenderEarly
 	PERF_START(ObjectRenderEarlyTime);
+	// Call Scene.RenderStart
 	ScriptManager::CallStaticClassFunction("Scene", "RenderStart");
 	for (int l = 0; l < Scene::PriorityPerLayer; l++) {
 		Scene::CurrentDrawGroup = l;
 
+		// Call Scene.RenderEarlyDrawGroupStart
 		args[0] = INTEGER_VAL(Scene::CurrentDrawGroup);
 		ScriptManager::CallStaticClassFunction("Scene", "RenderEarlyDrawGroupStart", args);
 
@@ -1100,6 +1102,7 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 			}
 		}
 
+		// Call Scene.RenderEarlyDrawGroupFinish
 		ScriptManager::CallStaticClassFunction("Scene", "RenderEarlyDrawGroupFinish", args);
 	}
 	PERF_END(ObjectRenderEarlyTime);
@@ -1115,6 +1118,7 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 	for (int l = 0; l < Scene::PriorityPerLayer; l++) {
 		Scene::CurrentDrawGroup = l;
 
+		// Call Scene.RenderDrawGroupStart
 		args[0] = INTEGER_VAL(Scene::CurrentDrawGroup);
 		ScriptManager::CallStaticClassFunction("Scene", "RenderDrawGroupStart", args);
 
@@ -1320,6 +1324,7 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 		Graphics::TextureBlend = texBlend;
 
 	finish_tile_render:
+		// Call Scene.RenderDrawGroupFinish
 		ScriptManager::CallStaticClassFunction("Scene", "RenderDrawGroupFinish", args);
 	}
 	if (viewPerf) {
@@ -1331,6 +1336,7 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 	for (int l = 0; l < Scene::PriorityPerLayer; l++) {
 		Scene::CurrentDrawGroup = l;
 
+		// Call Scene.RenderLateDrawGroupStart
 		args[0] = INTEGER_VAL(Scene::CurrentDrawGroup);
 		ScriptManager::CallStaticClassFunction("Scene", "RenderLateDrawGroupStart", args);
 
@@ -1349,8 +1355,10 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 			}
 		}
 
+		// Call Scene.RenderLateDrawGroupFinish
 		ScriptManager::CallStaticClassFunction("Scene", "RenderLateDrawGroupFinish", args);
 	}
+	// Call Scene.RenderFinish
 	ScriptManager::CallStaticClassFunction("Scene", "RenderFinish");
 	Scene::CurrentDrawGroup = -1;
 	PERF_END(ObjectRenderLateTime);

--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -765,16 +765,25 @@ void Scene::FrameUpdate() {
 	Scene::SortEntities();
 }
 void Scene::Update() {
+	// Call Scene.OnUpdateStart
+	ScriptManager::CallStaticClassFunction("Scene", "OnUpdateStart");
+
 	// Call global updates
 	if (Scene::ObjectLists) {
 		Scene::ObjectLists->ForAllOrdered(ObjectList_CallGlobalUpdates);
 	}
+
+	// Call Scene.OnUpdateEarly
+	ScriptManager::CallStaticClassFunction("Scene", "OnUpdateEarly");
 
 	// Early Update
 	for (Entity *ent = Scene::ObjectFirst, *next; ent; ent = next) {
 		next = ent->NextSceneEntity;
 		UpdateObjectEarly(ent);
 	}
+
+	// Call Scene.OnUpdate
+	ScriptManager::CallStaticClassFunction("Scene", "OnUpdate");
 
 	// Update objects
 	for (Entity *ent = Scene::ObjectFirst, *next; ent; ent = next) {
@@ -786,13 +795,27 @@ void Scene::Update() {
 		UpdateObject(ent);
 	}
 
+	// Call Scene.OnUpdateLate
+	ScriptManager::CallStaticClassFunction("Scene", "OnUpdateLate");
+
 	// Late Update
 	for (Entity *ent = Scene::ObjectFirst, *next; ent; ent = next) {
 		next = ent->NextSceneEntity;
 		UpdateObjectLate(ent);
 	}
+
+	// Call Scene.OnUpdateEnd
+	ScriptManager::CallStaticClassFunction("Scene", "OnUpdateEnd");
 }
 void Scene::FixedUpdate() {
+	// Call Scene.OnFixedUpdateStart
+	if (!Application::UseFixedTimestep) {
+		ScriptManager::CallStaticClassFunction("Scene", "OnFixedUpdateStart");
+	}
+	else {
+		ScriptManager::CallStaticClassFunction("Scene", "OnUpdateStart");
+	}
+
 	// Animate tiles
 	Scene::RunTileAnimations();
 
@@ -803,10 +826,26 @@ void Scene::FixedUpdate() {
 				: ObjectList_CallGlobalFixedUpdates);
 	}
 
+	// Call Scene.OnFixedUpdateEarly
+	if (!Application::UseFixedTimestep) {
+		ScriptManager::CallStaticClassFunction("Scene", "OnFixedUpdateEarly");
+	}
+	else {
+		ScriptManager::CallStaticClassFunction("Scene", "OnUpdateEarly");
+	}
+
 	// Early Update
 	for (Entity *ent = Scene::ObjectFirst, *next; ent; ent = next) {
 		next = ent->NextSceneEntity;
 		FixedUpdateObjectEarly(ent);
+	}
+
+	// Call Scene.OnFixedUpdate
+	if (!Application::UseFixedTimestep) {
+		ScriptManager::CallStaticClassFunction("Scene", "OnFixedUpdate");
+	}
+	else {
+		ScriptManager::CallStaticClassFunction("Scene", "OnUpdate");
 	}
 
 	// Update objects
@@ -817,6 +856,14 @@ void Scene::FixedUpdate() {
 
 		// Execute whatever on object
 		FixedUpdateObject(ent);
+	}
+
+	// Call Scene.OnFixedUpdateLate
+	if (!Application::UseFixedTimestep) {
+		ScriptManager::CallStaticClassFunction("Scene", "OnFixedUpdateLate");
+	}
+	else {
+		ScriptManager::CallStaticClassFunction("Scene", "OnUpdateLate");
 	}
 
 	// Late Update
@@ -836,6 +883,14 @@ void Scene::FixedUpdate() {
 	if (!Scene::Paused) {
 		Scene::Frame++;
 		Scene::ProcessSceneTimer();
+	}
+
+	// Call Scene.OnFixedUpdateEnd
+	if (!Application::UseFixedTimestep) {
+		ScriptManager::CallStaticClassFunction("Scene", "OnFixedUpdateEnd");
+	}
+	else {
+		ScriptManager::CallStaticClassFunction("Scene", "OnUpdateEnd");
 	}
 }
 void Scene::RunTileAnimations() {
@@ -1010,6 +1065,7 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 		viewPerf->RecreatedDrawTarget = true;
 	}
 
+	DrawGroupList* drawGroupList;
 	int viewRenderFlag = 1 << viewIndex;
 
 	// Adjust projection
@@ -1019,27 +1075,28 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 
 	// RenderEarly
 	PERF_START(ObjectRenderEarlyTime);
+	ScriptManager::CallStaticClassFunction("Scene", "OnRenderStart");
 	for (int l = 0; l < Scene::PriorityPerLayer; l++) {
-		if (DEV_NoObjectRender) {
-			break;
-		}
-
-		DrawGroupList* drawGroupList = PriorityLists[l];
-		if (!drawGroupList) {
-			continue;
-		}
-
-		if (drawGroupList->NeedsSorting) {
-			drawGroupList->Sort();
-		}
-
 		Scene::CurrentDrawGroup = l;
 
-		for (Entity* ent : *drawGroupList->Entities) {
-			if (ent->Active) {
-				ent->RenderEarly();
+		ScriptManager::CallStaticClassFunction("Scene", "OnRenderEarlyDrawGroupStart");
+
+		if (!DEV_NoObjectRender) {
+			drawGroupList = PriorityLists[l];
+			if (drawGroupList) {
+				if (drawGroupList->NeedsSorting) {
+					drawGroupList->Sort();
+				}
+
+				for (Entity* ent : *drawGroupList->Entities) {
+					if (ent->Active) {
+						ent->RenderEarly();
+					}
+				}
 			}
 		}
+
+		ScriptManager::CallStaticClassFunction("Scene", "OnRenderEarlyDrawGroupEnd");
 	}
 	PERF_END(ObjectRenderEarlyTime);
 
@@ -1051,8 +1108,11 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 	float _vw = currentView->GetScaledWidth();
 	float _vh = currentView->GetScaledHeight();
 	double objectTimeTotal = 0.0;
-	DrawGroupList* drawGroupList;
 	for (int l = 0; l < Scene::PriorityPerLayer; l++) {
+		Scene::CurrentDrawGroup = l;
+
+		ScriptManager::CallStaticClassFunction("Scene", "OnRenderDrawGroupStart");
+
 		if (DEV_NoObjectRender) {
 			goto DEV_NoTilesCheck;
 		}
@@ -1063,9 +1123,8 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 		float _oy;
 		float entX1, entX2;
 		float entY1, entY2;
+		bool texBlend;
 		objectTime = Clock::GetTicks();
-
-		Scene::CurrentDrawGroup = l;
 
 		drawGroupList = PriorityLists[l];
 		if (drawGroupList) {
@@ -1215,18 +1274,18 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 
 	DEV_NoTilesCheck:
 		if (DEV_NoTiles) {
-			continue;
+			goto finish_tile_render;
 		}
 
 		if (Scene::Tilesets.size() == 0) {
-			continue;
+			goto finish_tile_render;
 		}
 
 		if ((Scene::TileViewRenderFlag & viewRenderFlag) == 0) {
-			continue;
+			goto finish_tile_render;
 		}
 
-		bool texBlend = Graphics::TextureBlend;
+		texBlend = Graphics::TextureBlend;
 		for (size_t li = 0; li < Layers.size(); li++) {
 			SceneLayer* layer = &Layers[li];
 			// Skip layer tile render if already rendered
@@ -1254,6 +1313,9 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 			}
 		}
 		Graphics::TextureBlend = texBlend;
+
+	finish_tile_render:
+		ScriptManager::CallStaticClassFunction("Scene", "OnRenderDrawGroupEnd");
 	}
 	if (viewPerf) {
 		viewPerf->ObjectRenderTime = objectTimeTotal;
@@ -1262,21 +1324,28 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 	// RenderLate
 	PERF_START(ObjectRenderLateTime);
 	for (int l = 0; l < Scene::PriorityPerLayer; l++) {
-		if (DEV_NoObjectRender) {
-			break;
-		}
-
 		Scene::CurrentDrawGroup = l;
 
-		DrawGroupList* drawGroupList = PriorityLists[l];
-		if (drawGroupList) {
-			for (Entity* ent : *drawGroupList->Entities) {
-				if (ent->Active) {
-					ent->RenderLate();
+		ScriptManager::CallStaticClassFunction("Scene", "OnRenderLateDrawGroupStart");
+
+		if (!DEV_NoObjectRender) {
+			drawGroupList = PriorityLists[l];
+			if (drawGroupList) {
+				if (drawGroupList->NeedsSorting) {
+					drawGroupList->Sort();
+				}
+
+				for (Entity* ent : *drawGroupList->Entities) {
+					if (ent->Active) {
+						ent->RenderLate();
+					}
 				}
 			}
 		}
+
+		ScriptManager::CallStaticClassFunction("Scene", "OnRenderLateDrawGroupEnd");
 	}
+	ScriptManager::CallStaticClassFunction("Scene", "OnRenderEnd");
 	Scene::CurrentDrawGroup = -1;
 	PERF_END(ObjectRenderLateTime);
 
@@ -1561,6 +1630,9 @@ void Scene::AfterScene() {
 	bool& doRestart = Scene::DoRestart;
 
 	if (Scene::NextScene[0]) {
+		// Call Scene.OnChange
+		ScriptManager::CallStaticClassFunction("Scene", "OnChange");
+
 		ScriptManager::ForceGarbageCollection();
 
 		Scene::LoadScene(Scene::NextScene);
@@ -1839,6 +1911,14 @@ void Scene::Restart() {
 	FinishLoad();
 }
 void Scene::FinishLoad() {
+	// Call Scene.OnRestart or Scene.OnLoad
+	if (Scene::Loaded) {
+		ScriptManager::CallStaticClassFunction("Scene", "OnRestart");
+	}
+	else {
+		ScriptManager::CallStaticClassFunction("Scene", "OnLoad");
+	}
+
 	// Run "OnSceneLoad" or "OnSceneRestart" on all objects
 	Scene::IterateAll(Scene::ObjectFirst, [](Entity* ent) -> void {
 		if (Scene::Loaded) {


### PR DESCRIPTION
Adds the following callbacks:
- `Application.OnGameStart()`: Called when the game starts. Called in place of `Static.GameStart()` if the former exists.
- `Application.OnGameChange()`: Called after a successful call to `Application.ChangeGame(path)`.
- `Application.OnGameEnd()`: Called when the game ends.
- `Application.OnQuit()`: Called when the application exits.
- `Scene.OnChange(path)`: Called when the current scene changes to `path`.
- `Scene.OnLoad(path)`: Called when the scene `path` finishes loading.
- `Scene.OnRestart(path)`: Called when the scene `path` restarts.
- `Scene.UpdateStart()`: Called at the start of a frame update. This is called during fixed update if variable time step is disabled.
- `Scene.UpdateEarly()`: Called before `UpdateEarly` is called on entities. This is called during fixed update if variable time step is disabled.
- `Scene.Update()`: Called before `Update` is called on entities. This is called during fixed update if variable time step is disabled.
- `Scene.UpdateLate()`: Called before `UpdateLate` is called on entities. This is called during fixed update if variable time step is disabled.
- `Scene.UpdateFinish()`: Called after `UpdateLate` is called on entities. This is called during fixed update if variable time step is disabled.
- `Scene.FixedUpdateStart()`: Called at the start of a fixed frame update.
- `Scene.FixedUpdateEarly()`: Called before `FixedUpdateEarly` is called on entities.
- `Scene.FixedUpdate()`: Called before `FixedUpdate` is called on entities.
- `Scene.FixedUpdateLate()`: Called before `FixedUpdateLate` is called on entities.
- `Scene.FixedUpdateFinish()`: Called after `FixedUpdateLate` is called on entities.
- `Scene.RenderStart()`: Called when a view begins rendering.
- `Scene.RenderEarlyDrawGroupStart(drawGroup)`: Called when a draw group begins rendering during `RenderEarly`.
- `Scene.RenderEarlyDrawGroupFinish(drawGroup)`: Called when a draw group finishes rendering during `RenderEarly`.
- `Scene.RenderDrawGroupStart(drawGroup)`: Called when a draw group begins rendering during `Render`.
- `Scene.RenderDrawGroupFinish(drawGroup)`: Called when a draw group finishes rendering during `Render`.
- `Scene.RenderLateDrawGroupStart(drawGroup)`: Called when a draw group begins rendering during `RenderLate`.
- `Scene.RenderLateDrawGroupFinish(drawGroup)`: Called when a draw group finishes rendering during `RenderLate`.
- `Scene.RenderFinish()`: Called when a view finishes rendering.
