### PR TITLE
Fix external Tiled tilesets not using the expected parent path

### DIFF
--- a/source/Engine/Graphics.cpp
+++ b/source/Engine/Graphics.cpp
@@ -2863,6 +2863,10 @@ void Graphics::DrawTileLayer_HorizontalParallax(TileLayer* layer, View* currentV
 				continue;
 			}
 
+			if ((size_t)tileID >= Scene::TileSpriteInfos.size()) {
+				continue;
+			}
+
 			TileSpriteInfo& info = Scene::TileSpriteInfos[tileID];
 			if (onlyAnimated && !info.IsAnimated) {
 				continue;
@@ -2943,6 +2947,10 @@ void Graphics::DrawTileLayer_HorizontalScrollIndexes(TileLayer* layer, View* cur
 
 			if ((tile & TILE_IDENT_MASK) != Scene::EmptyTile) {
 				int tileID = tile & TILE_IDENT_MASK;
+				if ((size_t)tileID >= Scene::TileSpriteInfos.size()) {
+					continue;
+				}
+
 				TileSpriteInfo& info = Scene::TileSpriteInfos[tileID];
 
 				bool flipX = (tile & TILE_FLIPX_MASK) != 0;

--- a/source/Engine/Rendering/GL/GLRenderer.cpp
+++ b/source/Engine/Rendering/GL/GLRenderer.cpp
@@ -4018,7 +4018,7 @@ void GLRenderer::MakeLayerTileBuffers(TileLayer* layer) {
 		for (int xx = 0; xx < layer->Width; xx++) {
 			size_t tileIndex = xx + (yy << layer->WidthInBits);
 			int tileID = layer->Tiles[tileIndex] & TILE_IDENT_MASK;
-			if (tileID == Scene::EmptyTile) {
+			if (tileID == Scene::EmptyTile || (size_t)tileID >= Scene::TileSpriteInfos.size()) {
 				layer->TileBufferIndexes[tileIndex] = SIZE_MAX;
 				continue;
 			}
@@ -4072,7 +4072,7 @@ void GLRenderer::MakeLayerTileBuffers(TileLayer* layer) {
 		for (int xx = 0; xx < layer->Width; xx++) {
 			int tile = layer->Tiles[xx + (yy << layer->WidthInBits)];
 			int tileID = tile & TILE_IDENT_MASK;
-			if (tileID == Scene::EmptyTile) {
+			if (tileID == Scene::EmptyTile || (size_t)tileID >= Scene::TileSpriteInfos.size()) {
 				continue;
 			}
 
@@ -4178,7 +4178,7 @@ void GLRenderer::RefreshTileBuffersForTileset(TileLayer* layer, size_t tilesetIn
 		for (int xx = 0; xx < layer->Width; xx++) {
 			size_t tileIndex = xx + (yy << layer->WidthInBits);
 			int tileID = layer->Tiles[tileIndex] & TILE_IDENT_MASK;
-			if (tileID == Scene::EmptyTile) {
+			if (tileID == Scene::EmptyTile || (size_t)tileID >= Scene::TileSpriteInfos.size()) {
 				layer->TileBufferIndexes[tileIndex] = SIZE_MAX;
 				continue;
 			}
@@ -4221,7 +4221,7 @@ void GLRenderer::RefreshTileBuffersForTileset(TileLayer* layer, size_t tilesetIn
 		for (int xx = 0; xx < layer->Width; xx++) {
 			int tile = layer->Tiles[xx + (yy << layer->WidthInBits)];
 			int tileID = tile & TILE_IDENT_MASK;
-			if (tileID == Scene::EmptyTile) {
+			if (tileID == Scene::EmptyTile || (size_t)tileID >= Scene::TileSpriteInfos.size()) {
 				continue;
 			}
 
@@ -4284,6 +4284,10 @@ void GLRenderer::UpdateBufferedLayerTile(TileLayer* layer, int x, int y) {
 
 	size_t tileIndex = x + (y << layer->WidthInBits);
 	int tile = layer->Tiles[tileIndex];
+	if ((size_t)tile >= Scene::TileSpriteInfos.size()) {
+		return;
+	}
+
 	TileSpriteInfo info = Scene::TileSpriteInfos[tile & TILE_IDENT_MASK];
 	if (info.IsAnimated) {
 		return;

--- a/source/Engine/ResourceTypes/SceneFormats/TiledMapReader.cpp
+++ b/source/Engine/ResourceTypes/SceneFormats/TiledMapReader.cpp
@@ -431,6 +431,8 @@ void TiledMapReader::LoadTileset(XMLNode* tileset, const char* parentFolder) {
 	XMLNode* tilesetXML = NULL;
 	XMLNode* tilesetNode = NULL;
 
+	char tilesetParentFolder[MAX_RESOURCE_PATH_LENGTH];
+
 	// If this is an external tileset, read the XML from that file.
 	if (tileset->attributes.Exists("source")) {
 		char resourcePath[MAX_RESOURCE_PATH_LENGTH];
@@ -440,6 +442,10 @@ void TiledMapReader::LoadTileset(XMLNode* tileset, const char* parentFolder) {
 			return;
 		}
 
+		// Use the external tileset's location as the parent path for ParseTilesetImage
+		memcpy(tilesetParentFolder, resourcePath, MAX_RESOURCE_PATH_LENGTH);
+		StringUtils::GetPathInPlace(tilesetParentFolder);
+
 		tilesetXML = XMLParser::ParseFromResource(resourcePath);
 		if (!tilesetXML) {
 			return;
@@ -448,6 +454,9 @@ void TiledMapReader::LoadTileset(XMLNode* tileset, const char* parentFolder) {
 	}
 	else {
 		tilesetNode = tileset;
+
+		// Use the .tmx's location as the parent path for ParseTilesetImage
+		StringUtils::Copy(tilesetParentFolder, parentFolder, sizeof(tilesetParentFolder));
 	}
 
 	Tileset* tilesetPtr = nullptr;
@@ -455,7 +464,7 @@ void TiledMapReader::LoadTileset(XMLNode* tileset, const char* parentFolder) {
 	for (size_t e = 0; e < tilesetNode->children.size(); e++) {
 		if (XMLParser::MatchToken(tilesetNode->children[e]->name, "image")) {
 			tilesetPtr =
-				ParseTilesetImage(tilesetNode->children[e], firstgid, parentFolder);
+				ParseTilesetImage(tilesetNode->children[e], firstgid, tilesetParentFolder);
 		}
 		else if (XMLParser::MatchToken(tilesetNode->children[e]->name, "tile")) {
 			ParseTile(tilesetPtr, tilesetNode->children[e]);

--- a/source/Engine/Utilities/StringUtils.cpp
+++ b/source/Engine/Utilities/StringUtils.cpp
@@ -286,6 +286,23 @@ char* StringUtils::GetPath(const char* filename) {
 
 	return path;
 }
+bool StringUtils::GetPathInPlace(char* filename) {
+	if (!filename) {
+		return false;
+	}
+
+	char* sep = strrchr(filename, '/');
+	if (!sep) {
+		sep = strrchr(filename, '\\');
+	}
+	if (!sep) {
+		return false;
+	}
+
+	sep[1] = '\0';
+
+	return true;
+}
 const char* StringUtils::GetFilename(const char* filename) {
 	if (!filename) {
 		return nullptr;

--- a/source/Engine/Utilities/StringUtils.h
+++ b/source/Engine/Utilities/StringUtils.h
@@ -27,6 +27,7 @@ public:
 	static bool ToDecimal(double* dst, string src);
 	static bool HexToUint32(Uint32* dst, const char* hexstr);
 	static char* GetPath(const char* filename);
+	static bool GetPathInPlace(char* filename);
 	static const char* GetFilename(const char* filename);
 	static const char* GetExtension(const char* filename);
 	static char* ReplacePathSeparators(const char* path);


### PR DESCRIPTION
This fixes external tilesets using the path of the .tmx as the parent path for images instead of the path of the .tsx.