### PR TITLE
Add `--project-file`, `--resource-file`, and `--scripts-dir` command line options

### DIFF
--- a/docs/main/manual/command_line_options.md
+++ b/docs/main/manual/command_line_options.md
@@ -2,12 +2,13 @@
 
 **Command Line Options** are arguments specified when running Hatch. They alter the behavior of the application in some way, such as loading a specific scene, or loading a resource file from a given path. Examples of ways command line options can be given to the application are running Hatch from a terminal, launching it from a shell script, or specified in a Windows shortcut.
 
-All command line options are prefixed by `--` (two hyphens). Additionally, a path to a .hatch file or to a file inside the `Resources/` directory can be specified directly after the path to the executable, which respectively will load a resource file or a scene file.
+All command line options are prefixed by `--` (two hyphens). Additionally, a path to a .hatch file or to a file inside the Resources directory can be specified directly after the path to the executable, which respectively will load a resource file or a scene file.
 
 ## All command line arguments
 
 | Argument          | Description |
 | ----------------- | ----------- |
+| `--project-dir <path>` | Specifies the location of the Resources and Scripts directories. |
 | `--resource-file <path>` | Specifies the resource file to load. This may be a .hatch file, or a directory containing the resources. |
 | `--scripts-dir <path>` | Specifies the path to the directory containing scripts. |
 | `--scene <resource-path>` | Specifies a scene file to load. This must be the name of a resource, not a path in the filesystem. |

--- a/docs/main/manual/command_line_options.md
+++ b/docs/main/manual/command_line_options.md
@@ -1,0 +1,13 @@
+@page command_line_options Command Line Options
+
+**Command Line Options** are arguments specified when running Hatch. They alter the behavior of the application in some way, such as loading a specific scene, or loading a resource file from a given path. Examples of ways command line options can be given to the application are running Hatch from a terminal, launching it from a shell script, or specified in a Windows shortcut.
+
+All command line options are prefixed by `--` (two hyphens). Additionally, a path to a .hatch file or to a file inside the `Resources/` directory can be specified directly after the path to the executable, which respectively will load a resource file or a scene file.
+
+## All command line arguments
+
+| Argument          | Description |
+| ----------------- | ----------- |
+| `--resource-file <path>` | Specifies the resource file to load. This may be a .hatch file, or a directory containing the resources. |
+| `--scripts-dir <path>` | Specifies the path to the directory containing scripts. |
+| `--scene <resource-path>` | Specifies a scene file to load. This must be the name of a resource, not a path in the filesystem. |

--- a/docs/main/manual/manual.md
+++ b/docs/main/manual/manual.md
@@ -5,6 +5,7 @@ TODO
 - @subpage scripting
 - @subpage gameconfig
 - @subpage settings
