### PR TITLE
Check entity activity when rendering

### DIFF
--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -1185,7 +1185,7 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 				_ox = ent->X - _vx;
 				_oy = ent->Y - _vy;
 
-				if (ent->Activity == ACTIVE_ALWAYS || ent->Activity == ACTIVE_NORMAL)
+				if (ent->Activity == ACTIVE_ALWAYS || ent->Activity == ACTIVE_NORMAL || (Scene::Paused && ent->Activity == ACTIVE_PAUSED))
 					goto DoCheckRender;
 
 				if (Scene::UseRenderRegions) {

--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -1185,6 +1185,9 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 				_ox = ent->X - _vx;
 				_oy = ent->Y - _vy;
 
+				if (ent->Activity == ACTIVE_ALWAYS || ent->Activity == ACTIVE_NORMAL)
+					goto DoCheckRender;
+
 				if (Scene::UseRenderRegions) {
 					if (ent->RenderRegionLeft || ent->RenderRegionRight) {
 						if (ent->RenderRegionLeft == 0.0f &&


### PR DESCRIPTION
Makes an entity render when its activity is ACTIVE_NORMAL, ACTIVE ALWAYS, or ACTIVE_PAUSED (when scene is paused). Matches behavior of setting the RenderRegionW/H to 0.0