### PR TITLE
Combine classes of native object types

### DIFF
--- a/include/Engine/Bytecode/TypeImpl/ArrayImpl.h
+++ b/include/Engine/Bytecode/TypeImpl/ArrayImpl.h
@@ -10,7 +10,8 @@ public:
 
 	static void Init();
 
-	static Obj* New();
+	static Obj* Constructor();
+	static VMValue VM_Initializer(int argCount, VMValue* args, Uint32 threadID);
 	static void Dispose(Obj* object);
 
 	static VMValue VM_Iterate(int argCount, VMValue* args, Uint32 threadID);

--- a/include/Engine/Bytecode/TypeImpl/FontImpl.h
+++ b/include/Engine/Bytecode/TypeImpl/FontImpl.h
@@ -4,6 +4,8 @@
 #include <Engine/Bytecode/Types.h>
 #include <Engine/Includes/Standard.h>
 
+#define CLASS_FONT "Font"
+
 #define IS_FONT(value) IsNativeInstance(value, CLASS_FONT)
 #define AS_FONT(value) ((ObjFont*)AS_OBJECT(value))
 
@@ -13,7 +15,7 @@ public:
 
 	static void Init();
 
-	static Obj* New(void);
+	static Obj* Constructor();
 	static ObjFont* New(void* fontPtr);
 	static void Dispose(Obj* object);
 

--- a/include/Engine/Bytecode/TypeImpl/FunctionImpl.h
+++ b/include/Engine/Bytecode/TypeImpl/FunctionImpl.h
@@ -10,6 +10,7 @@ public:
 
 	static void Init();
 
+	static Obj* Constructor();
 	static Obj* New();
 
 	static VMValue VM_Bind(int argCount, VMValue* args, Uint32 threadID);

--- a/include/Engine/Bytecode/TypeImpl/InstanceImpl.h
+++ b/include/Engine/Bytecode/TypeImpl/InstanceImpl.h
@@ -6,10 +6,6 @@
 
 class InstanceImpl {
 public:
-	static ObjClass* Class;
-
-	static void Init();
-
 	static Obj* New(size_t size, ObjType type);
 	static void Dispose(Obj* object);
 };

--- a/include/Engine/Bytecode/TypeImpl/MapImpl.h
+++ b/include/Engine/Bytecode/TypeImpl/MapImpl.h
@@ -10,11 +10,12 @@ public:
 
 	static void Init();
 
-	static Obj* New();
+	static Obj* Constructor();
 	static void Dispose(Obj* object);
 
+	static VMValue VM_Length(int argCount, VMValue* args, Uint32 threadID);
 	static VMValue VM_GetKeys(int argCount, VMValue* args, Uint32 threadID);
-	static VMValue VM_RemoveKey(int argCount, VMValue* args, Uint32 threadID);
+	static VMValue VM_Remove(int argCount, VMValue* args, Uint32 threadID);
 	static VMValue VM_Iterate(int argCount, VMValue* args, Uint32 threadID);
 	static VMValue VM_IteratorValue(int argCount, VMValue* args, Uint32 threadID);
 };

--- a/include/Engine/Bytecode/TypeImpl/MaterialImpl.h
+++ b/include/Engine/Bytecode/TypeImpl/MaterialImpl.h
@@ -4,6 +4,8 @@
 #include <Engine/Bytecode/Types.h>
 #include <Engine/Includes/Standard.h>
 
+#define CLASS_MATERIAL "Material"
+
 #define IS_MATERIAL(value) IsNativeInstance(value, CLASS_MATERIAL)
 #define AS_MATERIAL(value) ((ObjMaterial*)AS_OBJECT(value))
 
@@ -13,7 +15,7 @@ public:
 
 	static void Init();
 
-	static Obj* New(void);
+	static Obj* Constructor();
 	static ObjMaterial* New(void* materialPtr);
 	static void Dispose(Obj* object);
 

--- a/include/Engine/Bytecode/TypeImpl/ShaderImpl.h
+++ b/include/Engine/Bytecode/TypeImpl/ShaderImpl.h
@@ -4,6 +4,8 @@
 #include <Engine/Bytecode/Types.h>
 #include <Engine/Includes/Standard.h>
 
