### PR TITLE
Fix `WINDOWS_COMPILE_AS_CONSOLE_APP`

### DIFF
--- a/cmake/Platforms/Windows.cmake
+++ b/cmake/Platforms/Windows.cmake
@@ -41,7 +41,9 @@ target_link_libraries(${PROJECT_NAME}
   Ws2_32.lib opengl32.lib winmm.lib imm32.lib version.lib setupapi.lib)
 
 if(NOT WINDOWS_COMPILE_AS_CONSOLE_APP)
-  target_link_libraries(${PROJECT_NAME} -mwindows)
+  set_target_properties(${PROJECT_NAME} PROPERTIES WIN32_EXECUTABLE ON)
+else()
+  target_compile_definitions(${PROJECT_NAME} PRIVATE -DWINDOWS_CONSOLE_APP)
 endif()
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE -DSDL_MAIN_HANDLED)

--- a/source/Engine/Main.cpp
+++ b/source/Engine/Main.cpp
@@ -2,7 +2,11 @@
 #include <Engine/Diagnostics/Log.h>
 #include <Engine/Includes/Standard.h>
 
+#if defined(WIN32) && !defined(WINDOWS_CONSOLE_APP)
+int WinMain(int argc, char* args[]) {
+#else
 int main(int argc, char* args[]) {
+#endif
 #if SWITCH
 	Log::Init();
 	socketInitializeDefault();


### PR DESCRIPTION
`-mwindows` wasn't doing anything anymore because it's MinGW specific. `WIN32_EXECUTABLE` handles this properly for the MSVC linker.

Fixes #196