### PR TITLE
Fix blend mode not being reset after a layer is rendered

### DIFF
--- a/source/Engine/Scene.cpp
+++ b/source/Engine/Scene.cpp
@@ -1352,9 +1352,13 @@ void Scene::RenderView(int viewIndex, bool doPerf) {
 				}
 				else {
 					Graphics::SetBlendColor(1.0, 1.0, 1.0, 1.0);
+					Graphics::SetBlendMode(BlendMode_NORMAL);
 				}
 
 				Graphics::DrawSceneLayer(layer, currentView, (int)li, true);
+
+				Graphics::SetBlendColor(1.0, 1.0, 1.0, 1.0);
+				Graphics::SetBlendMode(BlendMode_NORMAL);
 				Graphics::ClearClip();
 
 				PERF_END(LayerTileRenderTime[li]);


### PR DESCRIPTION
`Scene::RenderView` was not changing the blend mode back to `BlendMode_NORMAL` after drawing a layer, so even layers that had blending disabled would keep blending enabled with the last blend mode.

Without the fix:
<img width="848" height="508" alt="image" src="https://github.com/user-attachments/assets/f725b829-83de-446e-84f7-94b6ba3b36c2" />

With the fix:
<img width="848" height="508" alt="image" src="https://github.com/user-attachments/assets/3f592ffa-b485-4cd0-b445-5212e0d53ecd" />
