### PR TITLE
Resources browser in scene select menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,7 @@ PUBHFILES := \
 	source/Engine/Bytecode/Value.h \
 	source/Engine/Bytecode/ValuePrinter.h \
 	source/Engine/Data/DefaultFonts.h \
+	source/Engine/DeveloperMenu.h \
 	source/Engine/Diagnostics/Clock.h \
 	source/Engine/Diagnostics/Log.h \
 	source/Engine/Diagnostics/Memory.h \

--- a/VisualC/HatchGameEngine.vcxproj
+++ b/VisualC/HatchGameEngine.vcxproj
@@ -297,8 +297,10 @@ copy "$(TargetPath)" "$(SolutionDir)..\builds\win\$(TargetName)-Release.exe"</Co
     <ClCompile Include="..\source\engine\resourcetypes\soundformats\SoundFormat.cpp" />
     <ClCompile Include="..\source\engine\resourcetypes\soundformats\WAV.cpp" />
     <ClCompile Include="..\source\engine\Scene.cpp" />
+    <ClCompile Include="..\source\Engine\Scene\ImageLayer.cpp" />
     <ClCompile Include="..\source\engine\scene\SceneInfo.cpp" />
     <ClCompile Include="..\source\engine\scene\SceneLayer.cpp" />
+    <ClCompile Include="..\source\Engine\Scene\TileLayer.cpp" />
     <ClCompile Include="..\source\engine\scene\View.cpp" />
     <ClCompile Include="..\source\engine\textformats\ini\INI.cpp" />
     <ClCompile Include="..\source\engine\textformats\xml\XMLParser.cpp" />

--- a/VisualC/HatchGameEngine.vcxproj.filters
+++ b/VisualC/HatchGameEngine.vcxproj.filters
@@ -279,9 +279,6 @@
     <ClCompile Include="..\source\engine\rendering\FaceInfo.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\source\engine\rendering\GameTexture.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\source\engine\rendering\gl\GLRenderer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -325,9 +322,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\source\engine\rendering\VertexBuffer.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\source\engine\rendering\ViewTexture.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\source\engine\resourcetypes\Font.cpp">
@@ -483,9 +477,6 @@
     <ClCompile Include="..\source\Libraries\linenoise-ng\linenoise.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\source\Libraries\wcwidth.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\source\engine\bytecode\TypeImpl\EntityImpl.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -496,6 +487,24 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\source\engine\bytecode\TypeImpl\TypeImpl.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\source\engine\bytecode\TypeImpl\TextureImpl.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\source\engine\bytecode\BytecodeDebugger.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\source\Engine\Utilities\Screenshot.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\source\Libraries\linenoise-ng\wcwidth.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\source\Engine\Scene\ImageLayer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\source\Engine\Scene\TileLayer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -1290,6 +1290,25 @@ void Application::LoadDevSettings() {
 			ResourceManager::SetMainResourceWritable(true);
 		}
 	}
+
+	char str[64];
+	if (Application::Settings->GetString("dev", "sceneBrowserMode", str, sizeof str) && str[0] != '\0') {
+		if (strcmp(str, "resources") == 0) {
+			DevMenu.SceneBrowserMode = SCENEBROWSER_RESOURCES;
+		}
+		else if (strcmp(str, "scenelist") == 0) {
+			DevMenu.SceneBrowserMode = SCENEBROWSER_SCENELIST;
+		}
+		else if (strcmp(str, "default") == 0) {
+			DevMenu.SceneBrowserMode = SCENEBROWSER_DEFAULT;
+		}
+		else {
+			Log::Print(Log::LOG_WARN,
+				"Unrecognized option \"%s\" for \"sceneBrowserMode\"",
+				str);
+			DevMenu.SceneBrowserMode = SCENEBROWSER_DEFAULT;
+		}
+	}
 #endif
 }
 