+- @subpage command_line_options
 - @subpage scenes
 - @subpage entities
 - @subpage resource_management

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -412,6 +412,7 @@ size_t Application::ProcessCommandLineOption(std::string arg, size_t i) {
 }
 
 void Application::InitScripting() {
+	SourceFileMap::Init();
 	GarbageCollector::Init();
 
 	Compiler::Init();

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -133,12 +133,17 @@ size_t ResourcesBrowserNumEntries = 0;
 std::vector<std::string> ResourcesBrowserEntries;
 std::vector<std::string> ResourcesBrowserPaths;
 
+bool Application::DevMode = false;
 bool Application::DevConvertModels = false;
 
 bool Application::AllowCmdLineSceneLoad = false;
 
 ApplicationMetrics Application::Metrics;
 std::vector<PerformanceMeasure*> Application::AllMetrics;
+
+std::string ResourceFilename;
+bool UseResourceFilename = false;
+std::string SceneToLoad;
 
 char StartingScene[MAX_RESOURCE_PATH_LENGTH];
 char NextGame[MAX_PATH_LENGTH];
@@ -148,7 +153,6 @@ char LogFilename[MAX_PATH_LENGTH];
 
 bool UseMemoryFileCache = false;
 
-bool DevMode = false;
 bool ToggleDebugger = false;
 bool ViewPerformance = false;
 bool TakePerfSnapshot = false;
@@ -220,15 +224,20 @@ void Application::Init(int argc, char* args[]) {
 	// Initialize a few needed subsystems
 	InputManager::Init();
 	Clock::Init();
+	SourceFileMap::Init();
+
+	// Parse command line arguments
+	Application::ParseCommandLineArgs();
 
 	// Load game stuff.
-#ifdef ALLOW_COMMAND_LINE_RESOURCE_LOAD
-	if (argc > 1 && !!StringUtils::StrCaseStr(args[1], ".hatch")) {
-		ResourceManager::Init(args[1]);
+	if (UseResourceFilename) {
+		Log::Print(Log::LOG_VERBOSE, "Resource file: %s", ResourceFilename.c_str());
+
+		ResourceManager::Init(ResourceFilename.c_str(), true);
 	}
-	else
-#endif
-		ResourceManager::Init(NULL);
+	else {
+		ResourceManager::Init(nullptr, true);
+	}
 
 	Application::LoadGameConfig();
 	Application::InitGameInfo();
@@ -268,6 +277,90 @@ void Application::Init(int argc, char* args[]) {
 
 	Running = true;
 }
+
+bool Application::HasCmdLineArg(std::string match) {
+	return GetCmdLineArgIndex(match) != -1;
+}
+int Application::GetCmdLineArgIndex(std::string match) {
+	for (size_t i = 0; i < Application::CmdLineArgs.size(); i++) {
+		if (Application::CmdLineArgs[i] == match) {
+			return (int)i;
+		}
+	}
+	return -1;
+}
+std::string Application::GetCmdLineOption(std::string match) {
+	size_t numArgs = Application::CmdLineArgs.size();
+	for (size_t i = 0; i < numArgs; i++) {
+		if (Application::CmdLineArgs[i] == match && i + 1 < numArgs) {
+			std::string option = Application::CmdLineArgs[i + 1];
+			if (!StringUtils::StartsWith(option.c_str(), "--")) {
+				return option;
+			}
+		}
+	}
+	return "";
+}
+void Application::ParseCommandLineArgs() {
+	if (CmdLineArgs.size() == 0) {
+		return;
+	}
+
+	// Interpret the first argument as a .hatch to load, or a scene file to load,
+	// for backwards compatibility.
+	const char* firstArg = CmdLineArgs[0].c_str();
+
+	if (CmdLineArgs.size() == 1 && !StringUtils::StartsWith(firstArg, "--")) {
+		char* pathStart = StringUtils::StrCaseStr(firstArg, "/Resources/");
+		if (pathStart == NULL) {
+			pathStart = StringUtils::StrCaseStr(firstArg, "\\Resources\\");
+		}
+
+		if (pathStart) {
+			char scenePath[MAX_RESOURCE_PATH_LENGTH];
+			StringUtils::Copy(
+				scenePath, pathStart + strlen("/Resources/"), sizeof scenePath);
+			StringUtils::ReplacePathSeparatorsInPlace(scenePath);
+			SceneToLoad = std::string(scenePath);
+		}
+		else {
+			Log::Print(Log::LOG_WARN,
+				"Map file \"%s\" not inside Resources folder!",
+				firstArg);
+		}
+
+#ifdef ALLOW_COMMAND_LINE_RESOURCE_LOAD
+		if (StringUtils::StrCaseStr(CmdLineArgs[0].c_str(), ".hatch")) {
+			ResourceFilename = CmdLineArgs[0];
+			UseResourceFilename = true;
+		}
+#endif
+	}
+
+#ifdef ALLOW_COMMAND_LINE_RESOURCE_LOAD
+	// Specify the resource file to load
+	std::string resourceFilePath = GetCmdLineOption("--resource-file");
+	if (resourceFilePath.size() > 0) {
+		ResourceFilename = Path::Normalize(Path::ToAbsolute(resourceFilePath));
+		UseResourceFilename = true;
+	}
+#endif
+
+	// Specify the path to use for the Scripts directory
+	std::string scriptsDirPath = GetCmdLineOption("--scripts-dir");
+	if (scriptsDirPath.size() > 0) {
+		scriptsDirPath = Path::Normalize(Path::ToAbsolute(scriptsDirPath));
+
+		StringUtils::Copy(SourceFileMap::Path, scriptsDirPath.c_str(), sizeof(SourceFileMap::Path));
+	}
+
+	// Specify a scene file to load
+	std::string scenePath = GetCmdLineOption("--scene");
+	if (scenePath.size() > 0) {
+		SceneToLoad = scenePath;
+	}
+}
+
 void Application::InitScripting() {
 	GarbageCollector::Init();
 
@@ -864,7 +957,7 @@ void Application::UpdateWindowTitle() {
 		titleText += ", "; \
 	titleText += text
 
-	if (DevMode) {
+	if (Application::DevMode) {
 		if (ResourceManager::UsingDataFolder) {
 			ADD_TEXT("using Resources folder");
 		}
@@ -1249,7 +1342,7 @@ void Application::InitPerformanceMetrics() {
 
 void Application::LoadDevSettings() {
 #ifdef DEVELOPER_MODE
-	Application::Settings->GetBool("dev", "devMenu", &DevMode);
+	Application::Settings->GetBool("dev", "devMenu", &Application::DevMode);
 	Application::Settings->GetBool("dev", "viewPerformance", &ViewPerformance);
 	Application::Settings->GetBool("dev", "doNothing", &DoNothing);
 	Application::Settings->GetInteger("dev", "fastForward", &UpdatesPerFastForward);
@@ -1434,7 +1527,7 @@ void Application::PollEvents() {
 				break;
 			}
 
-			if (DevMode) {
+			if (Application::DevMode) {
 				// Quit application (dev)
 				// Unbound by default, must be set in GameConfig
 				if (key == KeyBindsSDL[(int)KeyBind::DevQuit]) {
@@ -1880,25 +1973,11 @@ void Application::Run(int argc, char* args[]) {
 	}
 
 	char scenePath[MAX_RESOURCE_PATH_LENGTH];
-	StringUtils::Copy(scenePath, StartingScene, sizeof scenePath);
-
-	// Run scene from command line argument
-	if (argc > 1 && AllowCmdLineSceneLoad) {
-		char* pathStart = StringUtils::StrCaseStr(args[1], "/Resources/");
-		if (pathStart == NULL) {
-			pathStart = StringUtils::StrCaseStr(args[1], "\\Resources\\");
-		}
-
-		if (pathStart) {
-			StringUtils::Copy(
-				scenePath, pathStart + strlen("/Resources/"), sizeof scenePath);
-			StringUtils::ReplacePathSeparatorsInPlace(scenePath);
-		}
-		else {
-			Log::Print(Log::LOG_WARN,
-				"Map file \"%s\" not inside Resources folder!",
-				args[1]);
-		}
+	if (AllowCmdLineSceneLoad && SceneToLoad.size() > 0) {
+		StringUtils::Copy(scenePath, SceneToLoad.c_str(), sizeof scenePath);
+	}
+	else {
+		StringUtils::Copy(scenePath, StartingScene, sizeof scenePath);
 	}
 
 	Application::StartGame(scenePath);
@@ -2659,7 +2738,7 @@ void Application::InitSettings() {
 	Application::Settings->SetInteger("display", "frameSkip", DEFAULT_MAX_FRAMESKIP);
 
 #ifdef DEVELOPER_MODE
-	DevMode = true;
+	Application::DevMode = true;
 	Application::Settings->SetBool("dev", "devMenu", true);
 	if (!Running) {
 		Application::Settings->SetBool("dev", "writeLogFile", true);

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -338,6 +338,18 @@ void Application::ParseCommandLineArgs() {
 	}
 
 #ifdef ALLOW_COMMAND_LINE_RESOURCE_LOAD
+	// Specify the path to both Resources and Scripts directory
+	std::string projectDirPath = GetCmdLineOption("--project-dir");
+	if (projectDirPath.size() > 0) {
+		projectDirPath = Path::Normalize(Path::ToAbsolute(projectDirPath));
+
+		ResourceFilename = projectDirPath + "/Resources";
+		std::string scriptsDirPath = projectDirPath + "/Scripts";
+
+		UseResourceFilename = true;
+		StringUtils::Copy(SourceFileMap::Path, scriptsDirPath.c_str(), sizeof(SourceFileMap::Path));
+	}
+
 	// Specify the resource file to load
 	std::string resourceFilePath = GetCmdLineOption("--resource-file");
 	if (resourceFilePath.size() > 0) {

--- a/source/Engine/Application.cpp
+++ b/source/Engine/Application.cpp
@@ -282,27 +282,34 @@ bool Application::HasCmdLineArg(std::string match) {
 	return GetCmdLineArgIndex(match) != -1;
 }
 int Application::GetCmdLineArgIndex(std::string match) {
-	for (size_t i = 0; i < Application::CmdLineArgs.size(); i++) {
-		if (Application::CmdLineArgs[i] == match) {
+	for (size_t i = 0; i < CmdLineArgs.size(); i++) {
+		if (CmdLineArgs[i] == match) {
 			return (int)i;
 		}
 	}
 	return -1;
 }
 std::string Application::GetCmdLineOption(std::string match) {
-	size_t numArgs = Application::CmdLineArgs.size();
+	size_t numArgs = CmdLineArgs.size();
 	for (size_t i = 0; i < numArgs; i++) {
-		if (Application::CmdLineArgs[i] == match && i + 1 < numArgs) {
-			std::string option = Application::CmdLineArgs[i + 1];
-			if (!StringUtils::StartsWith(option.c_str(), "--")) {
-				return option;
-			}
+		if (CmdLineArgs[i] == match) {
+			return GetCmdLineOption(i + 1);
+		}
+	}
+	return "";
+}
+std::string Application::GetCmdLineOption(size_t index) {
+	if (index < CmdLineArgs.size()) {
+		std::string option = CmdLineArgs[index];
+		if (!StringUtils::StartsWith(option.c_str(), "--")) {
+			return option;
 		}
 	}
 	return "";
 }
 void Application::ParseCommandLineArgs() {
-	if (CmdLineArgs.size() == 0) {
+	size_t numArgs = CmdLineArgs.size();
+	if (numArgs == 0) {
 		return;
 	}
 
@@ -310,7 +317,7 @@ void Application::ParseCommandLineArgs() {
 	// for backwards compatibility.
 	const char* firstArg = CmdLineArgs[0].c_str();
 
-	if (CmdLineArgs.size() == 1 && !StringUtils::StartsWith(firstArg, "--")) {
+	if (numArgs == 1 && !StringUtils::StartsWith(firstArg, "--")) {
 		char* pathStart = StringUtils::StrCaseStr(firstArg, "/Resources/");
 		if (pathStart == NULL) {
 			pathStart = StringUtils::StrCaseStr(firstArg, "\\Resources\\");
@@ -335,42 +342,73 @@ void Application::ParseCommandLineArgs() {
 			UseResourceFilename = true;
 		}
 #endif
+
+		return;
 	}
 
+	for (size_t i = 0; i < numArgs; i++) {
+		std::string arg = CmdLineArgs[i];
+		if (!StringUtils::StartsWith(arg.c_str(), "--")) {
+			continue;
+		}
+
+		i = ProcessCommandLineOption(arg, i);
+	}
+}
+size_t Application::ProcessCommandLineOption(std::string arg, size_t i) {
 #ifdef ALLOW_COMMAND_LINE_RESOURCE_LOAD
 	// Specify the path to both Resources and Scripts directory
-	std::string projectDirPath = GetCmdLineOption("--project-dir");
-	if (projectDirPath.size() > 0) {
+	if (arg == "--project-dir") {
+		std::string projectDirPath = GetCmdLineOption(i + 1);
+		if (projectDirPath.size() == 0) {
+			return i;
+		}
+
 		projectDirPath = Path::Normalize(Path::ToAbsolute(projectDirPath));
 
-		ResourceFilename = projectDirPath + "/Resources";
-		std::string scriptsDirPath = projectDirPath + "/Scripts";
+		ResourceFilename = Path::Concat(projectDirPath, "Resources");
+		std::string scriptsDirPath = Path::Concat(projectDirPath, "Scripts");
 
 		UseResourceFilename = true;
 		StringUtils::Copy(SourceFileMap::Path, scriptsDirPath.c_str(), sizeof(SourceFileMap::Path));
+		return i + 1;
 	}
-
 	// Specify the resource file to load
-	std::string resourceFilePath = GetCmdLineOption("--resource-file");
-	if (resourceFilePath.size() > 0) {
+	else if (arg == "--resource-file") {
+		std::string resourceFilePath = GetCmdLineOption(i + 1);
+		if (resourceFilePath.size() == 0) {
+			return i;
+		}
+
 		ResourceFilename = Path::Normalize(Path::ToAbsolute(resourceFilePath));
 		UseResourceFilename = true;
+		return i + 1;
 	}
+	else
 #endif
-
 	// Specify the path to use for the Scripts directory
-	std::string scriptsDirPath = GetCmdLineOption("--scripts-dir");
-	if (scriptsDirPath.size() > 0) {
+	if (arg == "--scripts-dir") {
+		std::string scriptsDirPath = GetCmdLineOption(i + 1);
+		if (scriptsDirPath.size() == 0) {
+			return i;
+		}
+
 		scriptsDirPath = Path::Normalize(Path::ToAbsolute(scriptsDirPath));
-
 		StringUtils::Copy(SourceFileMap::Path, scriptsDirPath.c_str(), sizeof(SourceFileMap::Path));
+		return i + 1;
+	}
+	// Specify a scene file to load
+	else if (arg == "--scene") {
+		std::string scenePath = GetCmdLineOption(++i);
+		if (scenePath.size() == 0) {
+			return i;
+		}
+
+		SceneToLoad = scenePath;
+		return i + 1;
 	}
 
-	// Specify a scene file to load
-	std::string scenePath = GetCmdLineOption("--scene");
-	if (scenePath.size() > 0) {
-		SceneToLoad = scenePath;
-	}
+	return i;
 }
 
 void Application::InitScripting() {

--- a/source/Engine/Application.h
+++ b/source/Engine/Application.h
@@ -144,6 +144,7 @@ public:
 	static int MasterVolume;
 	static int MusicVolume;
 	static int SoundVolume;
+	static bool DevMode;
 	static bool DevConvertModels;
 	static bool AllowCmdLineSceneLoad;
 	static bool DisableDefaultActions;
@@ -155,6 +156,10 @@ public:
 	static std::vector<PerformanceMeasure*> AllMetrics;
 
 	static void Init(int argc, char* args[]);
+	static bool HasCmdLineArg(std::string match);
+	static int GetCmdLineArgIndex(std::string match);
+	static std::string GetCmdLineOption(std::string match);
+	static void ParseCommandLineArgs();
 	static void InitScripting();
 	static void SetTargetFrameRate(int targetFPS);
 	static bool IsPC();

--- a/source/Engine/Application.h
+++ b/source/Engine/Application.h
@@ -159,7 +159,9 @@ public:
 	static bool HasCmdLineArg(std::string match);
 	static int GetCmdLineArgIndex(std::string match);
 	static std::string GetCmdLineOption(std::string match);
+	static std::string GetCmdLineOption(size_t index);
 	static void ParseCommandLineArgs();
+	static size_t ProcessCommandLineOption(std::string arg, size_t i);
 	static void InitScripting();
 	static void SetTargetFrameRate(int targetFPS);
 	static bool IsPC();

--- a/source/Engine/Bytecode/SourceFileMap.cpp
+++ b/source/Engine/Bytecode/SourceFileMap.cpp
@@ -18,13 +18,15 @@
 #define OBJECTS_HCM_NAME OBJECTS_DIR_NAME "Objects.hcm"
 
 bool SourceFileMap::Initialized = false;
+char SourceFileMap::Path[MAX_PATH_LENGTH];
+bool SourceFileMap::Loaded = false;
 bool SourceFileMap::AllowCompilation = false;
 HashMap<Uint32>* SourceFileMap::Checksums = NULL;
 HashMap<vector<Uint32>*>* SourceFileMap::ClassMap = NULL;
 Uint32 SourceFileMap::DirectoryChecksum = 0;
 Uint32 SourceFileMap::Magic = MAGIC_LE32("HMAP");
 
-void SourceFileMap::CheckInit() {
+void SourceFileMap::Init() {
 	if (SourceFileMap::Initialized) {
 		return;
 	}
@@ -34,6 +36,16 @@ void SourceFileMap::CheckInit() {
 	}
 	if (SourceFileMap::ClassMap == NULL) {
 		SourceFileMap::ClassMap = new HashMap<vector<Uint32>*>(Murmur::EncryptData, 16);
+	}
+
+	StringUtils::Copy(SourceFileMap::Path, SCRIPTS_DIRECTORY_NAME, sizeof SourceFileMap::Path);
+
+	SourceFileMap::Initialized = true;
+}
+
+void SourceFileMap::Load() {
+	if (SourceFileMap::Loaded) {
+		return;
 	}
 
 	if (ResourceManager::ResourceExists(OBJECTS_HCM_NAME)) {
@@ -74,26 +86,40 @@ void SourceFileMap::CheckInit() {
 
 #ifndef NO_SCRIPT_COMPILING
 	SourceFileMap::AllowCompilation = true;
-
-	if (File::ProtectedExists(SOURCEFILEMAP_NAME, true)) {
-		char* bytes;
-		size_t len = File::ReadAllBytes(SOURCEFILEMAP_NAME, &bytes, true);
-		if (len >= sizeof(Uint32) * 3) {
-			SourceFileMap::Checksums->FromBytes((Uint8*)bytes,
-				(len - sizeof(Uint32)) / (sizeof(Uint32) + sizeof(Uint32)));
-			SourceFileMap::DirectoryChecksum = *(Uint32*)(bytes + len - sizeof(Uint32));
-		}
-		else {
-			SourceFileMap::DirectoryChecksum = 0;
-		}
-		Memory::Free(bytes);
-	}
+	SourceFileMap::ReadFileMap();
 #endif
 
-	SourceFileMap::Initialized = true;
+	SourceFileMap::Loaded = true;
+}
+void SourceFileMap::ReadFileMap() {
+	Stream* stream = FileStream::New(SOURCEFILEMAP_NAME, FileStream::READ_ACCESS, true);
+	if (!stream) {
+		return;
+	}
+
+	size_t len = stream->Length();
+	char* bytes = (char*)Memory::Malloc(len);
+	if (!bytes) {
+		stream->Close();
+		return;
+	}
+
+	stream->ReadBytes(bytes, len);
+	stream->Close();
+
+	if (len >= sizeof(Uint32) * 3) {
+		SourceFileMap::Checksums->FromBytes((Uint8*)bytes,
+			(len - sizeof(Uint32)) / (sizeof(Uint32) + sizeof(Uint32)));
+		SourceFileMap::DirectoryChecksum = *(Uint32*)(bytes + len - sizeof(Uint32));
+	}
+	else {
+		SourceFileMap::DirectoryChecksum = 0;
+	}
+
+	Memory::Free(bytes);
 }
 bool SourceFileMap::CheckForUpdate() {
-	SourceFileMap::CheckInit();
+	SourceFileMap::Load();
 
 #ifndef NO_SCRIPT_COMPILING
 	if (!SourceFileMap::AllowCompilation) {
@@ -107,12 +133,12 @@ bool SourceFileMap::CheckForUpdate() {
 
 	bool anyChanges = false;
 
-	if (!Directory::Exists(SCRIPTS_DIRECTORY_NAME)) {
+	if (!Directory::Exists(SourceFileMap::Path)) {
 		return false;
 	}
 
 	vector<std::filesystem::path> list;
-	Directory::GetFiles(&list, SCRIPTS_DIRECTORY_NAME, "*.hsl", true);
+	Directory::GetFiles(&list, SourceFileMap::Path, "*.hsl", true);
 
 	if (list.size() == 0) {
 		list.clear();
@@ -126,7 +152,7 @@ bool SourceFileMap::CheckForUpdate() {
 		anyChanges = true;
 	}
 
-	size_t scriptFolderNameLen = strlen(SCRIPTS_DIRECTORY_NAME);
+	size_t scriptFolderNameLen = strlen(SourceFileMap::Path);
 
 	Uint32 oldDirectoryChecksum = SourceFileMap::DirectoryChecksum;
 
@@ -156,7 +182,7 @@ bool SourceFileMap::CheckForUpdate() {
 		SourceFileMap::ClassMap->Clear();
 	}
 
-	std::string scriptFolderPathStr = std::string(SCRIPTS_DIRECTORY_NAME) + "/";
+	std::string scriptFolderPathStr = std::string(SourceFileMap::Path) + "/";
 	const char* scriptFolderPath = scriptFolderPathStr.c_str();
 	size_t scriptFolderPathLen = scriptFolderPathStr.size();
 
@@ -177,11 +203,32 @@ bool SourceFileMap::CheckForUpdate() {
 		Uint32 oldChecksum = 0;
 		bool doRecompile = false;
 
-		char* source;
-		File::ReadAllBytes(listEntry, &source, false);
-		newChecksum = Murmur::EncryptString(source);
+		char* source = nullptr;
 
-		Memory::Track(source, "SourceFileMap::SourceText");
+		// Read the script file
+		Stream* stream = File::Open(listEntry, File::READ_ACCESS);
+		if (stream) {
+			size_t streamSize = stream->Length();
+			if (streamSize > 0) {
+				source = (char*)Memory::TrackedCalloc("SourceFileMap::SourceText", streamSize + 1, sizeof(char));
+				if (source) {
+					stream->ReadBytes(source, streamSize);
+				}
+				else {
+					Log::Print(Log::LOG_ERROR, "Not enough memory for reading \"%s\"!", listEntry);
+				}
+			}
+			stream->Close();
+		}
+		else {
+			Log::Print(Log::LOG_ERROR, "Couldn't open \"%s\"!", listEntry);
+		}
+
+		if (source == nullptr) {
+			continue;
+		}
+
+		newChecksum = Murmur::EncryptString(source);
 
 		if (SourceFileMap::Checksums->Exists(filenameHash)) {
 			oldChecksum = SourceFileMap::Checksums->Get(filenameHash);
@@ -239,9 +286,7 @@ bool SourceFileMap::CheckForUpdate() {
 						mainVfs->CloseStream(stream);
 					}
 					else {
-						Log::Print(Log::LOG_ERROR,
-							"Couldn't open file '%s' for writing compiled script!",
-							outFile);
+						Log::Print(Log::LOG_ERROR, "Couldn't open \"%s\"!", outFile);
 					}
 
 					// Add this file to the list
@@ -256,7 +301,7 @@ bool SourceFileMap::CheckForUpdate() {
 				delete compiler;
 			}
 			else {
-				Log::Print(Log::LOG_ERROR, "Not enough memory for compiling '%s'!", outFile);
+				Log::Print(Log::LOG_ERROR, "Not enough memory for compiling \"%s\"!", outFile);
 			}
 
 			Compiler::FinishCompiling();
@@ -323,7 +368,7 @@ void SourceFileMap::HandleCompileError(const char* error) {
 	const SDL_MessageBoxData messageBoxData = {
 		SDL_MESSAGEBOX_ERROR,
 		NULL,
-		"Syntax Error",
+		"Compile Error",
 		error,
 		SDL_arraysize(buttons),
 		buttons,

--- a/source/Engine/Bytecode/SourceFileMap.h
+++ b/source/Engine/Bytecode/SourceFileMap.h
@@ -2,6 +2,7 @@
 #define ENGINE_BYTECODE_SOURCEFILEMAP_H
 
 #include <Engine/Bytecode/Compiler.h>
+#include <Engine/Filesystem/Path.h>
 #include <Engine/Hashing/CombinedHash.h>
 #include <Engine/Includes/HashMap.h>
 
@@ -9,19 +10,23 @@
 
 class SourceFileMap {
 private:
+	static bool Loaded;
+	static HashMap<Uint32>* Checksums;
+
+	static void ReadFileMap();
 	static void AddToList(Compiler* compiler, Uint32 filenameHash);
 	static void HandleCompileError(const char* error);
+	static void Load();
 
 public:
 	static bool Initialized;
+	static char Path[MAX_PATH_LENGTH];
 	static bool AllowCompilation;
-	static HashMap<Uint32>* Checksums;
 	static HashMap<vector<Uint32>*>* ClassMap;
 	static Uint32 DirectoryChecksum;
 	static Uint32 Magic;
-	static bool DoLogging;
 
-	static void CheckInit();
+	static void Init();
 	static bool CheckForUpdate();
 	static void Dispose();
 };

--- a/source/Engine/Bytecode/StandardLibrary.cpp
+++ b/source/Engine/Bytecode/StandardLibrary.cpp
@@ -7744,7 +7744,7 @@ VMValue Ease_Triangle(int argCount, VMValue* args, Uint32 threadID) {
 VMValue File_Exists(int argCount, VMValue* args, Uint32 threadID) {
 	CHECK_ARGCOUNT(1);
 	char* filePath = GET_ARG(0, GetString);
-	return INTEGER_VAL(File::ProtectedExists(filePath, true));
+	return INTEGER_VAL(FileStream::Exists(filePath, true));
 }
 /***
  * File.ReadAllText

--- a/source/Engine/Filesystem/File.cpp
+++ b/source/Engine/Filesystem/File.cpp
@@ -29,7 +29,6 @@ Stream* File::Open(const char* filename, Uint32 access) {
 	return StandardIOStream::New(filename, streamAccess);
 }
 
-// Do not expose to HSL.
 bool File::Exists(const char* path) {
 	Stream* stream = Open(path, READ_ACCESS);
 	if (stream) {
@@ -40,23 +39,18 @@ bool File::Exists(const char* path) {
 	return false;
 }
 
-bool File::ProtectedExists(const char* path, bool allowURLs) {
-	if (path == nullptr) {
-		return false;
+size_t File::ReadAllBytes(const char* path, char** out) {
+	if (!path || !*path || !out) {
+		return 0;
 	}
 
-	return FileStream::Exists(path, allowURLs);
-}
-
-size_t File::ReadAllBytes(const char* path, char** out, bool allowURLs) {
-	FileStream* stream = FileStream::New(path, FileStream::READ_ACCESS, allowURLs);
+	Stream* stream = File::Open(path, File::READ_ACCESS);
 	if (stream) {
 		size_t size = stream->Length();
-		*out = (char*)Memory::Malloc(size + 1);
+		*out = (char*)Memory::Malloc(size);
 		if (!*out) {
 			return 0;
 		}
-		(*out)[size] = 0;
 		stream->ReadBytes(*out, size);
 		stream->Close();
 		return size;
@@ -64,18 +58,12 @@ size_t File::ReadAllBytes(const char* path, char** out, bool allowURLs) {
 	return 0;
 }
 
-bool File::WriteAllBytes(const char* path, const char* bytes, size_t len, bool allowURLs) {
-	if (!path) {
-		return false;
-	}
-	if (!*path) {
-		return false;
-	}
-	if (!bytes) {
+bool File::WriteAllBytes(const char* path, const char* bytes, size_t len) {
+	if (!path || !*path || !bytes) {
 		return false;
 	}
 
-	FileStream* stream = FileStream::New(path, FileStream::WRITE_ACCESS, allowURLs);
+	Stream* stream = File::Open(path, File::WRITE_ACCESS);
 	if (stream) {
 		stream->WriteBytes((char*)bytes, len);
 		stream->Close();

--- a/source/Engine/Filesystem/File.h
+++ b/source/Engine/Filesystem/File.h
@@ -10,9 +10,8 @@ public:
 
 	static Stream* Open(const char* filename, Uint32 access);
 	static bool Exists(const char* path);
-	static bool ProtectedExists(const char* path, bool allowURLs);
-	static size_t ReadAllBytes(const char* path, char** out, bool allowURLs);
-	static bool WriteAllBytes(const char* path, const char* bytes, size_t len, bool allowURLs);
+	static size_t ReadAllBytes(const char* path, char** out);
+	static bool WriteAllBytes(const char* path, const char* bytes, size_t len);
 };
 
 #endif /* ENGINE_FILESYSTEM_FILE_H */

--- a/source/Engine/Filesystem/Path.cpp
+++ b/source/Engine/Filesystem/Path.cpp
@@ -2,6 +2,7 @@
 #include <Engine/Filesystem/Directory.h>
 #include <Engine/Filesystem/Path.h>
 #include <Engine/Includes/StandardSDL2.h>
+#include <Engine/ResourceTypes/ResourceManager.h>
 #include <Engine/Utilities/StringUtils.h>
 
 #if UNIX
@@ -120,13 +121,17 @@ bool Path::GetCurrentWorkingDirectory(char* out, size_t sz) {
 #endif
 }
 
-std::string Path::GetPortableModePath() {
+std::string Path::GetCurrentWorkingDirectory() {
 	char workingDir[MAX_PATH_LENGTH];
 	if (!GetCurrentWorkingDirectory(workingDir, sizeof workingDir)) {
 		return "";
 	}
 
 	return std::string(workingDir);
+}
+
+std::string Path::GetPortableModePath() {
+	return GetCurrentWorkingDirectory();
 }
 
 bool Path::AreMatching(std::string base, std::string path) {
@@ -786,11 +791,21 @@ bool Path::IsAbsolute(const char* filename) {
 }
 
 bool Path::IsValidDefaultLocation(const char* filename) {
+	if (ResourceManager::DataFolderPath[0] != '\0' &&
+		StringUtils::StartsWith(filename, ResourceManager::DataFolderPath)) {
+		// It's allowed to access anything inside of the current Resources directory.
+		return true;
+	}
+
+	// Otherwise, check if this is in the current directory.
+	// If it is, allow access.
 	if (!IsInCurrentDir(filename)) {
 		return false;
 	}
 
-	if (Path::IsAbsolute(filename)) {
+	// Lastly check if the path is absolute.
+	// If it is, disallow access.
+	if (IsAbsolute(filename)) {
 		return false;
 	}
 

--- a/source/Engine/Filesystem/Path.h
+++ b/source/Engine/Filesystem/Path.h
@@ -153,6 +153,7 @@ public:
 	static bool Create(const char* path);
 	static std::string Concat(std::string pathA, std::string pathB);
 	static bool GetCurrentWorkingDirectory(char* out, size_t sz);
+	static std::string GetCurrentWorkingDirectory();
 	static bool IsInDir(const char* dirPath, const char* path);
 	static bool IsInCurrentDir(const char* path);
 	static bool HasRelativeComponents(const char* path);

--- a/source/Engine/ResourceTypes/ResourceManager.cpp
+++ b/source/Engine/ResourceTypes/ResourceManager.cpp
@@ -16,6 +16,7 @@ VirtualFileSystem* vfs = nullptr;
 VFSProvider* mainResource = nullptr;
 
 bool ResourceManager::UsingDataFolder = false;
+char ResourceManager::DataFolderPath[MAX_PATH_LENGTH];
 
 const char* data_files[] = {PATHLOCATION_GAME_URL "Data.hatch",
 	PATHLOCATION_GAME_URL "Game.hatch",
@@ -54,16 +55,15 @@ char* GetDataFileCandidate(std::vector<DataFileCandidate> candidates) {
 	return nullptr;
 }
 
-bool ResourceManager::Init(const char* dataFilePath) {
+bool ResourceManager::Init(const char* dataFilePath, bool useResourcesFolder) {
 	bool foundDataFile = false;
 	bool isDirectory = false;
 	char* filename = nullptr;
 
 	std::vector<DataFileCandidate> candidates = FindDataFiles();
 
-	bool useResourcesFolder = true;
-
 	UsingDataFolder = false;
+	DataFolderPath[0] = '\0';
 
 	vfs = new VirtualFileSystem();
 
@@ -71,10 +71,7 @@ bool ResourceManager::Init(const char* dataFilePath) {
 	if (dataFilePath != nullptr) {
 		bool found = false;
 
-		useResourcesFolder = false;
-
-		if (dataFilePath[strlen(dataFilePath) - 1] == '/' &&
-			Directory::Exists(dataFilePath)) {
+		if (Directory::Exists(dataFilePath)) {
 			found = true;
 			isDirectory = true;
 		}
@@ -87,7 +84,7 @@ bool ResourceManager::Init(const char* dataFilePath) {
 			foundDataFile = true;
 		}
 		else {
-			Log::Print(Log::LOG_ERROR, "Could not find file \"%s\"!", dataFilePath);
+			Log::Print(Log::LOG_ERROR, "Could not find file or directory \"%s\"!", dataFilePath);
 		}
 	}
 	else if (candidates.size() > 0) {
@@ -101,7 +98,18 @@ bool ResourceManager::Init(const char* dataFilePath) {
 		Log::Print(Log::LOG_ERROR, "No valid location to access data file!");
 	}
 
+	// Use Resources folder
+	if (!foundDataFile) {
+		filename = StringUtils::Create(RESOURCES_DIR_PATH);
+		isDirectory = true;
+	}
+
 	if (isDirectory) {
+		Uint16 flags = VFS_READABLE;
+		if (useResourcesFolder) {
+			flags |= VFS_WRITABLE;
+		}
+
 		size_t filenameLength = strlen(filename);
 		if (filename[filenameLength - 1] == '/') {
 			filename[filenameLength - 1] = '\0';
@@ -112,9 +120,16 @@ bool ResourceManager::Init(const char* dataFilePath) {
 		Log::Print(Log::LOG_VERBOSE, "Loading \"%s\"...", filenameOnly);
 
 		VFSMountStatus status = vfs->Mount(
-			RESOURCES_VFS_NAME, filename, nullptr, VFSType::FILESYSTEM, VFS_READABLE);
+			RESOURCES_VFS_NAME, filename, nullptr, VFSType::FILESYSTEM, flags);
 
-		if (status != VFSMountStatus::MOUNTED) {
+		if (status == VFSMountStatus::MOUNTED) {
+			UsingDataFolder = useResourcesFolder;
+
+			std::string fullPath = Path::Normalize(Path::ToAbsolute(filename));
+
+			StringUtils::Copy(DataFolderPath, fullPath.c_str(), sizeof DataFolderPath);
+		}
+		else {
 			Log::Print(Log::LOG_ERROR, "Could not access \"%s\"!", filename);
 		}
 	}
@@ -125,24 +140,6 @@ bool ResourceManager::Init(const char* dataFilePath) {
 
 		ResourceManager::Mount(
 			RESOURCES_VFS_NAME, filename, nullptr, VFSType::HATCH, VFS_READABLE);
-	}
-	else if (useResourcesFolder) {
-		VFSMountStatus status = vfs->Mount(RESOURCES_VFS_NAME,
-			RESOURCES_DIR_PATH,
-			nullptr,
-			VFSType::FILESYSTEM,
-			VFS_READABLE | VFS_WRITABLE);
-
-		if (status == VFSMountStatus::MOUNTED) {
-#ifdef DEVELOPER_MODE
-			Log::Print(Log::LOG_INFO, "Using \"%s\" folder.", RESOURCES_DIR_PATH);
-#endif
-
-			ResourceManager::UsingDataFolder = true;
-		}
-		else {
-			Log::Print(Log::LOG_ERROR, "Could not access \"%s\"!", RESOURCES_DIR_PATH);
-		}
 	}
 
 	Memory::Free(filename);
@@ -191,8 +188,8 @@ bool ResourceManager::Init(const char* dataFilePath) {
 
 		return false;
 	}
-	else if (useResourcesFolder && GetMainResource()->IsEmpty()) {
-		Log::Print(Log::LOG_WARN, "\"%s\" folder is empty.", RESOURCES_DIR_PATH);
+	else if (UsingDataFolder && GetMainResource()->IsEmpty()) {
+		Log::Print(Log::LOG_WARN, "Resources directory is empty.", RESOURCES_DIR_PATH);
 	}
 
 	return true;

--- a/source/Engine/ResourceTypes/ResourceManager.h
+++ b/source/Engine/ResourceTypes/ResourceManager.h
@@ -1,6 +1,7 @@
 #ifndef ENGINE_RESOURCETYPES_RESOURCEMANAGER_H
 #define ENGINE_RESOURCETYPES_RESOURCEMANAGER_H
 
+#include <Engine/Filesystem/Path.h>
 #include <Engine/Filesystem/VFS/VFSProvider.h>
 #include <Engine/Filesystem/VFS/VirtualFileSystem.h>
 #include <Engine/Includes/Standard.h>
@@ -8,8 +9,9 @@
 class ResourceManager {
 public:
 	static bool UsingDataFolder;
+	static char DataFolderPath[MAX_PATH_LENGTH];
 
-	static bool Init(const char* dataFilePath);
+	static bool Init(const char* dataFilePath = nullptr, bool useResourcesFolder = false);
 	static bool Mount(const char* name,
 		const char* filename,
 		const char* mountPoint,

--- a/source/Engine/ResourceTypes/SceneFormats/TiledMapReader.cpp
+++ b/source/Engine/ResourceTypes/SceneFormats/TiledMapReader.cpp
@@ -294,7 +294,7 @@ bool TiledMapReader::GetRelativeResourcePath(Token source, const char* parentFol
 
 	// If it starts with "../"
 	if (StringUtils::StartsWith(resourcePath, "../")) {
-		if (ResourceManager::UsingDataFolder) {
+		if (Application::DevMode) {
 			Log::Print(Log::LOG_WARN, "Path \"%s\" is outside of Resources.", resourcePath);
 		}
 		return false;

--- a/source/Engine/TextFormats/INI/INI.cpp
+++ b/source/Engine/TextFormats/INI/INI.cpp
@@ -69,7 +69,7 @@ bool INI::Save() {
 	return Save(Filename);
 }
 bool INI::IsPersisted() {
-	return File::ProtectedExists(Filename, true);
+	return FileStream::Exists(Filename, true);
 }
 void INI::SetFilename(const char* filename) {
 	Memory::Free(Filename);

--- a/source/Engine/Utilities/Screenshot.cpp
+++ b/source/Engine/Utilities/Screenshot.cpp
@@ -1,5 +1,5 @@
 #include <Engine/Application.h>
-#include <Engine/Filesystem/File.h>
+#include <Engine/IO/FileStream.h>
 #include <Engine/Utilities/Screenshot.h>
 
 std::vector<ScreenshotOperation> Queue;
@@ -73,7 +73,7 @@ bool Screenshot::Exists(std::string path) {
 		}
 	}
 
-	return File::ProtectedExists(path.c_str(), true);
+	return FileStream::Exists(path.c_str(), true);
 }
 
 void Screenshot::QueueOperation(ScreenshotOperation operation) {


### PR DESCRIPTION
Resolves #173. Also adds `--scene`.

| Argument          | Description |
| ----------------- | ----------- |
| `--project-dir <path>` | Specifies the location of the Resources and Scripts directories. |
| `--resource-file <path>` | Specifies the resource file to load. This may be a .hatch file, or a directory containing the resources. |
| `--scripts-dir <path>` | Specifies the path to the directory containing scripts. |
| `--scene <resource-path>` | Specifies a scene file to load. This must be the name of a resource, not a path in the filesystem. |