+#define CLASS_SHADER "Shader"
+
 #define IS_SHADER(value) IsNativeInstance(value, CLASS_SHADER)
 #define AS_SHADER(value) ((ObjShader*)AS_OBJECT(value))
 
@@ -13,7 +15,7 @@ public:
 
 	static void Init();
 
-	static Obj* New(void);
+	static Obj* Constructor();
 	static ObjShader* New(void* shaderPtr);
 	static void Dispose(Obj* object);
 

--- a/include/Engine/Bytecode/TypeImpl/StreamImpl.h
+++ b/include/Engine/Bytecode/TypeImpl/StreamImpl.h
@@ -4,6 +4,8 @@
 #include <Engine/Bytecode/Types.h>
 #include <Engine/Includes/Standard.h>
 
+#define CLASS_STREAM "Stream"
+
 #define IS_STREAM(value) IsNativeInstance(value, CLASS_STREAM)
 #define AS_STREAM(value) ((ObjStream*)AS_OBJECT(value))
 
@@ -13,6 +15,7 @@ public:
 
 	static void Init();
 
+	static Obj* Constructor();
 	static ObjStream* New(void* streamPtr, bool writable);
 	static void Dispose(Obj* object);
 };

--- a/include/Engine/Bytecode/TypeImpl/StringImpl.h
+++ b/include/Engine/Bytecode/TypeImpl/StringImpl.h
@@ -10,6 +10,7 @@ public:
 
 	static void Init();
 
+	static Obj* Constructor();
 	static Obj* New(char* chars, size_t length);
 	static void Dispose(Obj* object);
 

--- a/include/Engine/Bytecode/TypeImpl/TextureImpl.h
+++ b/include/Engine/Bytecode/TypeImpl/TextureImpl.h
@@ -15,7 +15,7 @@ public:
 
 	static void Init();
 
-	static Obj* New(void);
+	static Obj* Constructor();
 	static VMValue VM_Initializer(int argCount, VMValue* args, Uint32 threadID);
 	static void Dispose(Obj* object);
 

--- a/include/Engine/Bytecode/TypeImpl/TypeImpl.h
+++ b/include/Engine/Bytecode/TypeImpl/TypeImpl.h
@@ -9,10 +9,7 @@ public:
 	static void Init();
 
 	static void RegisterClass(ObjClass* klass);
