### PR TITLE
Add SCOPE_GROUP

### DIFF
--- a/include/Engine/Scene.h
+++ b/include/Engine/Scene.h
@@ -122,6 +122,7 @@ public:
 	static char CurrentFolder[256];
 	static char CurrentID[256];
 	static char CurrentResourceFolder[256];
+	static char PreviousResourceFolder[256];
 	static char CurrentCategory[256];
 	static int ActiveCategory;
 	static int DebugMode;

--- a/include/Engine/Scene/SceneInfo.h
+++ b/include/Engine/Scene/SceneInfo.h
@@ -31,6 +31,7 @@ public:
 	static std::string GetName(int categoryID, int entryID);
 	static std::string GetFolder(int categoryID, int entryID);
 	static std::string GetID(int categoryID, int entryID);
+	static std::string GetResourceFolder(int categoryID, int entryID);
 	static int GetFilter(int categoryID, int entryID);
 	static std::string GetTileConfigFilename(int categoryID, int entryID);
 	static char* GetEntryProperty(int categoryID, int entryID, char* property);

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -21943,6 +21943,11 @@ This is preferred over <ref Math>'s random functions if you require consistency,
     */
 	DEF_ENUM(SCOPE_SCENE);
 	/***
+	* \enum SCOPE_GROUP
+	* \desc Group scope, determined by whether the resource folder of the current scene matches the resource folder of the previous scene.
+	*/
+	DEF_ENUM(SCOPE_GROUP);
+	/***
     * \enum SCOPE_GAME
     * \desc Game scope.
     */

