### PR TITLE
Allow using values other than strings as keys of maps

### DIFF
--- a/docs/main/manual/scripting/variables.md
+++ b/docs/main/manual/scripting/variables.md
@@ -188,7 +188,7 @@ The following are considered **object types** in HSL:
 | ---------------- | ---------------- | ---------------- |
 | String | Text. | `"Hello world"` |
 | Array | A resizable list of values. | `[ 10, 2.0, "omelette" ]` |
-| Map | A collection of key-value pairs. Other languages also call this type a dictionary. Keys must be strings and are stored in order of insertion. | `{"tankCapacity": 60.0, "color": "red"}` |
+| Map | A collection of key-value pairs. Other languages also call this type a dictionary. Keys are stored in order of insertion. | `{"tankCapacity": 60.0, "color": "red"}` |
 | Class | Contains methods and (optionally) a constructor. Typically used to define entities. | `class Car { ... }` |
 | Function | A callable that accepts arguments and optionally returns a value. When defined inside of a class, a function is called a "method". Some functions are defined natively and execute C++ code. | `event IsVehicle() { return true; }` |
 | Bound method | A method with arguments bound to it. | `IsVehicle.bind(car);` |

--- a/source/Engine/Bytecode/Compiler.cpp
+++ b/source/Engine/Bytecode/Compiler.cpp
@@ -1856,10 +1856,11 @@ ExprContext Compiler::GetMap(ExprContext context) {
 	Uint32 count = 0;
 
 	while (!MatchToken(TOKEN_RIGHT_BRACE)) {
-		ConsumeToken(TOKEN_STRING, "Expected string for map key.");
-		GetString(EXPRCONTEXT_VALUE);
+		// Get key
+		GetExpression();
+		ConsumeToken(TOKEN_COLON, "Expected ':' after map key.");
 
-		ConsumeToken(TOKEN_COLON, "Expected ':' after key string.");
+		// Get value
 		GetExpression();
 		count++;
 

--- a/source/Engine/Bytecode/GarbageCollector.cpp
+++ b/source/Engine/Bytecode/GarbageCollector.cpp
@@ -240,6 +240,9 @@ void GarbageCollector::BlackenObject(Obj* object) {
 	}
 	case OBJ_MAP: {
 		ObjMap* map = (ObjMap*)object;
+		map->Keys->ForAll([](Uint32, VMValue v) -> void {
+			GrayValue(v);
+		});
 		map->Values->ForAll([](Uint32, VMValue v) -> void {
 			GrayValue(v);
 		});

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -678,9 +678,9 @@ VMValue ReturnString(std::string str) {
 }
 
 void AddToMap(ObjMap* map, const char* key, VMValue value) {
-	char* keyString = StringUtils::Duplicate(key);
-	Uint32 hash = map->Keys->HashFunction(keyString, strlen(keyString));
-	map->Keys->Put(hash, keyString);
+	VMValue keyValue = OBJECT_VAL(CopyString(key));
+	Uint32 hash = Value::Hash(keyValue);
+	map->Keys->Put(hash, keyValue);
 	map->Values->Put(hash, value);
 }
 
@@ -8817,8 +8817,13 @@ VMValue Input_GetAnalogActionInput(int argCount, VMValue* args, Uint32 threadID)
 static KeyboardBind* GetKeyboardActionBind(ObjMap* map, Uint32 threadID) {
 	KeyboardBind* bind = new KeyboardBind();
 
-	map->Keys->WithAllOrdered([bind, map, threadID](Uint32 hash, char* key) -> void {
+	map->Keys->WithAllOrdered([bind, map, threadID](Uint32 hash, VMValue keyValue) -> void {
 		VMValue value;
+		if (!IS_STRING(keyValue)) {
+			return;
+		}
+
+		char* key = AS_CSTRING(keyValue);
 
 		// key: Integer
 		if (strcmp("key", key) == 0) {
@@ -8859,8 +8864,13 @@ static KeyboardBind* GetKeyboardActionBind(ObjMap* map, Uint32 threadID) {
 static ControllerButtonBind* GetControllerButtonActionBind(ObjMap* map, Uint32 threadID) {
 	ControllerButtonBind* bind = new ControllerButtonBind();
 
-	map->Keys->WithAllOrdered([&bind, map, threadID](Uint32 hash, char* key) -> void {
+	map->Keys->WithAllOrdered([&bind, map, threadID](Uint32 hash, VMValue keyValue) -> void {
 		VMValue value;
+		if (!IS_STRING(keyValue)) {
+			return;
+		}
+
+		char* key = AS_CSTRING(keyValue);
 
 		// button: Integer
 		if (strcmp("button", key) == 0) {
@@ -8890,8 +8900,13 @@ static ControllerButtonBind* GetControllerButtonActionBind(ObjMap* map, Uint32 t
 static ControllerAxisBind* GetControllerAxisActionBind(ObjMap* map, Uint32 threadID) {
 	ControllerAxisBind* bind = new ControllerAxisBind();
 
-	map->Keys->WithAllOrdered([&bind, map, threadID](Uint32 hash, char* key) -> void {
+	map->Keys->WithAllOrdered([&bind, map, threadID](Uint32 hash, VMValue keyValue) -> void {
 		VMValue value;
+		if (!IS_STRING(keyValue)) {
+			return;
+		}
+
+		char* key = AS_CSTRING(keyValue);
 
 		// axis: Integer
 		if (strcmp("axis", key) == 0) {
@@ -9938,13 +9953,14 @@ static int JSON_FillMap(ObjMap* map, const char* text, jsmntok_t* t, size_t coun
 		return 0;
 	}
 
-	Uint32 keyHash;
 	int tokcount = 0;
 	for (int i = 0; i < t->size; i++) {
 		key = t + 1 + tokcount;
-		keyHash = map->Keys->HashFunction(text + key->start, key->end - key->start);
-		map->Keys->Put(
-			keyHash, StringUtils::Duplicate(text + key->start, key->end - key->start));
+
+		VMValue keyValue = OBJECT_VAL(CopyString(text + key->start, key->end - key->start));
+		Uint32 keyHash = Value::Hash(keyValue);
+		map->Keys->Put(keyHash, keyValue);
+
 		tokcount += 1;
 		if (key->size > 0) {
 			VMValue val = NULL_VAL;
@@ -20059,7 +20075,6 @@ VMValue Window_IsResizeable(int argCount, VMValue* args, Uint32 threadID) {
 // #region XML
 static VMValue XML_FillMap(XMLNode* parent) {
 	ObjMap* map = NewMap();
-	Uint32 keyHash;
 
 	XMLAttributes* attributes = &parent->attributes;
 	size_t numAttr = attributes->KeyVector.size();
@@ -20069,10 +20084,8 @@ static VMValue XML_FillMap(XMLNode* parent) {
 		Token text = parent->children[0]->name;
 
 		if (numAttr) {
-			char* textKey = StringUtils::Duplicate("#text");
-			keyHash = map->Keys->HashFunction(textKey, 5);
-			map->Keys->Put(keyHash, textKey);
-			map->Values->Put(keyHash, OBJECT_VAL(CopyString(text.Start, text.Length)));
+			VMValue value = OBJECT_VAL(CopyString(text.Start, text.Length));
+			AddToMap(map, "#text", value);
 		}
 		else {
 			return OBJECT_VAL(CopyString(text.Start, text.Length));
@@ -20083,7 +20096,8 @@ static VMValue XML_FillMap(XMLNode* parent) {
 			XMLNode* node = parent->children[i];
 
 			Token* nodeName = &node->name;
-			keyHash = map->Keys->HashFunction(nodeName->Start, nodeName->Length);
+			VMValue key = OBJECT_VAL(CopyString(nodeName->Start, nodeName->Length));
+			Uint32 keyHash = Value::Hash(key);
 
 			// If the key already exists, push into it
 			if (map->Keys->Exists(keyHash)) {
@@ -20103,8 +20117,7 @@ static VMValue XML_FillMap(XMLNode* parent) {
 				thisArray->Values->push_back(XML_FillMap(node));
 			}
 			else {
-				map->Keys->Put(keyHash,
-					StringUtils::Duplicate(nodeName->Start, nodeName->Length));
+				map->Keys->Put(keyHash, key);
 				map->Values->Put(keyHash, XML_FillMap(node));
 			}
 		}
@@ -20133,8 +20146,9 @@ static VMValue XML_FillMap(XMLNode* parent) {
 
 		snprintf(attrName, attrNameSize, "#%s", key);
 
-		keyHash = map->Keys->HashFunction(attrName, attrNameSize - 1);
-		map->Keys->Put(keyHash, StringUtils::Duplicate(attrName));
+		VMValue keyValue = OBJECT_VAL(CopyString(attrName, attrNameSize - 1));
+		Uint32 keyHash = Value::Hash(keyValue);
+		map->Keys->Put(keyHash, keyValue);
 		map->Values->Put(keyHash, OBJECT_VAL(CopyString(value)));
 
 		Memory::Free(value);

--- a/source/Engine/Bytecode/TypeImpl/MapImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/MapImpl.cpp
@@ -2,6 +2,7 @@
 #include <Engine/Bytecode/StandardLibrary.h>
 #include <Engine/Bytecode/TypeImpl/MapImpl.h>
 #include <Engine/Bytecode/TypeImpl/TypeImpl.h>
+#include <Engine/Bytecode/Value.h>
 
 /***
 * \class Map
@@ -36,17 +37,12 @@ Obj* MapImpl::Constructor() {
 	Memory::Track(map, "NewMap");
 	map->Object.Class = Class;
 	map->Values = new OrderedHashMap<VMValue>(NULL, 4);
-	map->Keys = new OrderedHashMap<char*>(NULL, 4);
+	map->Keys = new OrderedHashMap<VMValue>(NULL, 4);
 	return (Obj*)map;
 }
 
 void MapImpl::Dispose(Obj* object) {
 	ObjMap* map = (ObjMap*)object;
-
-	// Free keys
-	map->Keys->WithAll([](Uint32, char* ptr) -> void {
-		Memory::Free(ptr);
-	});
 
 	// Free Keys table
 	delete map->Keys;
@@ -74,7 +70,7 @@ VMValue MapImpl::VM_Length(int argCount, VMValue* args, Uint32 threadID) {
 /***
  * \method GetKeys
  * \desc Gets a list of all keys in the map.
- * \return array Returns an array of strings.
+ * \return array Returns an array of values.
  * \ns Map
  */
 VMValue MapImpl::VM_GetKeys(int argCount, VMValue* args, Uint32 threadID) {
@@ -84,8 +80,8 @@ VMValue MapImpl::VM_GetKeys(int argCount, VMValue* args, Uint32 threadID) {
 
 	ObjArray* array = NewArray();
 
-	map->Keys->WithAllOrdered([array](Uint32, char* key) -> void {
-		array->Values->push_back(OBJECT_VAL(CopyString(key)));
+	map->Keys->WithAllOrdered([array](Uint32, VMValue value) -> void {
+		array->Values->push_back(value);
 	});
 
 	return OBJECT_VAL(array);
@@ -94,17 +90,23 @@ VMValue MapImpl::VM_GetKeys(int argCount, VMValue* args, Uint32 threadID) {
 /***
  * \method Remove
  * \desc Removes a key from the map.
- * \param key (string): The key to remove.
+ * \param key (value): The key to remove.
  * \ns Map
  */
 VMValue MapImpl::VM_Remove(int argCount, VMValue* args, Uint32 threadID) {
 	StandardLibrary::CheckArgCount(argCount, 2);
 
 	ObjMap* map = GET_ARG(0, GetMap);
-	const char* key = GET_ARG(1, GetString);
+	VMValue key = args[1];
+	if (IS_NULL(key)) {
+		ScriptManager::Threads[threadID].ThrowRuntimeError(false,
+			"Cannot remove value from map using 'null' as a key.");
+		return NULL_VAL;
+	}
 
-	map->Keys->Remove(key);
-	map->Values->Remove(key);
+	Uint32 hash = Value::Hash(key);
+	map->Keys->Remove(hash);
+	map->Values->Remove(hash);
 
 	return NULL_VAL;
 }

--- a/source/Engine/Bytecode/TypeImpl/MapImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/MapImpl.cpp
@@ -97,14 +97,7 @@ VMValue MapImpl::VM_Remove(int argCount, VMValue* args, Uint32 threadID) {
 	StandardLibrary::CheckArgCount(argCount, 2);
 
 	ObjMap* map = GET_ARG(0, GetMap);
-	VMValue key = args[1];
-	if (IS_NULL(key)) {
-		ScriptManager::Threads[threadID].ThrowRuntimeError(false,
-			"Cannot remove value from map using 'null' as a key.");
-		return NULL_VAL;
-	}
-
-	Uint32 hash = Value::Hash(key);
+	Uint32 hash = Value::Hash(args[1]);
 	map->Keys->Remove(hash);
 	map->Values->Remove(hash);
 

--- a/source/Engine/Bytecode/TypeImpl/MapImpl.cpp
+++ b/source/Engine/Bytecode/TypeImpl/MapImpl.cpp
@@ -117,7 +117,7 @@ VMValue MapImpl::VM_Iterate(int argCount, VMValue* args, Uint32 threadID) {
 		key = map->Values->GetNextKey(GET_ARG(1, GetInteger));
 	}
 
-	if (key) {
+	if (key != 0xFFFFFFFF) {
 		return INTEGER_VAL(key);
 	}
 

--- a/source/Engine/Bytecode/Types.h
+++ b/source/Engine/Bytecode/Types.h
@@ -415,7 +415,7 @@ struct ObjArray {
 struct ObjMap {
 	Obj Object;
 	OrderedHashMap<VMValue>* Values;
-	OrderedHashMap<char*>* Keys;
+	OrderedHashMap<VMValue>* Keys;
 };
 struct ObjNamespace {
 	Obj Object;

--- a/source/Engine/Bytecode/VMThread.cpp
+++ b/source/Engine/Bytecode/VMThread.cpp
@@ -1166,9 +1166,12 @@ int VMThread::RunInstruction() {
 		if (ScriptManager::Lock()) {
 			ObjMap* map = NewMap();
 			for (int i = count - 1; i >= 0; i--) {
-				char* keystr = AS_CSTRING(Peek(i * 2 + 1));
-				map->Values->Put(keystr, Peek(i * 2));
-				map->Keys->Put(keystr, StringUtils::Duplicate(keystr));
+				VMValue key = Peek(i * 2 + 1);
+				if (!IS_NULL(key)) {
+					Uint32 hash = Value::Hash(key);
+					map->Values->Put(hash, Peek(i * 2));
+					map->Keys->Put(hash, key);
+				}
 			}
 			for (int i = count - 1; i >= 0; i--) {
 				Pop();
@@ -2741,23 +2744,18 @@ VMValue VMThread::GetElement(VMValue object, VMValue at) {
 		}
 	}
 	else if (IS_MAP(object)) {
-		if (!IS_STRING(at)) {
+		if (IS_NULL(at)) {
 			ThrowRuntimeError(false,
-				"Cannot get value from map using non-String value as an index.");
+				"Cannot get value from map using 'null' as a key.");
 			return NULL_VAL;
 		}
 
 		if (ScriptManager::Lock()) {
 			ObjMap* map = AS_MAP(object);
-			char* index = AS_CSTRING(at);
-			if (!*index) {
-				ThrowRuntimeError(false, "Cannot find value at empty key.");
-				ScriptManager::Unlock();
-				return NULL_VAL;
-			}
+			Uint32 hash = Value::Hash(at);
 
 			VMValue result;
-			if (!map->Values->GetIfExists(index, &result)) {
+			if (!map->Values->GetIfExists(hash, &result)) {
 				result = NULL_VAL;
 			}
 
@@ -2840,23 +2838,17 @@ VMValue VMThread::SetElement(VMValue object, VMValue at, VMValue value) {
 		}
 	}
 	else if (IS_MAP(object)) {
-		if (!IS_STRING(at)) {
+		if (IS_NULL(at)) {
 			ThrowRuntimeError(false,
-				"Cannot get value from map using non-String value as an index.");
+				"Cannot get value from map using 'null' as a key.");
 			return value;
 		}
 
 		if (ScriptManager::Lock()) {
 			ObjMap* map = AS_MAP(object);
-			char* index = AS_CSTRING(at);
-			if (!*index) {
-				ThrowRuntimeError(false, "Cannot find value at empty key.");
-				ScriptManager::Unlock();
-				return value;
-			}
-
-			map->Values->Put(index, value);
-			map->Keys->Put(index, StringUtils::Duplicate(index));
+			Uint32 hash = Value::Hash(at);
+			map->Values->Put(hash, value);
+			map->Keys->Put(hash, at);
 			ScriptManager::Unlock();
 		}
 	}

--- a/source/Engine/Bytecode/VMThread.cpp
+++ b/source/Engine/Bytecode/VMThread.cpp
@@ -1167,11 +1167,9 @@ int VMThread::RunInstruction() {
 			ObjMap* map = NewMap();
 			for (int i = count - 1; i >= 0; i--) {
 				VMValue key = Peek(i * 2 + 1);
-				if (!IS_NULL(key)) {
-					Uint32 hash = Value::Hash(key);
-					map->Values->Put(hash, Peek(i * 2));
-					map->Keys->Put(hash, key);
-				}
+				Uint32 hash = Value::Hash(key);
+				map->Values->Put(hash, Peek(i * 2));
+				map->Keys->Put(hash, key);
 			}
 			for (int i = count - 1; i >= 0; i--) {
 				Pop();
@@ -2744,12 +2742,6 @@ VMValue VMThread::GetElement(VMValue object, VMValue at) {
 		}
 	}
 	else if (IS_MAP(object)) {
-		if (IS_NULL(at)) {
-			ThrowRuntimeError(false,
-				"Cannot get value from map using 'null' as a key.");
-			return NULL_VAL;
-		}
-
 		if (ScriptManager::Lock()) {
 			ObjMap* map = AS_MAP(object);
 			Uint32 hash = Value::Hash(at);
@@ -2838,12 +2830,6 @@ VMValue VMThread::SetElement(VMValue object, VMValue at, VMValue value) {
 		}
 	}
 	else if (IS_MAP(object)) {
-		if (IS_NULL(at)) {
-			ThrowRuntimeError(false,
-				"Cannot get value from map using 'null' as a key.");
-			return value;
-		}
-
 		if (ScriptManager::Lock()) {
 			ObjMap* map = AS_MAP(object);
 			Uint32 hash = Value::Hash(at);

--- a/source/Engine/Bytecode/Value.cpp
+++ b/source/Engine/Bytecode/Value.cpp
@@ -5,6 +5,8 @@
 
 Uint32 Value::Hash(VMValue value) {
 	switch (value.Type) {
+	case VAL_NULL:
+		return 0;
 	case VAL_INTEGER:
 	case VAL_LINKED_INTEGER: {
 		float val = (float)AS_INTEGER(value);

--- a/source/Engine/Bytecode/Value.cpp
+++ b/source/Engine/Bytecode/Value.cpp
@@ -6,13 +6,13 @@
 Uint32 Value::Hash(VMValue value) {
 	switch (value.Type) {
 	case VAL_INTEGER:
-	case VAL_LINKED_INTEGER:
-		return (Uint32)AS_INTEGER(value);
-	case VAL_DECIMAL:
-	case VAL_LINKED_DECIMAL: {
-		float val = AS_DECIMAL(value);
-		return Murmur::EncryptData(&val, sizeof(float));
+	case VAL_LINKED_INTEGER: {
+		float val = (float)AS_INTEGER(value);
+		return HashDecimal(val);
 	}
+	case VAL_DECIMAL:
+	case VAL_LINKED_DECIMAL:
+		return HashDecimal(AS_DECIMAL(value));
 	case VAL_HITBOX:
 		return Murmur::EncryptData(AS_HITBOX(value), sizeof(Sint16) * NUM_HITBOX_SIDES);
 	case VAL_OBJECT:
@@ -30,6 +30,10 @@ Uint32 Value::Hash(VMValue value) {
 	}
 
 	return 0xFFFFFFFF;
+}
+
+Uint32 Value::HashDecimal(float val) {
+	return Murmur::EncryptData(&val, sizeof(float));
 }
 
 const char* Value::GetObjectTypeName(Uint32 type) {

--- a/source/Engine/Bytecode/Value.cpp
+++ b/source/Engine/Bytecode/Value.cpp
@@ -3,6 +3,35 @@
 #include <Engine/Bytecode/Value.h>
 #include <Engine/Bytecode/ValuePrinter.h>
 
+Uint32 Value::Hash(VMValue value) {
+	switch (value.Type) {
+	case VAL_INTEGER:
+	case VAL_LINKED_INTEGER:
+		return (Uint32)AS_INTEGER(value);
+	case VAL_DECIMAL:
+	case VAL_LINKED_DECIMAL: {
+		float val = AS_DECIMAL(value);
+		return Murmur::EncryptData(&val, sizeof(float));
+	}
+	case VAL_HITBOX:
+		return Murmur::EncryptData(AS_HITBOX(value), sizeof(Sint16) * NUM_HITBOX_SIDES);
+	case VAL_OBJECT:
+		switch (OBJECT_TYPE(value)) {
+		case OBJ_STRING: {
+			ObjString* str = AS_STRING(value);
+			return Murmur::EncryptData(str->Chars, str->Length);
+		}
+		default:
+			return (uintptr_t)value.as.Object;
+		}
+		break;
+	default:
+		break;
+	}
+
+	return 0xFFFFFFFF;
+}
+
 const char* Value::GetObjectTypeName(Uint32 type) {
 	switch (type) {
 	case OBJ_FUNCTION:

--- a/source/Engine/Bytecode/Value.h
+++ b/source/Engine/Bytecode/Value.h
@@ -7,6 +7,9 @@
 #include <Engine/Utilities/PrintBuffer.h>
 
 class Value {
+private:
+	static Uint32 HashDecimal(float val);
+
 public:
 	static Uint32 Hash(VMValue value);
 	static const char* GetPrintableObjectName(VMValue value);

--- a/source/Engine/Bytecode/Value.h
+++ b/source/Engine/Bytecode/Value.h
@@ -8,6 +8,7 @@
 
 class Value {
 public:
+	static Uint32 Hash(VMValue value);
 	static const char* GetPrintableObjectName(VMValue value);
 	static const char* GetObjectTypeName(VMValue value);
 	static const char* GetObjectTypeName(ObjClass* klass);

--- a/source/Engine/Bytecode/ValuePrinter.cpp
+++ b/source/Engine/Bytecode/ValuePrinter.cpp
@@ -178,7 +178,28 @@ void ValuePrinter::PrintMap(ObjMap* map, int indent) {
 
 		hash = map->Values->Keys[i];
 		value = map->Values->Data[hash];
-		buffer_printf(Buffer, "\"%s\": ", map->Keys->Get(hash));
+
+		VMValue keyValue = map->Keys->Get(hash);
+		if (IS_STRING(keyValue)) {
+			buffer_printf(Buffer, "\"%s\": ", AS_CSTRING(keyValue));
+		}
+		else {
+			if (IsJSON) {
+				buffer_printf(Buffer, "\"");
+			}
+			if (IS_OBJECT(keyValue)) {
+				buffer_printf(Buffer, "<%s 0x%x>",
+					Value::GetObjectTypeName(keyValue),
+					AS_OBJECT(keyValue));
+			}
+			else {
+				PrintValue(keyValue, indent + 1);
+			}
+			if (IsJSON) {
+				buffer_printf(Buffer, "\"");
+			}
+			buffer_printf(Buffer, ": ");
+		}
 		PrintValue(value, indent + 1);
 	}
 	if (PrettyPrint) {

--- a/source/Engine/IO/Serializer.cpp
+++ b/source/Engine/IO/Serializer.cpp
@@ -1,13 +1,15 @@
-#include <Engine/IO/Serializer.h>
-
+#include <Engine/Bytecode/Value.h>
 #include <Engine/Diagnostics/Log.h>
+#include <Engine/IO/Serializer.h>
 #include <Engine/Utilities/StringUtils.h>
 
 Uint32 Serializer::Magic = 0x9D939FF0;
-Uint32 Serializer::Version = 0x00000001;
+Uint32 Serializer::Version = 0x00000002;
 
 Serializer::Serializer(Stream* stream) {
 	StreamPtr = stream;
+	CurrentVersion = Serializer::Version;
+
 	ObjToID.clear();
 	ObjList.clear();
 	ChunkList.clear();
@@ -88,23 +90,11 @@ void Serializer::WriteObject(Obj* obj) {
 		WriteObjectPreamble(Serializer::OBJ_TYPE_MAP);
 
 		ObjMap* map = (ObjMap*)obj;
-		Uint32 numKeys = 0;
-		Uint32 numValues = 0;
-		map->Keys->WithAll([&numKeys](Uint32, char*) -> void {
-			numKeys++;
-		});
-		map->Values->WithAll([&numValues](Uint32, VMValue) -> void {
-			numValues++;
-		});
-
-		StreamPtr->WriteUInt32(numKeys);
-		StreamPtr->WriteUInt32(numValues);
-
-		map->Keys->WithAll([this](Uint32, char* ptr) -> void {
-			StreamPtr->WriteUInt32(GetUniqueStringID(ptr, strlen(ptr)));
+		StreamPtr->WriteUInt32(map->Keys->Count());
+		map->Keys->WithAll([this](Uint32 hash, VMValue mapKey) -> void {
+			WriteValue(mapKey);
 		});
 		map->Values->WithAll([this](Uint32 hash, VMValue mapVal) -> void {
-			StreamPtr->WriteUInt32(hash);
 			WriteValue(mapVal);
 		});
 		break;
@@ -243,8 +233,10 @@ void Serializer::AddUniqueObject(Obj* obj) {
 	}
 	case OBJ_MAP: {
 		ObjMap* map = (ObjMap*)obj;
-		map->Keys->WithAll([this](Uint32, char* mapKey) -> void {
-			AddUniqueString(mapKey, strlen(mapKey));
+		map->Keys->WithAll([this](Uint32, VMValue mapKey) -> void {
+			if (IS_OBJECT(mapKey)) {
+				AddUniqueObject(AS_OBJECT(mapKey));
+			}
 		});
 		map->Values->WithAll([this](Uint32, VMValue mapVal) -> void {
 			if (IS_OBJECT(mapVal)) {
@@ -261,7 +253,7 @@ void Serializer::AddUniqueObject(Obj* obj) {
 void Serializer::Store(VMValue val) {
 	// Write header
 	StreamPtr->WriteUInt32(Serializer::Magic);
-	StreamPtr->WriteUInt32(Serializer::Version);
+	StreamPtr->WriteUInt32(CurrentVersion);
 
 	// We're gonna patch this later.
 	size_t chunkAddrPos = StreamPtr->Position();
@@ -382,28 +374,67 @@ void Serializer::ReadObject(Obj* obj) {
 		return;
 	}
 	case Serializer::OBJ_TYPE_MAP: {
-		Uint32 numKeys = StreamPtr->ReadUInt32();
-		Uint32 numValues = StreamPtr->ReadUInt32();
+		std::vector<VMValue> keys;
+
+		Uint32 count = StreamPtr->ReadUInt32();
+
+		if (CurrentVersion == 0x00000001) {
+			// Version 1 writes the amount of values separately from the amount of keys.
+			// Version 2 and newer writes just the amount of keys.
+			StreamPtr->ReadUInt32();
+		}
+
 		ObjMap* map = (ObjMap*)obj;
-		for (Uint32 i = 0; i < numKeys; i++) {
-			Uint32 stringID = StreamPtr->ReadUInt32();
-			if (stringID >= StringList.size()) {
-				Log::Print(
-					Log::LOG_ERROR, "Attempted to read an invalid string ID!");
-				continue;
-			}
-			else if (StringList[stringID].Chars != nullptr) {
-				Uint32 length = StringList[stringID].Length;
-				char* mapKey = StringUtils::Create(
-					(void*)StringList[stringID].Chars, length);
-				if (mapKey) {
-					map->Keys->Put(mapKey, mapKey);
+
+		// Read the keys
+		for (Uint32 i = 0; i < count; i++) {
+			VMValue mapKey = NULL_VAL;
+
+			// Version 1 serializes keys as strings.
+			if (CurrentVersion == 0x00000001) {
+				Uint32 stringID = StreamPtr->ReadUInt32();
+				if (stringID >= StringList.size()) {
+					Log::Print(
+						Log::LOG_ERROR, "Attempted to read an invalid string ID!");
+					continue;
+				}
+				else if (StringList[stringID].Chars != nullptr) {
+					Uint32 length = StringList[stringID].Length;
+					mapKey = OBJECT_VAL(CopyString(StringList[stringID].Chars, length));
 				}
 			}
+			// Version 2 and newer serializes keys as values.
+			else {
+				mapKey = ReadValue();
+			}
+
+			keys.push_back(mapKey);
+
+			// Ensure null doesn't get added as a key.
+			if (IS_NULL(mapKey)) {
+				continue;
+			}
+
+			Uint32 keyHash = Value::Hash(mapKey);
+			map->Keys->Put(keyHash, mapKey);
 		}
-		for (Uint32 i = 0; i < numValues; i++) {
-			Uint32 valueHash = StreamPtr->ReadUInt32();
-			map->Values->Put(valueHash, ReadValue());
+
+		// Read the values
+		for (Uint32 i = 0; i < count; i++) {
+			if (CurrentVersion == 0x00000001) {
+				// Version 1 writes the hash this value belongs to.
+				// Not needed anymore because the keys get re-hashed.
+				StreamPtr->ReadUInt32();
+			}
+
+			VMValue mapKey = keys[i];
+			VMValue value = ReadValue();
+
+			// Don't add values whose keys are null.
+			if (!IS_NULL(mapKey)) {
+				Uint32 keyHash = Value::Hash(mapKey);
+				map->Values->Put(keyHash, value);
+			}
 		}
 		return;
 	}
@@ -506,8 +537,8 @@ VMValue Serializer::Retrieve() {
 		return NULL_VAL;
 	}
 
-	Uint32 version = StreamPtr->ReadUInt32();
-	if (version != Serializer::Version) {
+	CurrentVersion = StreamPtr->ReadUInt32();
+	if (CurrentVersion > Serializer::Version) {
 		Log::Print(Log::LOG_ERROR, "Invalid version!");
 		return NULL_VAL;
 	}

--- a/source/Engine/IO/Serializer.cpp
+++ b/source/Engine/IO/Serializer.cpp
@@ -396,7 +396,6 @@ void Serializer::ReadObject(Obj* obj) {
 				if (stringID >= StringList.size()) {
 					Log::Print(
 						Log::LOG_ERROR, "Attempted to read an invalid string ID!");
-					continue;
 				}
 				else if (StringList[stringID].Chars != nullptr) {
 					Uint32 length = StringList[stringID].Length;
@@ -408,15 +407,9 @@ void Serializer::ReadObject(Obj* obj) {
 				mapKey = ReadValue();
 			}
 
-			keys.push_back(mapKey);
-
-			// Ensure null doesn't get added as a key.
-			if (IS_NULL(mapKey)) {
-				continue;
-			}
-
 			Uint32 keyHash = Value::Hash(mapKey);
 			map->Keys->Put(keyHash, mapKey);
+			keys.push_back(mapKey);
 		}
 
 		// Read the values
@@ -427,14 +420,9 @@ void Serializer::ReadObject(Obj* obj) {
 				StreamPtr->ReadUInt32();
 			}
 
-			VMValue mapKey = keys[i];
 			VMValue value = ReadValue();
-
-			// Don't add values whose keys are null.
-			if (!IS_NULL(mapKey)) {
-				Uint32 keyHash = Value::Hash(mapKey);
-				map->Values->Put(keyHash, value);
-			}
+			Uint32 keyHash = Value::Hash(keys[i]);
+			map->Values->Put(keyHash, value);
 		}
 		return;
 	}

--- a/source/Engine/IO/Serializer.h
+++ b/source/Engine/IO/Serializer.h
@@ -23,6 +23,8 @@ private:
 	void ReadObject(Obj* obj);
 	VMValue ReadValue();
 
+	Uint32 CurrentVersion;
+
 public:
 	std::map<Obj*, Uint32> ObjToID;
 	std::vector<Obj*> ObjList;

--- a/source/Engine/Includes/OrderedHashMap.h
+++ b/source/Engine/Includes/OrderedHashMap.h
@@ -78,14 +78,14 @@ public:
 		if (Keys.size() > 0) {
 			return Keys[0];
 		}
-		return 0;
+		return 0xFFFFFFFF;
 	}
 	Uint32 GetNextKey(Uint32 key) {
 		auto it = std::find(Keys.begin(), Keys.end(), key);
 		if (it != Keys.end() && it + 1 != Keys.end()) {
 			return *(it + 1);
 		}
-		return 0;
+		return 0xFFFFFFFF;
 	}
 
 	~OrderedHashMap<T>() {


### PR DESCRIPTION
Allows using any value type as the key of a map. Resolves #213.

Strings and numbers that are equal are considered the same key. `true` and `false` are considered the same as `1` and `0` respectively. Objects (arrays, maps, etc.) that may have the same contents but aren't actually the same object are considered different keys.

NOTE: `Serializer` currently cannot serialize all kinds of values, so when serializing a map, keys must be strings, numbers, arrays, maps, hitboxes, or `null`.

```js
var arr = [ 1, 2, 3 ];
var map = {
    "abc": 123,
    456.0: "def",
    arr: "ghi",
    null: "nothing",
    Application: "app"
};

print map["abc"];
print map[456];
print map[arr];
print map[null];
print map[Application];

print map;
print map.GetKeys();

for (value in map) {
    print value;
}
```

```
     INFO: 123
     INFO: def
     INFO: ghi
     INFO: nothing
     INFO: app
     INFO: {"abc": 123,456.000000: "def",<array 0x8abf50e0>: "ghi",null: "nothing",<class 0x8aca6a10>: "app"}
     INFO: ["abc",456.000000,[1,2,3],null,<class Application>]
     INFO: 123
     INFO: def
     INFO: ghi
     INFO: nothing
     INFO: app
```