-	static void ExposeClass(const char* name, ObjClass* klass);
-
-	static void DefinePrintableName(ObjClass* klass, const char* name);
-	static const char* GetPrintableName(ObjClass* klass);
+	static void ExposeClass(ObjClass* klass);
 };
 
 #endif /* ENGINE_BYTECODE_TYPEIMPL_TYPEIMPL_H */

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -2319,7 +2319,7 @@ VMValue Application_Quit(int argCount, VMValue* args, Uint32 threadID) {
  * \desc Creates an array.
  * \param size (integer): Size of the array.
  * \paramOpt initialValue (value): Initial value to set the array elements to.
- * \return value A reference value to the array.
+ * \return array Returns the created array.
  * \ns Array
  */
 VMValue Array_Create(int argCount, VMValue* args, Uint32 threadID) {
@@ -18265,7 +18265,7 @@ VMValue Texture_Create(int argCount, VMValue* args, Uint32 threadID) {
 
 	Texture* texture = Graphics::CreateTexture(TextureFormat_NATIVE, TextureAccess_STREAMING, width, height);
 	if (texture) {
-		Obj* objTexture = TextureImpl::New();
+		Obj* objTexture = TextureImpl::Constructor();
 		ScriptManager::RegistryAdd(texture, objTexture);
 		return OBJECT_VAL(objTexture);
 	}
@@ -20438,11 +20438,8 @@ They require the Game SDK library to be present.
 	// #endregion
 
 	// #region Array
-	/***
-    * \class Array
-    * \desc Array manipulation.
-    */
-	INIT_CLASS(Array);
+	// TODO: Move to ArrayImpl
+	GET_CLASS(Array);
 	DEF_NATIVE(Array, Create);
 	DEF_NATIVE(Array, Length);
 	DEF_NATIVE(Array, Push);
@@ -22388,11 +22385,8 @@ This is preferred over <ref Math>'s random functions if you require consistency,
 	// #endregion
 
 	// #region Stream
-	/***
-    * \class Stream
-    * \desc Functions for opening streams, as well as functions for reading and writing data.
-    */
-	INIT_CLASS(Stream);
+	// TODO: Move to StreamImpl
+	GET_CLASS(Stream);
 	DEF_NATIVE(Stream, FromResource);
 	DEF_NATIVE(Stream, FromFile);
 	DEF_NATIVE(Stream, Close);
@@ -22446,11 +22440,8 @@ This is preferred over <ref Math>'s random functions if you require consistency,
 	// #endregion
 
 	// #region String
-	/***
-    * \class String
-    * \desc String manipulation functions.
-    */
-	INIT_CLASS(String);
+	// TODO: Move to StringImpl
+	GET_CLASS(String);
 	DEF_NATIVE(String, Format);
 	DEF_NATIVE(String, Split);
 	DEF_NATIVE(String, CharAt);

--- a/source/Engine/Bytecode/TypeImpl/ArrayImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/ArrayImpl.cpp
@@ -3,23 +3,61 @@
 #include <Engine/Bytecode/TypeImpl/ArrayImpl.h>
 #include <Engine/Bytecode/TypeImpl/TypeImpl.h>
 
+/***
+* \class Array
+* \desc A resizable list of values.
+*/
+
 ObjClass* ArrayImpl::Class = nullptr;
 
 void ArrayImpl::Init() {
-	Class = NewClass(CLASS_ARRAY);
+	Class = NewClass("Array");
+	Class->NewFn = Constructor;
+	Class->Initializer = OBJECT_VAL(NewNative(VM_Initializer));
 
 	ScriptManager::DefineNative(Class, "iterate", ArrayImpl::VM_Iterate);
 	ScriptManager::DefineNative(Class, "iteratorValue", ArrayImpl::VM_IteratorValue);
 
 	TypeImpl::RegisterClass(Class);
+	TypeImpl::ExposeClass(Class);
 }
 
-Obj* ArrayImpl::New() {
+Obj* ArrayImpl::Constructor() {
 	ObjArray* array = (ObjArray*)AllocateObject(sizeof(ObjArray), OBJ_ARRAY);
 	Memory::Track(array, "NewArray");
 	array->Object.Class = Class;
 	array->Values = new vector<VMValue>();
 	return (Obj*)array;
+}
+
+#define GET_ARG(argIndex, argFunction) (StandardLibrary::argFunction(args, argIndex, threadID))
+
+/***
+ * \constructor
+ * \desc Creates an array.
+ * \paramOpt size (integer): Size of the array.
+ * \paramOpt initialValue (value): Initial value to set the array elements to.
+ * \ns Array
+ */
+VMValue ArrayImpl::VM_Initializer(int argCount, VMValue* args, Uint32 threadID) {
+	ObjArray* array = AS_ARRAY(args[0]);
+
+	StandardLibrary::CheckAtLeastArgCount(argCount, 1);
+
+	int length = 0;
+	VMValue initialValue = NULL_VAL;
+	if (argCount >= 2) {
+		length = GET_ARG(1, GetInteger);
+	}
+	if (argCount >= 3) {
+		initialValue = args[2];
+	}
+
+	for (int i = 0; i < length; i++) {
+		array->Values->push_back(initialValue);
+	}
+
+	return OBJECT_VAL(array);
 }
 
 void ArrayImpl::Dispose(Obj* object) {
@@ -30,8 +68,6 @@ void ArrayImpl::Dispose(Obj* object) {
 
 	delete array->Values;
 }
-
-#define GET_ARG(argIndex, argFunction) (StandardLibrary::argFunction(args, argIndex, threadID))
 
 VMValue ArrayImpl::VM_Iterate(int argCount, VMValue* args, Uint32 threadID) {
 	StandardLibrary::CheckArgCount(argCount, 2);

--- a/source/Engine/Bytecode/TypeImpl/FontImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/FontImpl.cpp
@@ -17,7 +17,7 @@ ObjClass* FontImpl::Class = nullptr;
 
 void FontImpl::Init() {
 	Class = NewClass(CLASS_FONT);
-	Class->NewFn = New;
+	Class->NewFn = Constructor;
 	Class->Initializer = OBJECT_VAL(NewNative(VM_Initializer));
 
 	ScriptManager::DefineNative(Class, "GetPixelsPerUnit", VM_GetPixelsPerUnit);
@@ -42,8 +42,7 @@ void FontImpl::Init() {
 	ScriptManager::DefineNative(Class, "SetAntialiasing", VM_SetAntialiasing);
 
 	TypeImpl::RegisterClass(Class);
-	TypeImpl::ExposeClass(CLASS_FONT, Class);
-	TypeImpl::DefinePrintableName(Class, "font");
+	TypeImpl::ExposeClass(Class);
 }
 
 #define GET_ARG(argIndex, argFunction) (StandardLibrary::argFunction(args, argIndex, threadID))
@@ -149,7 +148,7 @@ void GetDefaultFonts(std::vector<Stream*>& streamList, std::vector<bool>& closeS
  * \paramOpt font (array): The list of fonts. If this argument is not given, it will use font the application was built with, if one is present.
  * \ns Font
  */
-Obj* FontImpl::New() {
+Obj* FontImpl::Constructor() {
 	Font* font = new Font();
 	ObjFont* obj = New((void*)font);
 	return (Obj*)obj;

--- a/source/Engine/Bytecode/TypeImpl/FunctionImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/FunctionImpl.cpp
@@ -3,14 +3,27 @@
 #include <Engine/Bytecode/TypeImpl/FunctionImpl.h>
 #include <Engine/Bytecode/TypeImpl/TypeImpl.h>
 
+/***
+* \class Function
+* \desc A function, defined in a HSL script.
+*/
+
 ObjClass* FunctionImpl::Class = nullptr;
 
 void FunctionImpl::Init() {
-	Class = NewClass(CLASS_FUNCTION);
+	Class = NewClass("Function");
+	Class->NewFn = Constructor;
 
+	ScriptManager::DefineNative(Class, "Bind", FunctionImpl::VM_Bind);
 	ScriptManager::DefineNative(Class, "bind", FunctionImpl::VM_Bind);
 
 	TypeImpl::RegisterClass(Class);
+	TypeImpl::ExposeClass(Class);
+}
+
+Obj* FunctionImpl::Constructor() {
+	throw ScriptException("Cannot directly construct Function!");
+	return nullptr;
 }
 
 Obj* FunctionImpl::New() {
@@ -23,6 +36,13 @@ Obj* FunctionImpl::New() {
 
 #define GET_ARG(argIndex, argFunction) (StandardLibrary::argFunction(args, argIndex, threadID))
 
+/***
+ * \method Bind
+ * \desc Binds a receiver to a method.
+ * \param receiver (value): The receiver to bind.
+ * \return <ref BoundMethod> Returns a bound method.
+ * \ns Function
+ */
 VMValue FunctionImpl::VM_Bind(int argCount, VMValue* args, Uint32 threadID) {
 	StandardLibrary::CheckArgCount(argCount, 2);
 

--- a/source/Engine/Bytecode/TypeImpl/InstanceImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/InstanceImpl.cpp
@@ -1,14 +1,5 @@
 #include <Engine/Bytecode/ScriptManager.h>
 #include <Engine/Bytecode/TypeImpl/InstanceImpl.h>
-#include <Engine/Bytecode/TypeImpl/TypeImpl.h>
-
-ObjClass* InstanceImpl::Class = nullptr;
-
-void InstanceImpl::Init() {
-	Class = NewClass(CLASS_INSTANCE);
-
-	TypeImpl::RegisterClass(Class);
-}
 
 Obj* InstanceImpl::New(size_t size, ObjType type) {
 	ObjInstance* instance = (ObjInstance*)AllocateObject(size, type);

--- a/source/Engine/Bytecode/TypeImpl/MapImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/MapImpl.cpp
@@ -26,6 +26,11 @@ void MapImpl::Init() {
 	TypeImpl::ExposeClass(Class);
 }
 
+/***
+ * \constructor
+ * \desc Creates a map.
+ * \ns Map
+ */
 Obj* MapImpl::Constructor() {
 	ObjMap* map = (ObjMap*)AllocateObject(sizeof(ObjMap), OBJ_MAP);
 	Memory::Track(map, "NewMap");

--- a/source/Engine/Bytecode/TypeImpl/MapImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/MapImpl.cpp
@@ -3,20 +3,30 @@
 #include <Engine/Bytecode/TypeImpl/MapImpl.h>
 #include <Engine/Bytecode/TypeImpl/TypeImpl.h>
 
+/***
+* \class Map
+* \desc An associative array, also known as a dictionary, or a map.
+*/
+
 ObjClass* MapImpl::Class = nullptr;
 
 void MapImpl::Init() {
-	Class = NewClass(CLASS_MAP);
+	Class = NewClass("Map");
+	Class->NewFn = Constructor;
 
+	ScriptManager::DefineNative(Class, "Length", MapImpl::VM_Length);
+	ScriptManager::DefineNative(Class, "GetKeys", MapImpl::VM_GetKeys);
 	ScriptManager::DefineNative(Class, "keys", MapImpl::VM_GetKeys);
-	ScriptManager::DefineNative(Class, "remove", MapImpl::VM_RemoveKey);
+	ScriptManager::DefineNative(Class, "Remove", MapImpl::VM_Remove);
+	ScriptManager::DefineNative(Class, "remove", MapImpl::VM_Remove);
 	ScriptManager::DefineNative(Class, "iterate", MapImpl::VM_Iterate);
 	ScriptManager::DefineNative(Class, "iteratorValue", MapImpl::VM_IteratorValue);
 
 	TypeImpl::RegisterClass(Class);
+	TypeImpl::ExposeClass(Class);
 }
 
-Obj* MapImpl::New() {
+Obj* MapImpl::Constructor() {
 	ObjMap* map = (ObjMap*)AllocateObject(sizeof(ObjMap), OBJ_MAP);
 	Memory::Track(map, "NewMap");
 	map->Object.Class = Class;
@@ -42,6 +52,26 @@ void MapImpl::Dispose(Obj* object) {
 
 #define GET_ARG(argIndex, argFunction) (StandardLibrary::argFunction(args, argIndex, threadID))
 
+/***
+ * \method Length
+ * \desc Get the number of items in the map.
+ * \return integer Returns an integer value.
+ * \ns Map
+ */
+VMValue MapImpl::VM_Length(int argCount, VMValue* args, Uint32 threadID) {
+	StandardLibrary::CheckArgCount(argCount, 1);
+
+	ObjMap* map = GET_ARG(0, GetMap);
+
+	return INTEGER_VAL((int)map->Keys->Count());
+}
+
+/***
+ * \method GetKeys
+ * \desc Gets a list of all keys in the map.
+ * \return array Returns an array of strings.
+ * \ns Map
+ */
 VMValue MapImpl::VM_GetKeys(int argCount, VMValue* args, Uint32 threadID) {
 	StandardLibrary::CheckArgCount(argCount, 1);
 
@@ -56,7 +86,13 @@ VMValue MapImpl::VM_GetKeys(int argCount, VMValue* args, Uint32 threadID) {
 	return OBJECT_VAL(array);
 }
 
-VMValue MapImpl::VM_RemoveKey(int argCount, VMValue* args, Uint32 threadID) {
+/***
+ * \method Remove
+ * \desc Removes a key from the map.
+ * \param key (string): The key to remove.
+ * \ns Map
+ */
+VMValue MapImpl::VM_Remove(int argCount, VMValue* args, Uint32 threadID) {
 	StandardLibrary::CheckArgCount(argCount, 2);
 
 	ObjMap* map = GET_ARG(0, GetMap);

--- a/source/Engine/Bytecode/TypeImpl/MaterialImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/MaterialImpl.cpp
@@ -44,7 +44,7 @@ Uint32 Hash_EmissiveTexture = 0;
 
 void MaterialImpl::Init() {
 	Class = NewClass(CLASS_MATERIAL);
-	Class->NewFn = New;
+	Class->NewFn = Constructor;
 	Class->Initializer = OBJECT_VAL(NewNative(VM_Initializer));
 
 	Hash_Name = Murmur::EncryptString("Name");
@@ -166,8 +166,7 @@ void MaterialImpl::Init() {
 #endif
 
 	TypeImpl::RegisterClass(Class);
-	TypeImpl::ExposeClass(CLASS_MATERIAL, Class);
-	TypeImpl::DefinePrintableName(Class, "material");
+	TypeImpl::ExposeClass(Class);
 }
 
 #define GET_ARG(argIndex, argFunction) (StandardLibrary::argFunction(args, argIndex, threadID))
@@ -177,7 +176,7 @@ void MaterialImpl::Init() {
  * \desc Creates a material.
  * \ns Material
  */
-Obj* MaterialImpl::New() {
+Obj* MaterialImpl::Constructor() {
 	Material* materialPtr = Material::Create(nullptr);
 	return (Obj*)New((void*)materialPtr);
 }

--- a/source/Engine/Bytecode/TypeImpl/ShaderImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/ShaderImpl.cpp
@@ -27,7 +27,7 @@ Uint32 Hash_Uniforms = 0;
 
 void ShaderImpl::Init() {
 	Class = NewClass(CLASS_SHADER);
-	Class->NewFn = New;
+	Class->NewFn = Constructor;
 
 	Hash_Uniforms = Murmur::EncryptString("Uniforms");
 
@@ -46,8 +46,7 @@ void ShaderImpl::Init() {
 	ScriptManager::DefineNative(Class, "Delete", VM_Delete);
 
 	TypeImpl::RegisterClass(Class);
-	TypeImpl::ExposeClass(CLASS_SHADER, Class);
-	TypeImpl::DefinePrintableName(Class, "shader");
+	TypeImpl::ExposeClass(Class);
 }
 
 #define CHECK_EXISTS(ptr) \
@@ -94,7 +93,7 @@ bool ShaderImpl::VM_PropertyGet(Obj* object, Uint32 hash, VMValue* result, Uint3
  * \desc Creates a shader program.
  * \ns Shader
  */
-Obj* ShaderImpl::New() {
+Obj* ShaderImpl::Constructor() {
 	Shader* shader = Graphics::CreateShader();
 	if (shader == nullptr) {
 		throw ScriptException("Could not create shader!");

--- a/source/Engine/Bytecode/TypeImpl/StreamImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/StreamImpl.cpp
@@ -6,13 +6,25 @@
 #include <Engine/Bytecode/Types.h>
 #include <Engine/IO/Stream.h>
 
+/***
+* \class Stream
+* \desc An abstraction of a continuous sequence of data.
+Use <ref Stream.FromResource> or <ref Stream.FromFile> to open a stream.
+*/
+
 ObjClass* StreamImpl::Class = nullptr;
 
 void StreamImpl::Init() {
 	Class = NewClass(CLASS_STREAM);
+	Class->NewFn = Constructor;
 
 	TypeImpl::RegisterClass(Class);
-	TypeImpl::DefinePrintableName(Class, "stream");
+	TypeImpl::ExposeClass(Class);
+}
+
+Obj* StreamImpl::Constructor() {
+	throw ScriptException("Cannot directly construct Stream! Use Stream.FromResource or Stream.FromFile.");
+	return nullptr;
 }
 
 ObjStream* StreamImpl::New(void* streamPtr, bool writable) {

--- a/source/Engine/Bytecode/TypeImpl/StringImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/StringImpl.cpp
@@ -3,13 +3,25 @@
 #include <Engine/Bytecode/TypeImpl/StringImpl.h>
 #include <Engine/Bytecode/TypeImpl/TypeImpl.h>
 
+/***
+* \class String
+* \desc A sequence of characters. All string literals are instances of String.
+*/
+
 ObjClass* StringImpl::Class = nullptr;
 
 void StringImpl::Init() {
-	Class = NewClass(CLASS_STRING);
+	Class = NewClass("String");
+	Class->NewFn = Constructor;
 	Class->ElementGet = VM_ElementGet;
 
 	TypeImpl::RegisterClass(Class);
+	TypeImpl::ExposeClass(Class);
+}
+
+Obj* StringImpl::Constructor() {
+	throw ScriptException("Cannot directly construct String!");
+	return nullptr;
 }
 
 Obj* StringImpl::New(char* chars, size_t length) {

--- a/source/Engine/Bytecode/TypeImpl/TextureImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/TextureImpl.cpp
@@ -19,7 +19,7 @@ Uint32 Hash_Access = 0;
 
 void TextureImpl::Init() {
 	Class = NewClass(CLASS_TEXTURE);
-	Class->NewFn = New;
+	Class->NewFn = Constructor;
 	Class->Initializer = OBJECT_VAL(NewNative(VM_Initializer));
 
 	/***
@@ -64,15 +64,14 @@ void TextureImpl::Init() {
 	ScriptManager::DefineNative(Class, "FormatHasAlphaChannel", VM_FormatHasAlphaChannel);
 
 	TypeImpl::RegisterClass(Class);
-	TypeImpl::ExposeClass(CLASS_TEXTURE, Class);
-	TypeImpl::DefinePrintableName(Class, "texture");
+	TypeImpl::ExposeClass(Class);
 }
 
 #define GET_ARG(argIndex, argFunction) (StandardLibrary::argFunction(args, argIndex, threadID))
 #define GET_ARG_OPT(argIndex, argFunction, argDefault) \
 	(argIndex < argCount ? GET_ARG(argIndex, StandardLibrary::argFunction) : argDefault)
 
-Obj* TextureImpl::New() {
+Obj* TextureImpl::Constructor() {
 	ObjTexture* texture = (ObjTexture*)NewNativeInstance(sizeof(ObjTexture));
 	Memory::Track(texture, "NewTexture");
 	texture->Object.Class = Class;
@@ -635,7 +634,7 @@ ObjTexture* TextureImpl::GetTextureObject(void* texture, bool isViewTexture) {
 		return (ObjTexture*)obj;
 	}
 
-	obj = ScriptManager::RegistryAdd(texture, TextureImpl::New());
+	obj = ScriptManager::RegistryAdd(texture, TextureImpl::Constructor());
 
 	ObjTexture* textureObj = (ObjTexture*)obj;
 	textureObj->IsViewTexture = isViewTexture;

--- a/source/Engine/Bytecode/TypeImpl/TypeImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/TypeImpl.cpp
@@ -13,14 +13,11 @@
 #include <Engine/Bytecode/TypeImpl/TextureImpl.h>
 #include <Engine/Bytecode/TypeImpl/TypeImpl.h>
 
-std::unordered_map<ObjClass*, const char*> PrintableNames;
-
 void TypeImpl::Init() {
 	ArrayImpl::Init();
 	EntityImpl::Init();
 	FontImpl::Init();
 	FunctionImpl::Init();
-	InstanceImpl::Init();
 	MaterialImpl::Init();
 	MapImpl::Init();
 	ShaderImpl::Init();
@@ -33,18 +30,6 @@ void TypeImpl::RegisterClass(ObjClass* klass) {
 	ScriptManager::ClassImplList.push_back(klass);
 }
 
-void TypeImpl::ExposeClass(const char* name, ObjClass* klass) {
-	ScriptManager::Globals->Put(name, OBJECT_VAL(klass));
-}
-
-void TypeImpl::DefinePrintableName(ObjClass* klass, const char* name) {
-	PrintableNames[klass] = name;
-}
-
-const char* TypeImpl::GetPrintableName(ObjClass* klass) {
-	if (PrintableNames.find(klass) != PrintableNames.end()) {
-		return PrintableNames[klass];
-	}
-
-	return nullptr;
+void TypeImpl::ExposeClass(ObjClass* klass) {
+	ScriptManager::Globals->Put(klass->Name, OBJECT_VAL(klass));
 }

--- a/source/Engine/Bytecode/Types.cpp
+++ b/source/Engine/Bytecode/Types.cpp
@@ -182,10 +182,10 @@ ObjBoundMethod* NewBoundMethod(VMValue receiver, ObjFunction* method) {
 	return bound;
 }
 ObjArray* NewArray() {
-	return (ObjArray*)ArrayImpl::New();
+	return (ObjArray*)ArrayImpl::Constructor();
 }
 ObjMap* NewMap() {
-	return (ObjMap*)MapImpl::New();
+	return (ObjMap*)MapImpl::Constructor();
 }
 ObjNamespace* NewNamespace(Uint32 hash) {
 	ObjNamespace* ns = ALLOCATE_OBJ(ObjNamespace, OBJ_NAMESPACE);
@@ -263,7 +263,11 @@ const char* GetTypeString(Uint32 type) {
 	return "unknown type";
 }
 const char* GetObjectTypeString(Uint32 type) {
-	return Value::GetObjectTypeName(type);
+	const char* typeString = Value::GetObjectTypeName(type);
+	if (typeString) {
+		return typeString;
+	}
+	return "unknown object type";
 }
 const char* GetValueTypeString(VMValue value) {
 	if (value.Type == VAL_OBJECT) {

--- a/source/Engine/Bytecode/Types.h
+++ b/source/Engine/Bytecode/Types.h
@@ -269,7 +269,7 @@ static inline VMLocation ELEMENT_LOCATION() {
 
 typedef VMValue (*NativeFn)(int argCount, VMValue* args, Uint32 threadID);
 
-typedef Obj* (*ClassNewFn)(void);
+typedef Obj* (*ClassNewFn)();
 typedef void (*ObjectDestructor)(Obj*);
 
 typedef bool (*ValueGetFn)(Obj* object, Uint32 hash, VMValue* value, Uint32 threadID);
@@ -297,17 +297,6 @@ enum ObjType {
 
 	MAX_OBJ_TYPE
 };
-
-#define CLASS_ARRAY "ArrayImpl"
-#define CLASS_ENTITY "EntityImpl"
-#define CLASS_FONT "Font"
-#define CLASS_FUNCTION "FunctionImpl"
-#define CLASS_INSTANCE "InstanceImpl"
-#define CLASS_MAP "MapImpl"
-#define CLASS_MATERIAL "Material"
-#define CLASS_SHADER "Shader"
-#define CLASS_STREAM "StreamImpl"
-#define CLASS_STRING "StringImpl"
 
 #define OBJECT_TYPE(value) (AS_OBJECT(value)->Type)
 #define IS_BOUND_METHOD(value) IsObjectType(value, OBJ_BOUND_METHOD)

--- a/source/Engine/Bytecode/Value.cpp
+++ b/source/Engine/Bytecode/Value.cpp
@@ -37,24 +37,25 @@ const char* Value::GetObjectTypeName(Uint32 type) {
 		return "module";
 	}
 
-	return "unknown object type";
+	return nullptr;
 }
 
 const char* Value::GetObjectTypeName(ObjClass* klass) {
-	const char* printableName = TypeImpl::GetPrintableName(klass);
-	if (printableName != nullptr) {
-		return printableName;
-	}
-	return "unknown";
+	return klass->Name;
 }
 
 const char* Value::GetObjectTypeName(VMValue value) {
-	Obj* object = AS_OBJECT(value);
-	const char* printableName = TypeImpl::GetPrintableName(object->Class);
-	if (printableName != nullptr) {
-		return printableName;
+	const char* typeString = GetObjectTypeName(OBJECT_TYPE(value));
+	if (typeString) {
+		return typeString;
 	}
-	return GetObjectTypeName(OBJECT_TYPE(value));
+
+	Obj* object = AS_OBJECT(value);
+	if (object->Class != nullptr) {
+		return GetObjectTypeName(object->Class);
+	}
+
+	return "object";
 }
 
 const char* Value::GetPrintableObjectName(VMValue value) {


### PR DESCRIPTION
Combine implementation classes of native object types with their StandardLibrary implementations.
Expose Function, and rename `bind` to `Bind`.
Expose Map, rename `keys` to `GetKeys`, `remove` to `Remove`, and add `Length`.
Document Function and Map.
Change descriptions of Array, Stream, and String.
Allow constructing Array and Map.
Remove the `PrintableNames` logic.
No longer create a class for `InstanceImpl`.