--- a/source/Engine/Includes/Standard.h
+++ b/source/Engine/Includes/Standard.h
@@ -101,7 +101,8 @@ struct DeveloperMenu {
 #define MAX_FRAMEBUFFER_HEIGHT 4096
 
 #define SCOPE_SCENE 0
-#define SCOPE_GAME 1
+#define SCOPE_GROUP 1
+#define SCOPE_GAME 2
 
 #define PALETTE_INDEX_TABLE_ID -1
 

--- a/source/Engine/Includes/Standard.h
+++ b/source/Engine/Includes/Standard.h
@@ -101,8 +101,8 @@ struct DeveloperMenu {
 #define MAX_FRAMEBUFFER_HEIGHT 4096
 
 #define SCOPE_SCENE 0
-#define SCOPE_GROUP 1
-#define SCOPE_GAME 2
+#define SCOPE_GAME 1
+#define SCOPE_GROUP 2 // SCOPE_GROUP is intentionally 2 for Hatch backwards compatibility, but behaves as a midpoint of SCOPE_SCENE and SCOPE_GAME.
 
 #define PALETTE_INDEX_TABLE_ID -1
 

--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -690,13 +690,7 @@ void Scene::SetInfoFromCurrentID() {
 		Scene::CurrentFolder[0] = '\0';
 	}
 
-	StringUtils::Copy(Scene::PreviousResourceFolder, Scene::CurrentResourceFolder, sizeof Scene::PreviousResourceFolder);
-	if (scene.ResourceFolder != nullptr) {
-		strcpy(Scene::CurrentResourceFolder, scene.ResourceFolder);
-	}
-	else {
-		Scene::CurrentResourceFolder[0] = '\0';
-	}
+	// Resource folder and filter are set in Scene::LoadScene
 }
 
 // Scene Lifecycle
@@ -2151,6 +2145,8 @@ void Scene::LoadScene(const char* sceneFilename) {
 		return;
 	}
 
+	StringUtils::Copy(Scene::CurrentScene, filename, sizeof Scene::CurrentScene);
+
 	if (SceneInfo::IsEntryValid(Scene::ActiveCategory, Scene::CurrentSceneInList)) {
 		StringUtils::Copy(Scene::PreviousResourceFolder, Scene::CurrentResourceFolder, sizeof Scene::PreviousResourceFolder);
 
@@ -2158,13 +2154,14 @@ void Scene::LoadScene(const char* sceneFilename) {
 		if (!nextResourceFolder.empty()) {
 			StringUtils::Copy(Scene::CurrentResourceFolder, nextResourceFolder.c_str(), sizeof Scene::CurrentResourceFolder);
 		}
+		else {
+			Scene::CurrentResourceFolder[0] = '\0';
+		}
 	}
 
 	if (strcmp(Scene::PreviousResourceFolder, Scene::CurrentResourceFolder)) {
 		Scene::DisposeInScope(SCOPE_GROUP);
 	}
-
-	StringUtils::Copy(Scene::CurrentScene, filename, sizeof Scene::CurrentScene);
 
 	Scene::Filter = SceneInfo::GetFilter(Scene::ActiveCategory, Scene::CurrentSceneInList);
 

--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -116,6 +116,7 @@ int Scene::CurrentSceneInList;
 char Scene::CurrentFolder[256];
 char Scene::CurrentID[256];
 char Scene::CurrentResourceFolder[256];
+char Scene::PreviousResourceFolder[256];
 char Scene::CurrentCategory[256];
 int Scene::ActiveCategory;
 
@@ -689,6 +690,7 @@ void Scene::SetInfoFromCurrentID() {
 		Scene::CurrentFolder[0] = '\0';
 	}
 
+	StringUtils::Copy(Scene::PreviousResourceFolder, Scene::CurrentResourceFolder, sizeof Scene::PreviousResourceFolder);
 	if (scene.ResourceFolder != nullptr) {
 		strcpy(Scene::CurrentResourceFolder, scene.ResourceFolder);
 	}
@@ -2147,6 +2149,19 @@ void Scene::LoadScene(const char* sceneFilename) {
 			MAX_RESOURCE_PATH_LENGTH);
 		Memory::Free(filename);
 		return;
+	}
+
+	if (SceneInfo::IsEntryValid(Scene::ActiveCategory, Scene::CurrentSceneInList)) {
+		StringUtils::Copy(Scene::PreviousResourceFolder, Scene::CurrentResourceFolder, sizeof Scene::PreviousResourceFolder);
+
+		std::string nextResourceFolder = SceneInfo::GetResourceFolder(Scene::ActiveCategory, Scene::CurrentSceneInList);
+		if (!nextResourceFolder.empty()) {
+			StringUtils::Copy(Scene::CurrentResourceFolder, nextResourceFolder.c_str(), sizeof Scene::CurrentResourceFolder);
+		}
+	}
+
+	if (strcmp(Scene::PreviousResourceFolder, Scene::CurrentResourceFolder)) {
+		Scene::DisposeInScope(SCOPE_GROUP);
 	}
 
 	StringUtils::Copy(Scene::CurrentScene, filename, sizeof Scene::CurrentScene);

--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -3499,7 +3499,7 @@ void Scene::DisposeInScope(Uint32 scope) {
 		if (!Scene::ModelList[i]) {
 			continue;
 		}
-		if (Scene::ModelList[i]->UnloadPolicy > scope) {
+		if (Scene::ModelList[i]->UnloadPolicy != scope) {
 			continue;
 		}
 
@@ -3512,7 +3512,7 @@ void Scene::DisposeInScope(Uint32 scope) {
 		if (!Scene::ImageList[i]) {
 			continue;
 		}
-		if (Scene::ImageList[i]->UnloadPolicy > scope) {
+		if (Scene::ImageList[i]->UnloadPolicy != scope) {
 			continue;
 		}
 		if (Scene::ImageList[i]->AsImage->References > 1) {
@@ -3528,7 +3528,7 @@ void Scene::DisposeInScope(Uint32 scope) {
 		if (!Scene::SpriteList[i]) {
 			continue;
 		}
-		if (Scene::SpriteList[i]->UnloadPolicy > scope) {
+		if (Scene::SpriteList[i]->UnloadPolicy != scope) {
 			continue;
 		}
 
@@ -3541,7 +3541,7 @@ void Scene::DisposeInScope(Uint32 scope) {
 		if (!Scene::SoundList[i]) {
 			continue;
 		}
-		if (Scene::SoundList[i]->UnloadPolicy > scope) {
+		if (Scene::SoundList[i]->UnloadPolicy != scope) {
 			continue;
 		}
 
@@ -3557,7 +3557,7 @@ void Scene::DisposeInScope(Uint32 scope) {
 		if (!Scene::MusicList[i]) {
 			continue;
 		}
-		if (Scene::MusicList[i]->UnloadPolicy > scope) {
+		if (Scene::MusicList[i]->UnloadPolicy != scope) {
 			continue;
 		}
 
@@ -3574,7 +3574,7 @@ void Scene::DisposeInScope(Uint32 scope) {
 		if (!Scene::MediaList[i]) {
 			continue;
 		}
-		if (Scene::MediaList[i]->UnloadPolicy > scope) {
+		if (Scene::MediaList[i]->UnloadPolicy != scope) {
 			continue;
 		}
 
@@ -3593,7 +3593,7 @@ void Scene::DisposeInScope(Uint32 scope) {
 		if (!Scene::AnimatorList[i]) {
 			continue;
 		}
-		if (Scene::AnimatorList[i]->UnloadPolicy > scope) {
+		if (Scene::AnimatorList[i]->UnloadPolicy != scope) {
 			continue;
 		}
 
@@ -3626,6 +3626,8 @@ void Scene::Dispose() {
 		}
 	}
 
+	Scene::DisposeInScope(SCOPE_SCENE);
+	Scene::DisposeInScope(SCOPE_GROUP);
 	Scene::DisposeInScope(SCOPE_GAME);
 	// Dispose of all resources
 	Scene::ImageList.clear();

--- a/source/Engine/Scene/SceneInfo.cpp
+++ b/source/Engine/Scene/SceneInfo.cpp
@@ -190,6 +190,16 @@ std::string SceneInfo::GetID(int categoryID, int entryID) {
 	return std::string(entry.ID);
 }
 
+std::string SceneInfo::GetResourceFolder(int categoryID, int entryID) {
+	if (!SceneInfo::IsEntryValid(categoryID, entryID)) {
+		return "";
+	}
+
+	SceneListEntry& entry = Categories[categoryID].Entries[entryID];
+
+	return entry.ResourceFolder;
+}
+
 int SceneInfo::GetFilter(int categoryID, int entryID) {
 	if (!SceneInfo::IsEntryValid(categoryID, entryID)) {
 		return 0xFF;


### PR DESCRIPTION
Adds SCOPE_GROUP, which allows assets to be maintained when loading a new scene with the same resource folder as the prior (resource folder is treated as an identifier here).

For example, if the first scene of a game has a resource folder of "GHZ", and the next loaded scene also has a resource folder of "scene", the assets with SCOPE_GROUP are kept in memory. If the next loaded scene was then "CPZ", the assets in this scope will be disposed.

This is to aid load times between scenes of the same group.