@@ -2812,7 +2831,12 @@ void Application::OpenDevMenu() {
 	DevMenu.Fullscreen = Application::WindowFullscreen;
 	DevMenu.WindowBorderless = Application::WindowBorderless;
 
-	DevMenu.ResourcesBrowserAvailable = IsResourcesBrowserAvailable();
+	if (DevMenu.SceneBrowserMode != SCENEBROWSER_SCENELIST && IsResourcesBrowserAvailable()) {
+		DevMenu.ResourcesBrowserAvailable = true;
+	}
+	else {
+		DevMenu.ResourcesBrowserAvailable = false;
+	}
 
 	AudioManager::AudioPauseAll();
 	AudioManager::Lock();
@@ -2946,11 +2970,21 @@ void Application::DevMenu_MainMenu() {
 			UpdateWindowTitle();
 			break;
 		case 2:
-			if (SceneInfo::Categories.empty()) {
+			switch (DevMenu.SceneBrowserMode) {
+			case SCENEBROWSER_RESOURCES:
 				DevMenu_OpenResourcesBrowser();
-			}
-			else {
+				break;
+			case SCENEBROWSER_SCENELIST:
 				DevMenu.State = Application::DevMenu_CategorySelectMenu;
+				break;
+			case SCENEBROWSER_DEFAULT:
+				if (SceneInfo::Categories.empty()) {
+					DevMenu_OpenResourcesBrowser();
+				}
+				else {
+					DevMenu.State = Application::DevMenu_CategorySelectMenu;
+				}
+				break;
 			}
 			break;
 		case 3:

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -3112,6 +3112,7 @@ void Application::DevMenu_OpenResourcesBrowser() {
 	}
 
 	paths.push_back("Scenes");
+	paths.push_back("scenes");
 	paths.push_back("Stages");
 	paths.push_back("");
 

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -129,6 +129,10 @@ bool Application::DisableDefaultActions = false;
 bool Application::DevMenuActivated = false;
 DeveloperMenu Application::DevMenu;
 
+size_t ResourcesBrowserNumEntries = 0;
+std::vector<std::string> ResourcesBrowserEntries;
+std::vector<std::string> ResourcesBrowserPaths;
+
 bool Application::DevConvertModels = false;
 
 bool Application::AllowCmdLineSceneLoad = false;
@@ -2708,6 +2712,16 @@ int Application::HandleAppEvents(void* data, SDL_Event* event) {
 	}
 }
 
+bool Application::IsResourcesBrowserAvailable() {
+	VFSProvider* mainVfs = ResourceManager::GetMainResource();
+	if (!mainVfs) {
+		return false;
+	}
+
+	std::string testPath = "Test/path";
+	return mainVfs->TransformFilename(testPath.c_str()) == testPath;
+}
+
 void Application::DrawDevString(const char* string, int x, int y, int align, bool isSelected) {
 	float scaleX = (float)DevMenu.CurrentWindowWidth / Application::WindowWidth;
 	float scaleY = (float)DevMenu.CurrentWindowHeight / Application::WindowHeight;
@@ -2798,6 +2812,8 @@ void Application::OpenDevMenu() {
 	DevMenu.Fullscreen = Application::WindowFullscreen;
 	DevMenu.WindowBorderless = Application::WindowBorderless;
 
+	DevMenu.ResourcesBrowserAvailable = IsResourcesBrowserAvailable();
+
 	AudioManager::AudioPauseAll();
 	AudioManager::Lock();
 	if (AudioManager::MusicStack.size() > 0) {
@@ -2868,7 +2884,9 @@ void Application::DevMenu_MainMenu() {
 		"Close the application."};
 	DrawDevString(tooltips[DevMenu.Selection], 160, 86, ALIGN_LEFT, true);
 
-	if (DevMenu.Selection == 2 && SceneInfo::Categories.empty()) {
+	if (DevMenu.Selection == 2 &&
+		SceneInfo::Categories.empty() &&
+		!DevMenu.ResourcesBrowserAvailable) {
 		DrawDevString("Warning: No scene list is loaded.", 160, 101, ALIGN_LEFT, false);
 		DrawDevString("This option is disabled.", 160, 116, ALIGN_LEFT, false);
 	}
@@ -2928,7 +2946,10 @@ void Application::DevMenu_MainMenu() {
 			UpdateWindowTitle();
 			break;
 		case 2:
-			if (!SceneInfo::Categories.empty()) {
+			if (SceneInfo::Categories.empty()) {
+				DevMenu_OpenResourcesBrowser();
+			}
+			else {
 				DevMenu.State = Application::DevMenu_CategorySelectMenu;
 			}
 			break;
@@ -3039,6 +3060,246 @@ void Application::DevMenu_CategorySelectMenu() {
 			DevMenu.Timer = 1 * FrameTimeDesired;
 		}
 	}
+}
+
+void Application::DevMenu_OpenResourcesBrowser() {
+	if (!DevMenu.ResourcesBrowserAvailable) {
+		return;
+	}
+
+	std::vector<std::string> paths;
+
+	if (Scene::CurrentScene[0] != '\0') {
+		const char* sep = strrchr(Scene::CurrentScene, '/');
+		if (sep) {
+			std::string currentPath = std::string(Scene::CurrentScene);
+			paths.push_back(currentPath.substr(0, sep - Scene::CurrentScene));
+		}
+	}
+
+	paths.push_back("Scenes");
+	paths.push_back("Stages");
+	paths.push_back("");
+
+	if (!DevMenu_ResourcesBrowserTryGoToPaths(paths)) {
+		return;
+	}
+
+	DevMenu.State = DevMenu_ResourcesBrowserMenu;
+	DevMenu.SubScrollPos = 0;
+}
+
+bool Application::DevMenu_ResourcesBrowserTryGoToPaths(std::vector<std::string> paths) {
+	for (size_t i = 0; i < paths.size(); i++) {
+		std::string path = paths[i];
+
+		if (!DevMenu_GetDirectories(path.c_str())) {
+			continue;
+		}
+
+		if (ResourcesBrowserNumEntries > 0) {
+			// Add the path components
+			ResourcesBrowserPaths.clear();
+
+			if (path != "") {
+				char* currentPath = StringUtils::Duplicate(path.c_str());
+				while (true) {
+					ResourcesBrowserPaths.insert(ResourcesBrowserPaths.begin(),
+						std::string(currentPath) + "/");
+
+					char* sep = strrchr(currentPath, '/');
+					if (!sep) {
+						break;
+					}
+
+					*sep = '\0';
+				}
+				Memory::Free(currentPath);
+			}
+
+			if (path != "") {
+				ResourcesBrowserEntries.insert(ResourcesBrowserEntries.begin(), PARENT_DIRECTORY);
+			}
+
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool Application::DevMenu_ResourcesBrowserGoToPath(std::string path, std::string parentPath) {
+	if (path == PARENT_DIRECTORY) {
+		ResourcesBrowserPaths.pop_back();
+
+		if (ResourcesBrowserPaths.size() > 0) {
+			path = ResourcesBrowserPaths.back();
+		}
+		else {
+			path = "";
+		}
+	}
+	else {
+		path = parentPath + path;
+
+		ResourcesBrowserPaths.push_back(path);
+	}
+
+	if (!DevMenu_GetDirectories(path.c_str())) {
+		return false;
+	}
+
+	if (ResourcesBrowserPaths.size() > 0) {
+		ResourcesBrowserEntries.insert(ResourcesBrowserEntries.begin(), PARENT_DIRECTORY);
+	}
+
+	return true;
+}
+
+bool Application::DevMenu_GetDirectories(const char* path) {
+	VFSEnumerationOptions options;
+	options.OnlyCurrentDirectory = true;
+
+	VFSProvider* mainVfs = ResourceManager::GetMainResource();
+	if (!mainVfs) {
+		return false;
+	}
+
+	VFSEnumeration enumeration = mainVfs->EnumerateFiles(path, options);
+	VFSEnumerationResult result = enumeration.Result;
+	if (result != VFSEnumerationResult::NO_RESULTS && result != VFSEnumerationResult::SUCCESS) {
+		return false;
+	}
+
+	ResourcesBrowserEntries.clear();
+
+	for (size_t i = 0; i < enumeration.Entries.size(); i++) {
+		ResourcesBrowserEntries.push_back(enumeration.Entries[i]);
+	}
+
+	ResourcesBrowserNumEntries = ResourcesBrowserEntries.size();
+
+	return true;
+}
+
+void Application::DevMenu_ResourcesBrowserMenu() {
+	DevMenu_DrawMainMenu();
+
+	char title[MAX_PATH_LENGTH + 10];
+	std::string currentPath;
+	if (ResourcesBrowserPaths.size() > 0) {
+		currentPath = ResourcesBrowserPaths.back();
+	}
+	snprintf(title, sizeof title, "Browsing /%s", currentPath.c_str());
+
+	DrawDevString(title, Application::WindowWidth / 2, 50, ALIGN_CENTER, true);
+
+	for (size_t i = 0, y = 86; i < 8 && DevMenu.SubScrollPos + i < ResourcesBrowserEntries.size();
+		i++, y += 14) {
+		const char* entry = ResourcesBrowserEntries[DevMenu.SubScrollPos + i].c_str();
+		if (strcmp(entry, PARENT_DIRECTORY) == 0) {
+			entry = "Back...";
+		}
+
+		DrawDevString(entry,
+			160,
+			y,
+			ALIGN_LEFT,
+			(DevMenu.SubSelection - DevMenu.SubScrollPos) == i);
+	}
+
+	int actionUp = InputManager::GetActionID("Up");
+	int actionDown = InputManager::GetActionID("Down");
+
+	if ((actionUp != -1 &&
+		    (InputManager::IsActionPressedByAny(actionUp) ||
+			    (InputManager::IsActionHeldByAny(actionUp) && !DevMenu.Timer))) ||
+		(actionDown != -1 &&
+			(InputManager::IsActionPressedByAny(actionDown) ||
+				(InputManager::IsActionHeldByAny(actionDown) && !DevMenu.Timer)))) {
+
+		DevMenu.SubSelection =
+			(DevMenu.SubSelection +
+				(((actionUp != -1 &&
+					  InputManager::IsActionPressedByAny(actionUp)) ||
+					 (actionUp != -1 &&
+						 InputManager::IsActionHeldByAny(actionUp)))
+						? -1
+						: 1) +
+				(int)ResourcesBrowserEntries.size()) %
+			(int)ResourcesBrowserEntries.size();
+
+		if (DevMenu.SubSelection >= DevMenu.SubScrollPos) {
+			if (DevMenu.SubSelection > DevMenu.SubScrollPos + 7) {
+				DevMenu.SubScrollPos = DevMenu.SubSelection - 7;
+			}
+		}
+		else {
+			DevMenu.SubScrollPos = DevMenu.SubSelection;
+		}
+
+		DevMenu.Timer = 8 * FrameTimeDesired;
+	}
+
+	if (DevMenu.Timer > 0) {
+		DevMenu.Timer = std::max(DevMenu.Timer - DeltaTime, 0.0);
+	}
+
+	bool confirm = false;
+	for (const char* action : {"A", "Start"}) {
+		int actionID = InputManager::GetActionID(action);
+		if (actionID != -1 && InputManager::IsActionPressedByAny(actionID)) {
+			confirm = true;
+			break;
+		}
+	}
+
+	if (confirm) {
+		std::string path = ResourcesBrowserEntries[DevMenu.SubSelection];
+
+		if (path.back() == '/' || path == PARENT_DIRECTORY) {
+			std::string parentPath;
+			if (ResourcesBrowserPaths.size() > 0) {
+				parentPath = ResourcesBrowserPaths.back();
+			}
+
+			DevMenu_ResourcesBrowserGoToPath(path, parentPath);
+		}
+		else {
+			if (ResourcesBrowserPaths.size() > 0) {
+				path = ResourcesBrowserPaths.back() + path;
+			}
+
+			Scene::ChangeFromPath(path.c_str(), -1);
+			StringUtils::Copy(Scene::NextScene,
+				path.c_str(),
+				sizeof(Scene::NextScene));
+
+			DevMenu_CloseResourcesBrowser();
+			CloseDevMenu();
+			AudioManager::AudioStopAll();
+			AudioManager::ClearMusic();
+			AudioManager::LowPassFilter = 0.0f;
+		}
+
+		DevMenu.SubSelection = 0;
+		DevMenu.SubScrollPos = 0;
+	}
+	else {
+		int actionB = InputManager::GetActionID("B");
+		if (actionB != -1 && InputManager::IsActionPressedByAny(actionB)) {
+			DevMenu_CloseResourcesBrowser();
+
+			DevMenu.State = DevMenu_MainMenu;
+			DevMenu.SubSelection = 0;
+			DevMenu.Timer = 1 * FrameTimeDesired;
+		}
+	}
+}
+
+void Application::DevMenu_CloseResourcesBrowser() {
+	ResourcesBrowserEntries.clear();
+	ResourcesBrowserPaths.clear();
 }
 
 void Application::DevMenu_SceneSelectMenu() {

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -2674,6 +2674,7 @@ void Application::InitSettings() {
 	Application::Settings->SetInteger("dev", "logLevel", logLevel);
 	Application::Settings->SetBool("dev", "trackMemory", false);
 	Application::Settings->SetBool("dev", "autoPerfSnapshots", false);
+	Application::Settings->SetString("dev", "sceneBrowserMode", "default");
 #endif
 }
 void Application::SaveSettings() {
@@ -3434,6 +3435,9 @@ void Application::DevMenu_SettingsMenu() {
 
 	DrawDevString("Change settings...", Application::WindowWidth / 2, 50, ALIGN_CENTER, true);
 
+	const char* browserMode[] = { "(Default)", "(Resources)", "(Scene List)" };
+	const char* browserModeConfig[] = { "default", "resources", "scenelist" };
+
 	std::string labels[] = {
 		"Video Settings",
 		"Audio Settings",
@@ -3445,6 +3449,7 @@ void Application::DevMenu_SettingsMenu() {
 		std::string("Object Region Viewer ") +
 			(Scene::ShowObjectRegions ? "(On)" : "(Off)"),
 		std::string("Hitbox Viewer ") + (Scene::ShowHitboxes ? "(On)" : "(Off)"),
+		std::string("Scene Browser Mode ") + browserMode[DevMenu.SceneBrowserMode]
 	};
 	for (size_t i = 0, y = 86; i < std::size(labels); i++, y += 14) {
 		DrawDevString(labels[i].c_str(), 160, y, ALIGN_LEFT, DevMenu.SubSelection == i);
@@ -3512,6 +3517,10 @@ void Application::DevMenu_SettingsMenu() {
 			break;
 		case 6: // Hitbox Viewer
 			Scene::ShowHitboxes ^= 1;
+			break;
+		case 7: // Scene Browser Mode
+			DevMenu.SceneBrowserMode = (DevMenu.SceneBrowserMode + 1) % 3;
+			Application::Settings->SetString("dev", "sceneBrowserMode", browserModeConfig[DevMenu.SceneBrowserMode]);
 			break;
 		}
 	}

--- a/source/Engine/Application.h
+++ b/source/Engine/Application.h
@@ -81,6 +81,7 @@ private:
 	static void LoadGameInfo();
 	static void DisposeSettings();
 	static int HandleAppEvents(void* data, SDL_Event* event);
+	static bool IsResourcesBrowserAvailable();
 	static void DrawDevString(const char* string, int x, int y, int align, bool isSelected);
 	static void OpenDevMenu();
 	static void CloseDevMenu();
@@ -92,6 +93,12 @@ private:
 	static void DevMenu_DrawTitleBar();
 	static void DevMenu_MainMenu();
 	static void DevMenu_CategorySelectMenu();
+	static void DevMenu_OpenResourcesBrowser();
+	static bool DevMenu_ResourcesBrowserTryGoToPaths(std::vector<std::string> paths);
+	static bool DevMenu_ResourcesBrowserGoToPath(std::string path, std::string parentPath);
+	static bool DevMenu_GetDirectories(const char* path);
+	static void DevMenu_ResourcesBrowserMenu();
+	static void DevMenu_CloseResourcesBrowser();
 	static void DevMenu_SceneSelectMenu();
 	static void DevMenu_SettingsMenu();
 	static void DevMenu_VideoMenu();

--- a/source/Engine/Application.h
+++ b/source/Engine/Application.h
@@ -2,6 +2,7 @@
 #define ENGINE_APPLICATION_H
 
 #include <Engine/Audio/AudioManager.h>
+#include <Engine/DeveloperMenu.h>
 #include <Engine/Diagnostics/PerformanceTypes.h>
 #include <Engine/Filesystem/Path.h>
 #include <Engine/Includes/Operation.h>

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -13053,33 +13053,22 @@ This does not load the scene. You must call <ref Scene.Load>.
  */
 VMValue Scene_ChangeFromPath(int argCount, VMValue* args, Uint32 threadID) {
     CHECK_AT_LEAST_ARGCOUNT(1);
-	const char* scenePath = GET_ARG(0, GetString);
+	const char* path = GET_ARG(0, GetString);
     int filter = GET_ARG_OPT(1, GetInteger, 0xFF);
 
-	if (filter == 0)
+	if (filter == 0) {
 		filter = 0xFF;
-	if (filter < 0)
+	}
+	if (filter < 0) {
 		return NULL_VAL;
+	}
 
-	bool found = false;
-	for (size_t i = 0; i < SceneInfo::Categories.size(); i++) {
-        SceneListCategory& category = SceneInfo::Categories[i];
+	if (argCount < 2) {
+		filter = -1;
+	}
 
-		for (size_t j = 0; j < category.Entries.size(); j++) {
-			SceneListEntry& scene = category.Entries[j];
+	Scene::ChangeFromPath(path, filter);
 
-			if (!strcmp(scenePath, SceneInfo::GetFilename(i, j).c_str())) {
-				if (argCount == 2 && !(scene.Filter & filter))
-					continue;
-				Scene::SetCurrent(category.Name, scene.Name);
-				found = true;
-				break;
-			}
-		}
-		if (found) {
-			break;
-		}
-    }
 	return NULL_VAL;
 }
 /***

--- a/source/Engine/DeveloperMenu.h
+++ b/source/Engine/DeveloperMenu.h
@@ -1,0 +1,32 @@
+#ifndef ENGINE_DEVELOPERMENU_H
+#define ENGINE_DEVELOPERMENU_H
+
+#include <Engine/Includes/Standard.h>
+
+enum {
+	SCENEBROWSER_DEFAULT,
+	SCENEBROWSER_RESOURCES,
+	SCENEBROWSER_SCENELIST
+};
+
+struct DeveloperMenu {
+	void (*State)();
+	int Selection;
+	int SubSelection;
+	int ScrollPos;
+	int SubScrollPos;
+	double Timer;
+	bool Fullscreen;
+	int SceneState;
+	int ListPos;
+	int WindowScale;
+	bool WindowBorderless;
+	int CurrentWindowWidth;
+	int CurrentWindowHeight;
+	int PlayerListPos;
+	bool MusicPausedStore;
+	bool ResourcesBrowserAvailable;
+	int SceneBrowserMode;
+};
+
+#endif /* ENGINE_DEVELOPERMENU_H */

--- a/source/Engine/Filesystem/Directory.cpp
+++ b/source/Engine/Filesystem/Directory.cpp
@@ -66,7 +66,7 @@ bool Directory::Create(const char* path) {
 void Directory::GetFiles(std::vector<std::filesystem::path>* files,
 	const char* path,
 	const char* searchPattern,
-	bool allDirs) {
+	SearchOptions options) {
 	char fullpath[MAX_PATH_LENGTH];
 
 #if WIN32
@@ -85,8 +85,11 @@ void Directory::GetFiles(std::vector<std::filesystem::path>* files,
 				continue;
 			}
 
-			if (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-				if (allDirs) {
+			bool isDirectory = (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+			bool isValidPath = false;
+
+			if (isDirectory) {
+				if (options.AllDirs) {
 					snprintf(fullpath,
 						sizeof fullpath,
 						"%s/%s",
@@ -94,8 +97,15 @@ void Directory::GetFiles(std::vector<std::filesystem::path>* files,
 						data.cFileName);
 					Directory::GetFiles(files, fullpath, searchPattern, true);
 				}
+				else if (options.ListDirs) {
+					isValidPath = true;
+				}
 			}
 			else if (StringUtils::WildcardMatch(data.cFileName, searchPattern)) {
+				isValidPath = true;
+			}
+
+			if (isValidPath) {
 				std::string entryName = std::string(data.cFileName);
 
 				std::filesystem::path pathFs =
@@ -104,6 +114,10 @@ void Directory::GetFiles(std::vector<std::filesystem::path>* files,
 
 				std::string tempPath = Path::ToString(pathFs / entryFs);
 				std::replace(tempPath.begin(), tempPath.end(), '\\', '/');
+
+				if (isDirectory) {
+					tempPath += "/";
+				}
 
 				std::filesystem::path finalPath = std::filesystem::u8path(tempPath);
 
@@ -125,8 +139,11 @@ void Directory::GetFiles(std::vector<std::filesystem::path>* files,
 				continue;
 			}
 
-			if (d->d_type == DT_DIR) {
-				if (allDirs) {
+			bool isDirectory = d->d_type == DT_DIR || d->d_type == DT_LNK;
+			bool isValidPath = false;
+
+			if (isDirectory) {
+				if (options.AllDirs) {
 					snprintf(fullpath,
 						sizeof fullpath,
 						"%s/%s",
@@ -134,26 +151,45 @@ void Directory::GetFiles(std::vector<std::filesystem::path>* files,
 						d->d_name);
 					Directory::GetFiles(files, fullpath, searchPattern, true);
 				}
+				else if (options.ListDirs) {
+					isValidPath = true;
+				}
 			}
 			else if (StringUtils::WildcardMatch(d->d_name, searchPattern)) {
+				isValidPath = true;
+			}
+
+			if (isValidPath) {
 				std::string entryName = std::string(d->d_name);
 
 				std::filesystem::path pathFs =
 					std::filesystem::u8path(std::string(path));
 				std::filesystem::path entryFs = std::filesystem::u8path(entryName);
 
-				files->push_back(pathFs / entryFs);
+				std::string tempPath = Path::ToString(pathFs / entryFs);
+				std::replace(tempPath.begin(), tempPath.end(), '\\', '/');
+
+				if (isDirectory) {
+					tempPath += "/";
+				}
+
+				std::filesystem::path finalPath = std::filesystem::u8path(tempPath);
+
+				files->push_back(finalPath);
 			}
 		}
 		closedir(dir);
 	}
 #endif
 }
-std::vector<std::filesystem::path>
-Directory::GetFiles(const char* path, const char* searchPattern, bool allDirs) {
-	std::vector<std::filesystem::path> files;
-	Directory::GetFiles(&files, path, searchPattern, allDirs);
-	return files;
+
+void Directory::GetFiles(std::vector<std::filesystem::path>* files,
+	const char* path,
+	const char* searchPattern,
+	bool allDirs) {
+	SearchOptions options;
+	options.AllDirs = allDirs;
+	GetFiles(files, path, searchPattern, options);
 }
 
 void Directory::GetDirectories(std::vector<std::filesystem::path>* files,

--- a/source/Engine/Filesystem/Directory.h
+++ b/source/Engine/Filesystem/Directory.h
@@ -5,8 +5,17 @@
 
 class Directory {
 public:
+	struct SearchOptions {
+		bool AllDirs = false;
+		bool ListDirs = false;
+	};
+
 	static bool Exists(const char* path);
 	static bool Create(const char* path);
+	static void GetFiles(std::vector<std::filesystem::path>* files,
+		const char* path,
+		const char* searchPattern,
+		SearchOptions options);
 	static void GetFiles(std::vector<std::filesystem::path>* files,
 		const char* path,
 		const char* searchPattern,

--- a/source/Engine/Filesystem/Path.cpp
+++ b/source/Engine/Filesystem/Path.cpp
@@ -193,6 +193,10 @@ bool Path::HasRelativeComponents(const char* path) {
 	return false;
 }
 
+std::string Path::ToAbsolute(std::string path) {
+	return ToString(std::filesystem::absolute(std::filesystem::u8path(path)));
+}
+
 std::string Path::Normalize(std::string path) {
 	std::filesystem::path fsPath = std::filesystem::u8path(path);
 

--- a/source/Engine/Filesystem/Path.h
+++ b/source/Engine/Filesystem/Path.h
@@ -156,6 +156,7 @@ public:
 	static bool IsInDir(const char* dirPath, const char* path);
 	static bool IsInCurrentDir(const char* path);
 	static bool HasRelativeComponents(const char* path);
+	static std::string ToAbsolute(std::string path);
 	static std::string Normalize(std::string path);
 	static std::string Normalize(const char* path);
 	static std::string

--- a/source/Engine/Filesystem/VFS/ArchiveVFS.cpp
+++ b/source/Engine/Filesystem/VFS/ArchiveVFS.cpp
@@ -2,6 +2,8 @@
 #include <Engine/IO/MemoryStream.h>
 #include <Engine/Utilities/StringUtils.h>
 
+#include <set>
+
 bool ArchiveVFS::AddEntry(VFSEntry* entry) {
 	// This adds the entry directly, without doing any filename transformation
 	// or modifying the entry name.
@@ -121,7 +123,7 @@ bool ArchiveVFS::EraseFile(const char* filename) {
 	return false;
 }
 
-VFSEnumeration ArchiveVFS::EnumerateFiles(const char* path) {
+VFSEnumeration ArchiveVFS::EnumerateFiles(const char* path, VFSEnumerationOptions options) {
 	VFSEnumeration enumeration;
 
 	if (NumEntries == 0) {
@@ -129,11 +131,37 @@ VFSEnumeration ArchiveVFS::EnumerateFiles(const char* path) {
 		return enumeration;
 	}
 
+	bool hasStartingPath = path != nullptr && path[0] != '\0';
+	size_t startingPathLength = hasStartingPath ? strlen(path) : 0;
+
+	std::set<std::string> dirs;
+
 	for (size_t i = 0; i < NumEntries; i++) {
 		std::string entryName = EntryNames[i];
-		if (path != nullptr && path[0] != '\0' &&
-			!StringUtils::StartsWith(entryName.c_str(), path)) {
+		if (hasStartingPath && !StringUtils::StartsWith(entryName.c_str(), path)) {
 			continue;
+		}
+
+		if (options.OnlyCurrentDirectory) {
+			const char* relPath = entryName.c_str();
+
+			relPath += startingPathLength;
+
+			if (relPath[0] == '/') {
+				relPath++;
+			}
+
+			entryName = std::string(relPath);
+
+			const char* sep = strchr(relPath, '/');
+			if (sep) {
+				entryName = entryName.substr(0, sep - relPath);
+				if (!dirs.count(entryName)) {
+					enumeration.Entries.push_back(entryName + "/");
+					dirs.insert(entryName);
+				}
+				continue;
+			}
 		}
 
 		enumeration.Entries.push_back(entryName);

--- a/source/Engine/Filesystem/VFS/ArchiveVFS.h
+++ b/source/Engine/Filesystem/VFS/ArchiveVFS.h
@@ -28,7 +28,7 @@ public:
 	virtual bool ReadEntryData(VFSEntry* entry, Uint8* memory, size_t memSize);
 	virtual bool PutFile(const char* filename, VFSEntry* entry);
 	virtual bool EraseFile(const char* filename);
-	virtual VFSEnumeration EnumerateFiles(const char* path);
+	virtual VFSEnumeration EnumerateFiles(const char* path, VFSEnumerationOptions options);
 	virtual Stream* OpenReadStream(const char* filename);
 	virtual Stream* OpenWriteStream(const char* filename);
 	virtual Stream* OpenAppendStream(const char* filename);

--- a/source/Engine/Filesystem/VFS/FileSystemVFS.cpp
+++ b/source/Engine/Filesystem/VFS/FileSystemVFS.cpp
@@ -171,7 +171,7 @@ bool FileSystemVFS::EraseFile(const char* filename) {
 	return false;
 }
 
-VFSEnumeration FileSystemVFS::EnumerateFiles(const char* path) {
+VFSEnumeration FileSystemVFS::EnumerateFiles(const char* path, VFSEnumerationOptions options) {
 	VFSEnumeration enumeration;
 
 	std::string fullPath = ParentPath;
@@ -194,8 +194,12 @@ VFSEnumeration FileSystemVFS::EnumerateFiles(const char* path) {
 		fullPathLength++;
 	}
 
+	Directory::SearchOptions searchOptions;
+	searchOptions.AllDirs = !options.OnlyCurrentDirectory;
+	searchOptions.ListDirs = !searchOptions.AllDirs;
+
 	std::vector<std::filesystem::path> results;
-	Directory::GetFiles(&results, fullPath.c_str(), "*", true);
+	Directory::GetFiles(&results, fullPath.c_str(), "*", searchOptions);
 	Directory::SortEntries(&results);
 
 	for (size_t i = 0; i < results.size(); i++) {

--- a/source/Engine/Filesystem/VFS/FileSystemVFS.h
+++ b/source/Engine/Filesystem/VFS/FileSystemVFS.h
@@ -27,7 +27,7 @@ public:
 	virtual bool ReadFile(const char* filename, Uint8** out, size_t* size);
 	virtual bool PutFile(const char* filename, VFSEntry* entry);
 	virtual bool EraseFile(const char* filename);
-	virtual VFSEnumeration EnumerateFiles(const char* path);
+	virtual VFSEnumeration EnumerateFiles(const char* path, VFSEnumerationOptions options);
 	virtual Stream* OpenReadStream(const char* filename);
 	virtual Stream* OpenWriteStream(const char* filename);
 	virtual Stream* OpenAppendStream(const char* filename);

--- a/source/Engine/Filesystem/VFS/HatchVFS.cpp
+++ b/source/Engine/Filesystem/VFS/HatchVFS.cpp
@@ -238,14 +238,14 @@ bool HatchVFS::EraseFile(const char* filename) {
 	return false;
 }
 
-VFSEnumeration HatchVFS::EnumerateFiles(const char* path) {
+VFSEnumeration HatchVFS::EnumerateFiles(const char* path, VFSEnumerationOptions options) {
 	if (path != nullptr && path[0] != '\0') {
 		VFSEnumeration enumeration;
 		enumeration.Result = VFSEnumerationResult::CANNOT_ENUMERATE_RELATIVELY;
 		return enumeration;
 	}
 
-	return ArchiveVFS::EnumerateFiles(path);
+	return ArchiveVFS::EnumerateFiles(path, options);
 }
 
 Stream* HatchVFS::OpenMemStreamForEntry(VFSEntry* entry) {

--- a/source/Engine/Filesystem/VFS/HatchVFS.h
+++ b/source/Engine/Filesystem/VFS/HatchVFS.h
@@ -24,7 +24,7 @@ public:
 	virtual bool ReadEntryData(VFSEntry* entry, Uint8* memory, size_t memSize);
 	virtual bool PutFile(const char* filename, VFSEntry* entry);
 	virtual bool EraseFile(const char* filename);
-	virtual VFSEnumeration EnumerateFiles(const char* path);
+	virtual VFSEnumeration EnumerateFiles(const char* path, VFSEnumerationOptions options);
 	virtual bool Flush();
 	virtual void Close();
 };

--- a/source/Engine/Filesystem/VFS/VFSProvider.cpp
+++ b/source/Engine/Filesystem/VFS/VFSProvider.cpp
@@ -64,7 +64,7 @@ bool VFSProvider::EraseFile(const char* filename) {
 }
 
 // Note that this may return the transformed filenames, depending on the provider.
-VFSEnumeration VFSProvider::EnumerateFiles(const char* path) {
+VFSEnumeration VFSProvider::EnumerateFiles(const char* path, VFSEnumerationOptions options) {
 	VFSEnumeration enumeration;
 	enumeration.Result = VFSEnumerationResult::NO_RESULTS;
 

--- a/source/Engine/Filesystem/VFS/VFSProvider.h
+++ b/source/Engine/Filesystem/VFS/VFSProvider.h
@@ -30,6 +30,10 @@ struct VFSEnumeration {
 	std::vector<std::string> Entries;
 };
 
+struct VFSEnumerationOptions {
+	bool OnlyCurrentDirectory = false;
+};
+
 class VFSProvider {
 private:
 	std::string MountPoint;
@@ -62,7 +66,7 @@ public:
 	virtual bool ReadFile(const char* filename, Uint8** out, size_t* size);
 	virtual bool PutFile(const char* filename, VFSEntry* entry);
 	virtual bool EraseFile(const char* filename);
-	virtual VFSEnumeration EnumerateFiles(const char* path);
+	virtual VFSEnumeration EnumerateFiles(const char* path, VFSEnumerationOptions options);
 	virtual Stream* OpenReadStream(const char* filename);
 	virtual Stream* OpenWriteStream(const char* filename);
 	virtual Stream* OpenAppendStream(const char* filename);

--- a/source/Engine/Includes/Standard.h
+++ b/source/Engine/Includes/Standard.h
@@ -68,25 +68,6 @@ enum class KeyBind {
 	Max
 };
 
-struct DeveloperMenu {
-	void (*State)();
-	int Selection;
-	int SubSelection;
-	int ScrollPos;
-	int SubScrollPos;
-	double Timer;
-	bool Fullscreen;
-	int SceneState;
-	int ListPos;
-	int WindowScale;
-	bool WindowBorderless;
-	int CurrentWindowWidth;
-	int CurrentWindowHeight;
-	int PlayerListPos;
-	bool MusicPausedStore;
-	bool ResourcesBrowserAvailable;
-};
-
 #define DEFAULT_TARGET_FRAMERATE 60
 
 #define MAX_TARGET_FRAMERATE 240

--- a/source/Engine/Includes/Standard.h
+++ b/source/Engine/Includes/Standard.h
@@ -84,6 +84,7 @@ struct DeveloperMenu {
 	int CurrentWindowHeight;
 	int PlayerListPos;
 	bool MusicPausedStore;
+	bool ResourcesBrowserAvailable;
 };
 
 #define DEFAULT_TARGET_FRAMERATE 60
@@ -130,6 +131,8 @@ typedef int64_t Sint64;
 #define HITBOX_RIGHT 2
 #define HITBOX_BOTTOM 3
 #define NUM_HITBOX_SIDES 4
+
+#define PARENT_DIRECTORY ".."
 
 #ifdef IOS
 #define NEW_STRUCT_MACRO(n) (n)

--- a/source/Engine/ResourceTypes/SceneFormats/RSDKSceneReader.cpp
+++ b/source/Engine/ResourceTypes/SceneFormats/RSDKSceneReader.cpp
@@ -151,6 +151,10 @@ void RSDKSceneReader::LoadObjectList() {
 	}
 
 	size_t sz = r->Length();
+	if (sz == 0) {
+		return;
+	}
+
 	ObjectNames = (char*)malloc(sz + 1);
 	r->ReadBytes(ObjectNames, sz);
 	ObjectNames[sz] = 0;
@@ -597,7 +601,14 @@ bool RSDKSceneReader::Read(Stream* r, const char* parentFolder) {
 		RSDKSceneReader::Initialized = true;
 	}
 
+	if (r->ReadUInt32BE() != 0x53434E00) {
+		Log::Print(Log::LOG_ERROR, "Not an RSDKv5 scene!");
+		r->Close();
+		return false;
+	}
+
 	if (!ObjectNames) {
+		Log::Print(Log::LOG_ERROR, "ObjectList.txt missing or empty!");
 		r->Close();
 		return false;
 	}
@@ -611,69 +622,67 @@ bool RSDKSceneReader::Read(Stream* r, const char* parentFolder) {
 	Scene::PriorityPerLayer = 16;
 	Scene::InitPriorityLists();
 
-	if (r->ReadUInt32BE() == 0x53434E00) {
-		r->Skip(16); // 16 bytes
-		r->Skip(r->ReadByte()); // RSDKString
+	r->Skip(16); // 16 bytes
+	r->Skip(r->ReadByte()); // RSDKString
 
-		r->ReadByte();
+	r->ReadByte();
 
-		double ticks = Clock::GetTicks();
+	double ticks = Clock::GetTicks();
 
-		// Read layers
-		Uint32 layerCount = r->ReadByte();
-		for (Uint32 i = 0; i < layerCount; i++) {
-			TileLayer* layer = RSDKSceneReader::ReadLayer(r);
+	// Read layers
+	Uint32 layerCount = r->ReadByte();
+	for (Uint32 i = 0; i < layerCount; i++) {
+		TileLayer* layer = RSDKSceneReader::ReadLayer(r);
 
-			Log::Print(Log::LOG_VERBOSE,
-				"Layer %d (%s): Width (%d) Height (%d) DrawGroup (%d)",
-				i,
-				layer->Name,
-				layer->Width,
-				layer->Height,
-				layer->DrawGroup);
+		Log::Print(Log::LOG_VERBOSE,
+			"Layer %d (%s): Width (%d) Height (%d) DrawGroup (%d)",
+			i,
+			layer->Name,
+			layer->Width,
+			layer->Height,
+			layer->DrawGroup);
 
-			Scene::AddLayer(layer);
-		}
+		Scene::AddLayer(layer);
+	}
 
-		ticks = Clock::GetTicks() - ticks;
-		Log::Print(Log::LOG_VERBOSE, "Scene Layer load took %.3f milliseconds.", ticks);
+	ticks = Clock::GetTicks() - ticks;
+	Log::Print(Log::LOG_VERBOSE, "Scene Layer load took %.3f milliseconds.", ticks);
 
-		// Read objects
-		ticks = Clock::GetTicks();
+	// Read objects
+	ticks = Clock::GetTicks();
 
-		int objectDefinitionCount = r->ReadByte();
-		Log::Print(Log::LOG_VERBOSE, "Object Definition Count: %d", objectDefinitionCount);
+	int objectDefinitionCount = r->ReadByte();
+	Log::Print(Log::LOG_VERBOSE, "Object Definition Count: %d", objectDefinitionCount);
 
-		Scene::AddManagers();
+	Scene::AddManagers();
 
-		int maxObjSlots = 0x940;
-		Entity** objSlots = (Entity**)calloc(maxObjSlots, sizeof(Entity*));
-		if (!objSlots) {
-			Log::Print(Log::LOG_ERROR, "Could not allocate memory for object slots!");
-			r->Close();
+	int maxObjSlots = 0x940;
+	Entity** objSlots = (Entity**)calloc(maxObjSlots, sizeof(Entity*));
+	if (!objSlots) {
+		Log::Print(Log::LOG_ERROR, "Could not allocate memory for object slots!");
+		r->Close();
+		return false;
+	}
+
+	// Read each object definition
+	for (int i = 0; i < objectDefinitionCount; i++) {
+		if (!ReadObjectDefinition(r, objSlots, maxObjSlots)) {
+			free(objSlots);
 			return false;
 		}
-
-		// Read each object definition
-		for (int i = 0; i < objectDefinitionCount; i++) {
-			if (!ReadObjectDefinition(r, objSlots, maxObjSlots)) {
-				free(objSlots);
-				return false;
-			}
-		}
-
-		// Add all objects to the static object list
-		for (int i = 0; i < maxObjSlots; i++) {
-			if (objSlots[i]) {
-				Scene::AddStatic(objSlots[i]->List, objSlots[i]);
-			}
-		}
-
-		free(objSlots);
-
-		ticks = Clock::GetTicks() - ticks;
-		Log::Print(Log::LOG_VERBOSE, "Scene Object load took %.3f milliseconds.", ticks);
 	}
+
+	// Add all objects to the static object list
+	for (int i = 0; i < maxObjSlots; i++) {
+		if (objSlots[i]) {
+			Scene::AddStatic(objSlots[i]->List, objSlots[i]);
+		}
+	}
+
+	free(objSlots);
+
+	ticks = Clock::GetTicks() - ticks;
+	Log::Print(Log::LOG_VERBOSE, "Scene Object load took %.3f milliseconds.", ticks);
 
 	r->Close();
 

--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -2235,6 +2235,27 @@ void Scene::ReadSceneFile(const char* filename) {
 	}
 }
 
+bool Scene::ChangeFromPath(const char* path, int filter) {
+	for (size_t i = 0; i < SceneInfo::Categories.size(); i++) {
+		SceneListCategory& category = SceneInfo::Categories[i];
+
+		for (size_t j = 0; j < category.Entries.size(); j++) {
+			SceneListEntry& scene = category.Entries[j];
+
+			if (!strcmp(path, SceneInfo::GetFilename(i, j).c_str())) {
+				if (filter != -1 && !(scene.Filter & filter)) {
+					continue;
+				}
+
+				Scene::SetCurrent(category.Name, scene.Name);
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 void Scene::ProcessSceneTimer() {
 	if (Scene::TimeEnabled) {
 		Scene::TimeCounter += 100;

--- a/source/Engine/Scene.h
+++ b/source/Engine/Scene.h
@@ -176,6 +176,7 @@ public:
 	static void Unload();
 	static void Prepare();
 	static void LoadScene(const char* filename);
+	static bool ChangeFromPath(const char* path, int filter);
 	static void AddStaticClass();
 	static void CallGameStart();
 	static void ProcessSceneTimer();


### PR DESCRIPTION
<img width="1280" height="748" alt="image" src="https://github.com/user-attachments/assets/aefb1389-abb0-497d-a7d6-2de051224437" />

Adds an alternative resources browsing mode to the scene select in the developer menu. This is the default if there is no scene list loaded, but it can be changed through the `dev/sceneBrowserMode` setting. Accepted options are `resources`, `scenelist`, and `default`. If the resources cannot be navigated through directories, this browsing mode does not work (for example: using a .hatch file.)