### PR TITLE
Implement layer tile batching

### DIFF
--- a/include/Engine/Graphics.h
+++ b/include/Engine/Graphics.h
@@ -20,6 +20,7 @@ class IModel;
 #include <Engine/ResourceTypes/ISprite.h>
 #include <Engine/Scene/SceneEnums.h>
 #include <Engine/Scene/SceneLayer.h>
+#include <Engine/Scene/TileSpriteInfo.h>
 #include <Engine/Scene/View.h>
 #include <Engine/Utilities/ColorUtils.h>
 
@@ -405,9 +406,13 @@ public:
 		LegacyTextDrawParams* params,
 		float& maxW,
 		float& maxH);
-	static void
-	DrawTile(int tile, int x, int y, bool flipX, bool flipY, bool usePaletteIndexLines);
-	static void DrawTilePart(int tile,
+	static void DrawTile(TileSpriteInfo& info,
+		int x,
+		int y,
+		bool flipX,
+		bool flipY,
+		bool usePaletteIndexLines);
+	static void DrawTilePart(TileSpriteInfo& info,
 		int sx,
 		int sy,
 		int sw,
@@ -425,6 +430,24 @@ public:
 		int layerIndex,
 		bool useCustomFunction);
 	static void RunCustomSceneLayerFunction(ObjFunction* func, int layerIndex);
+	static void BeginTextureBatching();
+	static void BatchTile(TileSpriteInfo& info,
+		int x,
+		int y,
+		bool flipX,
+		bool flipY,
+		bool usePaletteIndexLines);
+	static void BatchTilePart(TileSpriteInfo& info,
+		int sx,
+		int sy,
+		int sw,
+		int sh,
+		int x,
+		int y,
+		bool flipX,
+		bool flipY,
+		bool usePaletteIndexLines);
+	static void FinishTextureBatching();
 	static void DrawPolygon3D(void* data,
 		int vertexCount,
 		int vertexFlag,

--- a/include/Engine/Rendering/GL/GLRenderer.h
+++ b/include/Engine/Rendering/GL/GLRenderer.h
@@ -11,6 +11,7 @@
 #include <Engine/Rendering/GL/Includes.h>
 #include <Engine/Rendering/Texture.h>
 #include <Engine/ResourceTypes/ISprite.h>
+#include <Engine/Scene/SceneLayer.h>
 
 #ifdef DEBUG
 #define GL_DO_ERROR_CHECKING
@@ -183,6 +184,32 @@ public:
 		float scaleH,
 		float rotation,
 		int paletteID);
+	static void BeginTextureBatching();
+	static void BatchSprite(ISprite* sprite,
+		int animation,
+		int frame,
+		float x,
+		float y,
+		bool flipX,
+		bool flipY,
+		float scaleW,
+		float scaleH,
+		int paletteID);
+	static void BatchSpritePart(ISprite* sprite,
+		int animation,
+		int frame,
+		int sx,
+		int sy,
+		int sw,
+		int sh,
+		float x,
+		float y,
+		bool flipX,
+		bool flipY,
+		float scaleW,
+		float scaleH,
+		int paletteID);
+	static void FinishTextureBatching();
 	static void DrawPolygon3D(void* data,
 		int vertexCount,
 		int vertexFlag,

--- a/source/Engine/Graphics.cpp
+++ b/source/Engine/Graphics.cpp
@@ -2619,8 +2619,10 @@ void Graphics::DrawSceneLayer_InitTileScanLines(SceneLayer* layer, View* current
 	}
 }
 
-void Graphics::DrawTile(int tile, int x, int y, bool flipX, bool flipY, bool usePaletteIndexLines) {
-	TileSpriteInfo info = Scene::TileSpriteInfos[tile];
+void Graphics::DrawTile(TileSpriteInfo& info, int x, int y, bool flipX, bool flipY, bool usePaletteIndexLines) {
+	if (!Graphics::GfxFunctions->DrawSprite) {
+		return;
+	}
 
 	int paletteID;
 	if (usePaletteIndexLines) {
@@ -2642,7 +2644,7 @@ void Graphics::DrawTile(int tile, int x, int y, bool flipX, bool flipY, bool use
 		0.0,
 		(int)paletteID);
 }
-void Graphics::DrawTilePart(int tile,
+void Graphics::DrawTilePart(TileSpriteInfo& info,
 	int sx,
 	int sy,
 	int sw,
@@ -2652,7 +2654,9 @@ void Graphics::DrawTilePart(int tile,
 	bool flipX,
 	bool flipY,
 	bool usePaletteIndexLines) {
-	TileSpriteInfo info = Scene::TileSpriteInfos[tile];
+	if (!Graphics::GfxFunctions->DrawSpritePart) {
+		return;
+	}
 
 	int paletteID;
 	if (usePaletteIndexLines) {
@@ -2734,6 +2738,8 @@ void Graphics::DrawSceneLayer_HorizontalParallax(SceneLayer* layer, View* curren
 
 	bool usePaletteIndexLines = Graphics::UsePaletteIndexLines && layer->UsePaletteIndexLines;
 
+	Graphics::BeginTextureBatching();
+
 	for (int dst_y = startY; dst_y < endY; dst_y += tileHeight, srcY += tileHeight) {
 		if (srcY < 0 || srcY >= layerHeightInPixels) {
 			if ((layer->Flags & SceneLayer::FLAGS_REPEAT_Y) == 0) {
@@ -2775,10 +2781,12 @@ void Graphics::DrawSceneLayer_HorizontalParallax(SceneLayer* layer, View* curren
 				continue;
 			}
 
+			TileSpriteInfo& info = Scene::TileSpriteInfos[tileID];
+
 			int srcTX = srcX % tileWidth;
 			int srcTY = srcY % tileHeight;
 
-			Graphics::DrawTile(tileID,
+			Graphics::BatchTile(info,
 				viewX + ((dst_x - srcTX) + tileWidthHalf),
 				viewY + ((dst_y - srcTY) + tileHeightHalf),
 				(tile & TILE_FLIPX_MASK) != 0,
@@ -2786,6 +2794,8 @@ void Graphics::DrawSceneLayer_HorizontalParallax(SceneLayer* layer, View* curren
 				usePaletteIndexLines);
 		}
 	}
+
+	Graphics::FinishTextureBatching();
 }
 void Graphics::DrawSceneLayer_HorizontalScrollIndexes(SceneLayer* layer, View* currentView) {
 	int viewWidth = (int)std::ceil(currentView->GetScaledWidth());
@@ -2800,6 +2810,8 @@ void Graphics::DrawSceneLayer_HorizontalScrollIndexes(SceneLayer* layer, View* c
 	int layerWidthInPixels = layer->Width * tileWidth;
 
 	bool usePaletteIndexLines = Graphics::UsePaletteIndexLines && layer->UsePaletteIndexLines;
+
+	Graphics::BeginTextureBatching();
 
 	TileScanLine* scanLine = TileScanLineBuffer;
 	for (int dst_y = 0; dst_y < max_y;) {
@@ -2846,6 +2858,8 @@ void Graphics::DrawSceneLayer_HorizontalScrollIndexes(SceneLayer* layer, View* c
 
 			if ((tile & TILE_IDENT_MASK) != Scene::EmptyTile) {
 				int tileID = tile & TILE_IDENT_MASK;
+				TileSpriteInfo& info = Scene::TileSpriteInfos[tileID];
+
 				bool flipX = (tile & TILE_FLIPX_MASK) != 0;
 				bool flipY = (tile & TILE_FLIPY_MASK) != 0;
 
@@ -2857,7 +2871,7 @@ void Graphics::DrawSceneLayer_HorizontalScrollIndexes(SceneLayer* layer, View* c
 					textureSrcTY = tileHeight - srcTY - tileDrawHeight;
 				}
 
-				Graphics::DrawTilePart(tileID,
+				Graphics::BatchTilePart(info,
 					0,
 					textureSrcTY,
 					tileWidth,
@@ -2873,6 +2887,8 @@ void Graphics::DrawSceneLayer_HorizontalScrollIndexes(SceneLayer* layer, View* c
 		scanLine += tileDrawHeight;
 		dst_y += tileDrawHeight;
 	}
+
+	Graphics::FinishTextureBatching();
 }
 void Graphics::DrawSceneLayer(SceneLayer* layer,
 	View* currentView,
@@ -2914,6 +2930,104 @@ void Graphics::RunCustomSceneLayerFunction(ObjFunction* func, int layerIndex) {
 	else {
 		thread->Push(INTEGER_VAL(layerIndex));
 		thread->RunEntityFunction(func, 1);
+	}
+}
+
+void Graphics::BeginTextureBatching() {
+	if (Graphics::SupportsBatching && Graphics::GfxFunctions->BeginTextureBatching) {
+		Graphics::GfxFunctions->BeginTextureBatching();
+	}
+}
+void Graphics::BatchTile(TileSpriteInfo& info, int x, int y, bool flipX, bool flipY, bool usePaletteIndexLines) {
+	int paletteID;
+	if (usePaletteIndexLines) {
+		paletteID = PALETTE_INDEX_TABLE_ID;
+	}
+	else {
+		paletteID = Scene::Tilesets[info.TilesetID].PaletteID;
+	}
+
+	if (Graphics::SupportsBatching && Graphics::GfxFunctions->BatchSprite) {
+		Graphics::GfxFunctions->BatchSprite(info.Sprite,
+			info.AnimationIndex,
+			info.FrameIndex,
+			x,
+			y,
+			flipX,
+			flipY,
+			1.0f,
+			1.0f,
+			(int)paletteID);
+	}
+	else if (Graphics::GfxFunctions->DrawSprite) {
+		Graphics::GfxFunctions->DrawSprite(info.Sprite,
+			info.AnimationIndex,
+			info.FrameIndex,
+			x,
+			y,
+			flipX,
+			flipY,
+			1.0f,
+			1.0f,
+			0.0f,
+			(int)paletteID);
+	}
+}
+void Graphics::BatchTilePart(TileSpriteInfo& info,
+	int sx,
+	int sy,
+	int sw,
+	int sh,
+	int x,
+	int y,
+	bool flipX,
+	bool flipY,
+	bool usePaletteIndexLines) {
+	int paletteID;
+	if (usePaletteIndexLines) {
+		paletteID = PALETTE_INDEX_TABLE_ID;
+	}
+	else {
+		paletteID = Scene::Tilesets[info.TilesetID].PaletteID;
+	}
+
+	if (Graphics::SupportsBatching && Graphics::GfxFunctions->BatchSpritePart) {
+		Graphics::GfxFunctions->BatchSpritePart(info.Sprite,
+			info.AnimationIndex,
+			info.FrameIndex,
+			sx,
+			sy,
+			sw,
+			sh,
+			x,
+			y,
+			flipX,
+			flipY,
+			1.0f,
+			1.0f,
+			(int)paletteID);
+	}
+	else {
+		Graphics::GfxFunctions->DrawSpritePart(info.Sprite,
+			info.AnimationIndex,
+			info.FrameIndex,
+			sx,
+			sy,
+			sw,
+			sh,
+			x,
+			y,
+			flipX,
+			flipY,
+			1.0f,
+			1.0f,
+			0.0f,
+			(int)paletteID);
+	}
+}
+void Graphics::FinishTextureBatching() {
+	if (Graphics::SupportsBatching && Graphics::GfxFunctions->FinishTextureBatching) {
+		Graphics::GfxFunctions->FinishTextureBatching();
 	}
 }
 

--- a/source/Engine/Rendering/GL/GLRenderer.cpp
+++ b/source/Engine/Rendering/GL/GLRenderer.cpp
@@ -63,6 +63,12 @@ PolygonRenderer polyRenderer;
 // TARGET_TEXTURES), and drawing functions should scale based on the
 // current render target.
 
+struct GL_TextureBatchState {
+	Texture* TexturePtr;
+	int PaletteID;
+	std::vector<GL_AnimFrameVert> Data;
+};
+
 struct GL_VertexBufferEntry {
 	float X, Y, Z;
 	float TextureU, TextureV;
@@ -134,6 +140,9 @@ GLenum GL_ActiveCullMode;
 bool GL_ClippingEnabled;
 
 int GL_CurrentTextureUnit = 0;
+
+bool GL_TextureBatchingEnabled = false;
+GL_TextureBatchState GL_CurrentTextureBatch;
 
 void GL_PrepareScreenTexture();
 void GL_MakeYUVShader();
@@ -1633,6 +1642,12 @@ void GLRenderer::SetGraphicsFunctions() {
 	Graphics::Internal.DrawTexture = GLRenderer::DrawTexture;
 	Graphics::Internal.DrawSprite = GLRenderer::DrawSprite;
 	Graphics::Internal.DrawSpritePart = GLRenderer::DrawSpritePart;
+
+	// Texture batching functions
+	Graphics::Internal.BeginTextureBatching = GLRenderer::BeginTextureBatching;
+	Graphics::Internal.BatchSprite = GLRenderer::BatchSprite;
+	Graphics::Internal.BatchSpritePart = GLRenderer::BatchSpritePart;
+	Graphics::Internal.FinishTextureBatching = GLRenderer::FinishTextureBatching;
 
 	// 3D drawing functions
 	Graphics::Internal.DrawPolygon3D = GLRenderer::DrawPolygon3D;
@@ -3261,6 +3276,150 @@ void GLRenderer::DrawSpritePart(ISprite* sprite,
 
 	Graphics::Restore();
 }
+
+// Texture batching functions
+void GLRenderer::BeginTextureBatching() {
+	GL_TextureBatchingEnabled = true;
+
+	GL_CurrentTextureBatch.TexturePtr = nullptr;
+	GL_CurrentTextureBatch.PaletteID = 0;
+	GL_CurrentTextureBatch.Data.clear();
+
+	glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+void GL_DrawTextureBatch() {
+	GL_TextureBatchState* batch = &GL_CurrentTextureBatch;
+	if (batch->Data.size() == 0) {
+		return;
+	}
+
+	void* data = batch->Data.data();
+
+	GL_Predraw(batch->TexturePtr, batch->PaletteID, false);
+
+	glVertexAttribPointer(GLRenderer::CurrentShader->LocPosition,
+		2,
+		GL_FLOAT,
+		GL_FALSE,
+		sizeof(GL_AnimFrameVert),
+		data);
+	glVertexAttribPointer(GLRenderer::CurrentShader->LocTexCoord,
+		2,
+		GL_FLOAT,
+		GL_FALSE,
+		sizeof(GL_AnimFrameVert),
+		(char*)data + offsetof(GL_AnimFrameVert, u));
+
+	glDrawArrays(GL_TRIANGLES, 0, batch->Data.size());
+
+	batch->Data.clear();
+}
+void GL_BatchTexture(Texture* texture,
+	float sx,
+	float sy,
+	float sw,
+	float sh,
+	float x,
+	float y,
+	float w,
+	float h,
+	int paletteID) {
+	GL_TextureBatchState* batch = &GL_CurrentTextureBatch;
+	if (batch->TexturePtr != texture || batch->PaletteID != paletteID) {
+		GL_DrawTextureBatch();
+
+		batch->TexturePtr = texture;
+		batch->PaletteID = paletteID;
+	}
+
+	float ffU0 = sx / (float)texture->Width;
+	float ffV0 = sy / (float)texture->Height;
+	float ffU1 = (sx + sw) / (float)texture->Width;
+	float ffV1 = (sy + sh) / (float)texture->Height;
+
+	batch->Data.push_back(GL_AnimFrameVert{x, y, ffU0, ffV0});
+	batch->Data.push_back(GL_AnimFrameVert{x + w, y, ffU1, ffV0});
+	batch->Data.push_back(GL_AnimFrameVert{x, y + h, ffU0, ffV1});
+
+	batch->Data.push_back(GL_AnimFrameVert{x + w, y, ffU1, ffV0});
+	batch->Data.push_back(GL_AnimFrameVert{x, y + h, ffU0, ffV1});
+	batch->Data.push_back(GL_AnimFrameVert{x + w, y + h, ffU1, ffV1});
+}
+void GLRenderer::BatchSprite(ISprite* sprite,
+	int animation,
+	int frame,
+	float x,
+	float y,
+	bool flipX,
+	bool flipY,
+	float scaleW,
+	float scaleH,
+	int paletteID) {
+	float fX = flipX ? -1.0 : 1.0;
+	float fY = flipY ? -1.0 : 1.0;
+
+	AnimFrame animframe = sprite->Animations[animation].Frames[frame];
+	GL_BatchTexture(sprite->Spritesheets[animframe.SheetNumber],
+		animframe.X,
+		animframe.Y,
+		animframe.Width,
+		animframe.Height,
+		x + (fX * animframe.OffsetX),
+		y + (fY * animframe.OffsetY),
+		fX * animframe.Width * scaleW,
+		fY * animframe.Height * scaleH,
+		paletteID);
+}
+void GLRenderer::BatchSpritePart(ISprite* sprite,
+	int animation,
+	int frame,
+	int sx,
+	int sy,
+	int sw,
+	int sh,
+	float x,
+	float y,
+	bool flipX,
+	bool flipY,
+	float scaleW,
+	float scaleH,
+	int paletteID) {
+	AnimFrame animframe = sprite->Animations[animation].Frames[frame];
+	if (sx == animframe.Width) {
+		return;
+	}
+	if (sy == animframe.Height) {
+		return;
+	}
+
+	float fX = flipX ? -1.0 : 1.0;
+	float fY = flipY ? -1.0 : 1.0;
+	if (sw >= animframe.Width - sx) {
+		sw = animframe.Width - sx;
+	}
+	if (sh >= animframe.Height - sy) {
+		sh = animframe.Height - sy;
+	}
+
+	GL_BatchTexture(sprite->Spritesheets[animframe.SheetNumber],
+		animframe.X + sx,
+		animframe.Y + sy,
+		sw,
+		sh,
+		x + (fX * (sx + animframe.OffsetX)),
+		y + (fY * (sy + animframe.OffsetY)),
+		fX * sw * scaleW,
+		fY * sh * scaleH,
+		paletteID);
+}
+void GLRenderer::FinishTextureBatching() {
+	if (GL_TextureBatchingEnabled) {
+		GL_DrawTextureBatch();
+	}
+
+	GL_TextureBatchingEnabled = false;
+}
+
 // 3D drawing functions
 void GLRenderer::DrawPolygon3D(void* data,
 	int vertexCount,

--- a/source/Engine/Rendering/GraphicsFunctions.h
+++ b/source/Engine/Rendering/GraphicsFunctions.h
@@ -134,6 +134,33 @@ struct GraphicsFunctions {
 		float rotation,
 		int paletteID);
 
+	void (*BeginTextureBatching)();
+	void (*BatchSprite)(ISprite* sprite,
+		int animation,
+		int frame,
+		float x,
+		float y,
+		bool flipX,
+		bool flipY,
+		float scaleW,
+		float scaleH,
+		int paletteID);
+	void (*BatchSpritePart)(ISprite* sprite,
+		int animation,
+		int frame,
+		int sx,
+		int sy,
+		int sw,
+		int sh,
+		float x,
+		float y,
+		bool flipX,
+		bool flipY,
+		float scaleW,
+		float scaleH,
+		int paletteID);
+	void (*FinishTextureBatching)();
+
 	void (*DrawPolygon3D)(void* data,
 		int vertexCount,
 		int vertexFlag,


### PR DESCRIPTION
Optimizes hardware renderer layer rendering by batching tile draws.

Performance measurements:

```
Profile #1:

"BG Outside" uses parallax.

Without batching:

IMPORTANT: General Performance Snapshot:
     INFO: Event Polling:            0.053 ms
     INFO: Post-Scene:               0.001 ms
     INFO: Input Polling:            0.004 ms
     INFO: Entity Update:            1.064 ms
     INFO: Clear Time:               0.025 ms
     INFO: World Render Commands:    5.803 ms
     INFO: Render Post-Process:      0.000 ms
     INFO: Frame Present Time:       0.166 ms
     INFO: FPS:                      58.000
IMPORTANT: View Rendering Performance Snapshot:
     INFO: View 0:
           - Render Setup:           0.009 ms 
           - Projection Setup:       0.001 ms
           - Object RenderEarly:     0.237 ms
           - Object Render:          0.260 ms
           - Object RenderLate:      0.230 ms
           - Layer Tiles Total:      4.924 ms
     >               BG Outside:      4.550 ms
     >                BG Cave 1:      0.000 ms
     >                BG Cave 2:      0.000 ms
     >                   FG Low:      0.317 ms
     >                  FG High:      0.058 ms
     >                  Scratch:      0.000 ms
           - Finish:                 0.019 ms
           - Total:                  5.682 ms

With batching:

IMPORTANT: General Performance Snapshot:
     INFO: Event Polling:            0.038 ms
     INFO: Post-Scene:               0.001 ms
     INFO: Input Polling:            0.005 ms
     INFO: Entity Update:            1.080 ms
     INFO: Clear Time:               0.020 ms
     INFO: World Render Commands:    1.268 ms
     INFO: Render Post-Process:      0.000 ms
     INFO: Frame Present Time:       0.168 ms
     INFO: FPS:                      60.000
IMPORTANT: View Rendering Performance Snapshot:
     INFO: View 0:
           - Render Setup:           0.009 ms 
           - Projection Setup:       0.000 ms
           - Object RenderEarly:     0.193 ms
           - Object Render:          0.222 ms
           - Object RenderLate:      0.226 ms
           - Layer Tiles Total:      0.486 ms
     >               BG Outside:      0.422 ms
     >                BG Cave 1:      0.000 ms
     >                BG Cave 2:      0.000 ms
     >                   FG Low:      0.042 ms
     >                  FG High:      0.023 ms
     >                  Scratch:      0.000 ms
           - Finish:                 0.017 ms
           - Total:                  1.155 ms

Profile #2:

"Background 1" uses parallax.

Without batching:

IMPORTANT: General Performance Snapshot:
     INFO: Event Polling:            0.057 ms
     INFO: Post-Scene:               0.001 ms
     INFO: Input Polling:            0.017 ms
     INFO: Entity Update:            1.228 ms
     INFO: Clear Time:               0.014 ms
     INFO: World Render Commands:   10.378 ms
     INFO: Render Post-Process:      0.000 ms
     INFO: Frame Present Time:       0.165 ms
     INFO: FPS:                      55.000
IMPORTANT: View Rendering Performance Snapshot:
     INFO: View 0:
           - Render Setup:           0.011 ms 
           - Projection Setup:       0.001 ms
           - Object RenderEarly:     0.257 ms
           - Object Render:          0.358 ms
           - Object RenderLate:      0.247 ms
           - Layer Tiles Total:      9.471 ms
     >             FG Super Low:      0.352 ms
     >                   FG Low:      0.245 ms
     >                  FG High:      0.036 ms
     >            FG Super High:      0.007 ms
     >                HUD Layer:      0.009 ms
     >             Background 1:      8.822 ms
           - Finish:                 0.020 ms
           - Total:                 10.369 ms

With batching:

IMPORTANT: General Performance Snapshot:
     INFO: Event Polling:            0.122 ms
     INFO: Post-Scene:               0.001 ms
     INFO: Input Polling:            0.023 ms
     INFO: Entity Update:            2.517 ms
     INFO: Clear Time:               0.066 ms
     INFO: World Render Commands:    3.506 ms
     INFO: Render Post-Process:      0.000 ms
     INFO: Frame Present Time:       0.423 ms
     INFO: FPS:                      60.000
IMPORTANT: View Rendering Performance Snapshot:
     INFO: View 0:
           - Render Setup:           0.019 ms 
           - Projection Setup:       0.001 ms
           - Object RenderEarly:     0.451 ms
           - Object Render:          0.843 ms
           - Object RenderLate:      0.441 ms
           - Layer Tiles Total:      1.664 ms
     >             FG Super Low:      0.068 ms
     >                   FG Low:      0.053 ms
     >                  FG High:      0.030 ms
     >            FG Super High:      0.018 ms
     >                HUD Layer:      0.020 ms
     >             Background 1:      1.474 ms
           - Finish:                 0.060 ms
           - Total:                  3.489 ms
```