### PR TITLE
Optimize `Directory::GetFiles` and `Directory::GetDirectories`

### DIFF
--- a/include/Engine/Filesystem/Directory.h
+++ b/include/Engine/Filesystem/Directory.h
@@ -20,6 +20,7 @@ public:
 	static std::vector<std::filesystem::path>
 	GetDirectories(const char* path, const char* searchPattern, bool allDirs);
 	static bool IsEmpty(const char* path);
+	static void SortEntries(std::vector<std::filesystem::path>* files);
 };
 
 #endif /* ENGINE_FILESYSTEM_DIRECTORY_H */

--- a/source/Engine/Bytecode/SourceFileMap.cpp
+++ b/source/Engine/Bytecode/SourceFileMap.cpp
@@ -120,6 +120,8 @@ bool SourceFileMap::CheckForUpdate() {
 		return false;
 	}
 
+	Directory::SortEntries(&list);
+
 	if (!mainVfs->HasFile(OBJECTS_HCM_NAME)) {
 		anyChanges = true;
 	}

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -3457,6 +3457,7 @@ VMValue Directory_GetFiles(int argCount, VMValue* args, Uint32 threadID) {
 
 	std::vector<std::filesystem::path> fileList;
 	Directory::GetFiles(&fileList, directory, pattern, allDirs);
+	Directory::SortEntries(&fileList);
 
 	if (ScriptManager::Lock()) {
 		array = NewArray();
@@ -3488,6 +3489,7 @@ VMValue Directory_GetDirectories(int argCount, VMValue* args, Uint32 threadID) {
 
 	std::vector<std::filesystem::path> fileList;
 	Directory::GetDirectories(&fileList, directory, pattern, allDirs);
+	Directory::SortEntries(&fileList);
 
 	if (ScriptManager::Lock()) {
 		array = NewArray();

--- a/source/Engine/Filesystem/Directory.cpp
+++ b/source/Engine/Filesystem/Directory.cpp
@@ -148,8 +148,6 @@ void Directory::GetFiles(std::vector<std::filesystem::path>* files,
 		closedir(dir);
 	}
 #endif
-
-	std::sort(files->begin(), files->end(), CompareFunction);
 }
 std::vector<std::filesystem::path>
 Directory::GetFiles(const char* path, const char* searchPattern, bool allDirs) {
@@ -249,8 +247,6 @@ void Directory::GetDirectories(std::vector<std::filesystem::path>* files,
 		closedir(dir);
 	}
 #endif
-
-	std::sort(files->begin(), files->end(), CompareFunction);
 }
 std::vector<std::filesystem::path>
 Directory::GetDirectories(const char* path, const char* searchPattern, bool allDirs) {
@@ -269,4 +265,12 @@ bool Directory::IsEmpty(const char* path) {
 	}
 
 	return false;
+}
+
+void Directory::SortEntries(std::vector<std::filesystem::path>* files) {
+	if (files == nullptr || files->size() < 2) {
+		return;
+	}
+
+	std::sort(files->begin(), files->end(), CompareFunction);
 }

--- a/source/Engine/Filesystem/VFS/FileSystemVFS.cpp
+++ b/source/Engine/Filesystem/VFS/FileSystemVFS.cpp
@@ -196,6 +196,7 @@ VFSEnumeration FileSystemVFS::EnumerateFiles(const char* path) {
 
 	std::vector<std::filesystem::path> results;
 	Directory::GetFiles(&results, fullPath.c_str(), "*", true);
+	Directory::SortEntries(&results);
 
 	for (size_t i = 0; i < results.size(); i++) {
 		std::string filename = Path::ToString(results[i]);


### PR DESCRIPTION
These two functions no longer sort the list of files. Now the caller does that if necessary.